### PR TITLE
fix(compositions): désactiver le picto Discord si aucun lieu n'est configuré

### DIFF
--- a/src/app/compositions/page.tsx
+++ b/src/app/compositions/page.tsx
@@ -3009,6 +3009,13 @@ export default function CompositionsPage() {
                                           title={
                                             !equipe.team.discordChannelId
                                               ? "Aucun canal Discord configuré pour cette équipe. Configurez-le dans la page des équipes."
+                                              : !equipe.team.location ||
+                                                !locations.find(
+                                                  (l) =>
+                                                    l.id ===
+                                                    equipe.team.location
+                                                )
+                                              ? "Aucun lieu configuré pour cette équipe. Configurez-le dans la page des équipes."
                                               : showMatchInfo[equipe.team.id]
                                               ? "Masquer le message"
                                               : "Afficher le message"
@@ -3025,7 +3032,13 @@ export default function CompositionsPage() {
                                                 }));
                                               }}
                                               disabled={
-                                                !equipe.team.discordChannelId
+                                                !equipe.team.discordChannelId ||
+                                                !equipe.team.location ||
+                                                !locations.find(
+                                                  (l) =>
+                                                    l.id ===
+                                                    equipe.team.location
+                                                )
                                               }
                                               color={
                                                 showMatchInfo[equipe.team.id]
@@ -3380,6 +3393,13 @@ export default function CompositionsPage() {
                                             title={
                                               !equipe.team.discordChannelId
                                                 ? "Aucun canal Discord configuré pour cette équipe. Configurez-le dans la page des équipes."
+                                                : !equipe.team.location ||
+                                                  !locations.find(
+                                                    (l) =>
+                                                      l.id ===
+                                                      equipe.team.location
+                                                  )
+                                                ? "Aucun lieu configuré pour cette équipe. Configurez-le dans la page des équipes."
                                                 : discordSentStatus[
                                                     equipe.team.id
                                                   ]?.sent
@@ -3426,7 +3446,14 @@ export default function CompositionsPage() {
                                                     equipe.team.id
                                                   ] ||
                                                   !matchInfo ||
-                                                  !equipe.team.discordChannelId
+                                                  !equipe.team
+                                                    .discordChannelId ||
+                                                  !equipe.team.location ||
+                                                  !locations.find(
+                                                    (l) =>
+                                                      l.id ===
+                                                      equipe.team.location
+                                                  )
                                                 }
                                                 sx={{ p: 0.5 }}
                                                 color={
@@ -3805,6 +3832,12 @@ export default function CompositionsPage() {
                                         title={
                                           !equipe.team.discordChannelId
                                             ? "Aucun canal Discord configuré pour cette équipe. Configurez-le dans la page des équipes."
+                                            : !equipe.team.location ||
+                                              !locations.find(
+                                                (l) =>
+                                                  l.id === equipe.team.location
+                                              )
+                                            ? "Aucun lieu configuré pour cette équipe. Configurez-le dans la page des équipes."
                                             : showMatchInfo[equipe.team.id]
                                             ? "Masquer le message"
                                             : "Afficher le message"
@@ -3821,7 +3854,12 @@ export default function CompositionsPage() {
                                               }));
                                             }}
                                             disabled={
-                                              !equipe.team.discordChannelId
+                                              !equipe.team.discordChannelId ||
+                                              !equipe.team.location ||
+                                              !locations.find(
+                                                (l) =>
+                                                  l.id === equipe.team.location
+                                              )
                                             }
                                             color={
                                               showMatchInfo[equipe.team.id]
@@ -4103,6 +4141,13 @@ export default function CompositionsPage() {
                                           title={
                                             !equipe.team.discordChannelId
                                               ? "Aucun canal Discord configuré pour cette équipe. Configurez-le dans la page des équipes."
+                                              : !equipe.team.location ||
+                                                !locations.find(
+                                                  (l) =>
+                                                    l.id ===
+                                                    equipe.team.location
+                                                )
+                                              ? "Aucun lieu configuré pour cette équipe. Configurez-le dans la page des équipes."
                                               : discordSentStatus[
                                                   equipe.team.id
                                                 ]?.sent
@@ -4148,7 +4193,13 @@ export default function CompositionsPage() {
                                                   equipe.team.id
                                                 ] ||
                                                 !matchInfo ||
-                                                !equipe.team.discordChannelId
+                                                !equipe.team.discordChannelId ||
+                                                !equipe.team.location ||
+                                                !locations.find(
+                                                  (l) =>
+                                                    l.id ===
+                                                    equipe.team.location
+                                                )
                                               }
                                               sx={{ p: 0.5 }}
                                               color={


### PR DESCRIPTION
## Description

Désactivation du picto permettant d'ouvrir/envoyer le message Discord lorsque aucun lieu n'est configuré pour l'équipe, de la même manière que c'est déjà fait pour les canaux Discord.

## Modifications

- Ajout de la vérification du lieu (`equipe.team.location`) pour désactiver le picto Discord
- Le picto est maintenant grisé et inactif si :
  - Aucun canal Discord n'est configuré (comportement existant)
  - **OU** aucun lieu n'est configuré (nouveau comportement)
- Mise à jour des tooltips pour indiquer clairement le problème (canal Discord ou lieu manquant)
- Application sur tous les boutons Discord :
  - Bouton "Afficher le message" (équipes masculines et féminines)
  - Bouton "Envoyer le message Discord" (équipes masculines et féminines)

## Comportement

Avant : Le picto était désactivé uniquement si aucun canal Discord n'était configuré.

Après : Le picto est désactivé si aucun canal Discord **OU** aucun lieu n'est configuré.

Cela garantit que le message Discord ne peut pas être généré/envoyé si les informations essentielles (canal et lieu) ne sont pas complètes.