### PR TITLE
feat(csrf): ajout du mode debug pour la validation d'origine

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -59,6 +59,13 @@ env:
     availability:
       - RUNTIME
 
+  # Debug mode (pour activer les logs de debug en production)
+  # À désactiver une fois le problème résolu pour éviter les logs verbeux
+  - variable: DEBUG
+    value: "true"
+    availability:
+      - RUNTIME
+
   # FFTT API Configuration (privées, côté serveur uniquement)
   # Utilisation de Cloud Secret Manager pour la sécurité
   # Voir CONFIG_SECRETS_FFTT.md pour la configuration


### PR DESCRIPTION
## Contexte
Suite à la PR #61 qui a amélioré la validation d'origine, cette PR ajoute un mode debug pour faciliter le diagnostic des problèmes de validation en production.

## Modifications
- Ajout de la variable `DEBUG = "true"` dans `apphosting.yaml`
- Amélioration des logs dans `validateOrigin` avec :
  - Log détaillé au début de la fonction avec toutes les valeurs d'entrée
  - Affichage des valeurs brutes et normalisées pour chaque type de mismatch
  - Logs conditionnels activés uniquement si `DEBUG=true` en production

## Utilisation
Une fois déployé, les logs de debug apparaîtront dans les logs Firebase App Hosting avec le préfixe `[validateOrigin]` pour diagnostiquer les problèmes de validation d'origine.

## À faire après résolution
Désactiver le debug en mettant `DEBUG: "false"` ou en retirant la variable de `apphosting.yaml`.