### PR TITLE
fix(paris): correction des wordings exacts des divisions du championnat de Paris

### DIFF
--- a/src/lib/compositions/validation.ts
+++ b/src/lib/compositions/validation.ts
@@ -769,7 +769,7 @@ export const getParisTeamStructure = (
 ): { groups: number; playersPerGroup: number; totalPlayers: number } | null => {
   const divisionLower = division.toLowerCase();
   
-  // 3 groupes (9 joueurs) : EXCELLENCE, PROMO EXCELLENCE, HONNEUR
+  // 3 groupes (9 joueurs) : Excellence, Promo Excellence, Honneur
   if (
     divisionLower.includes("excellence") ||
     divisionLower.includes("honneur")
@@ -777,13 +777,23 @@ export const getParisTeamStructure = (
     return { groups: 3, playersPerGroup: 3, totalPlayers: 9 };
   }
   
-  // 2 groupes (6 joueurs) : DIVISION 1
-  if (divisionLower.includes("division 1") || divisionLower.includes("div 1")) {
+  // 2 groupes (6 joueurs) : 1ere Division ou 1ère Division
+  if (
+    divisionLower.includes("1ere division") ||
+    divisionLower.includes("1ère division") ||
+    divisionLower.includes("1ere div") ||
+    divisionLower.includes("1ère div")
+  ) {
     return { groups: 2, playersPerGroup: 3, totalPlayers: 6 };
   }
   
-  // 1 groupe (3 joueurs) : DIVISION 2
-  if (divisionLower.includes("division 2") || divisionLower.includes("div 2")) {
+  // 1 groupe (3 joueurs) : 2eme Division ou 2ème Division
+  if (
+    divisionLower.includes("2eme division") ||
+    divisionLower.includes("2ème division") ||
+    divisionLower.includes("2eme div") ||
+    divisionLower.includes("2ème div")
+  ) {
     return { groups: 1, playersPerGroup: 3, totalPlayers: 3 };
   }
   


### PR DESCRIPTION
## Description

Correction des wordings exacts utilisés pour identifier les divisions du championnat de Paris dans la fonction `getParisTeamStructure`.

## Modifications

- Remplacement de `division 1` / `div 1` par `1ere Division` / `1ère Division` (avec variantes)
- Remplacement de `division 2` / `div 2` par `2eme Division` / `2ème Division` (avec variantes)
- Conservation de `Excellence`, `Promo Excellence` et `Honneur` (déjà corrects)

## Wordings exacts supportés

- **1ere Division** ou **1ère Division** (2 groupes, 6 joueurs)
- **2eme Division** ou **2ème Division** (1 groupe, 3 joueurs)
- **Excellence** (3 groupes, 9 joueurs)
- **Promo Excellence** (3 groupes, 9 joueurs)
- **Honneur** (3 groupes, 9 joueurs)

La fonction supporte également les variantes avec/sans accents et avec/sans le mot "div" pour plus de robustesse.