### PR TITLE
Refactor composition filters and drag handling

### DIFF
--- a/src/components/compositions/AvailablePlayersPanel.tsx
+++ b/src/components/compositions/AvailablePlayersPanel.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import React from "react";
-import {
-  Paper,
-  Box,
-  Typography,
-  TextField,
-  Divider,
-  List,
-} from "@mui/material";
+import { Paper, Box, Typography, Divider, List } from "@mui/material";
+import { SearchInput } from "./Filters/SearchInput";
 import type { Player } from "@/types/team-management";
 
 export interface AvailablePlayersPanelProps {
@@ -74,14 +68,9 @@ export const AvailablePlayersPanel: React.FC<AvailablePlayersPanelProps> = ({
           </Typography>
         )}
         <Divider sx={{ mb: 2 }} />
-        <TextField
-          fullWidth
-          size="small"
-          placeholder="Rechercher un joueur..."
+        <SearchInput
           value={searchQuery}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-            onSearchChange(event.target.value)
-          }
+          onChange={onSearchChange}
           sx={{ mb: actions ? 1.5 : 2 }}
         />
 

--- a/src/components/compositions/Filters/EpreuveSelect.tsx
+++ b/src/components/compositions/Filters/EpreuveSelect.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  type SxProps,
+  type Theme,
+} from "@mui/material";
+import type { EpreuveType } from "@/lib/shared/epreuve-utils";
+
+interface EpreuveSelectProps {
+  value: EpreuveType | null;
+  onChange: (value: EpreuveType) => void;
+  id?: string;
+  labelId?: string;
+  sx?: SxProps<Theme>;
+}
+
+export const EpreuveSelect: React.FC<EpreuveSelectProps> = ({
+  value,
+  onChange,
+  id = "epreuve-select",
+  labelId = "epreuve-select-label",
+  sx,
+}) => {
+  return (
+    <FormControl size="small" sx={{ minWidth: 200, ...sx }}>
+      <InputLabel id={labelId}>Épreuve</InputLabel>
+      <Select
+        labelId={labelId}
+        id={id}
+        value={value || ""}
+        label="Épreuve"
+        onChange={(event) => onChange(event.target.value as EpreuveType)}
+      >
+        <MenuItem value="championnat_equipes">Championnat par Équipes</MenuItem>
+        <MenuItem value="championnat_paris">Championnat de Paris IDF</MenuItem>
+      </Select>
+    </FormControl>
+  );
+};

--- a/src/components/compositions/Filters/PhaseSelect.tsx
+++ b/src/components/compositions/Filters/PhaseSelect.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  type SxProps,
+  type Theme,
+} from "@mui/material";
+
+interface PhaseSelectProps {
+  value: "aller" | "retour" | null;
+  onChange: (value: "aller" | "retour") => void;
+  disabled?: boolean;
+  hidden?: boolean;
+  id?: string;
+  labelId?: string;
+  sx?: SxProps<Theme>;
+}
+
+export const PhaseSelect: React.FC<PhaseSelectProps> = ({
+  value,
+  onChange,
+  disabled = false,
+  hidden,
+  id = "phase-select",
+  labelId = "phase-select-label",
+  sx,
+}) => {
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <FormControl size="small" sx={{ minWidth: 150, ...sx }} disabled={disabled}>
+      <InputLabel id={labelId}>Phase</InputLabel>
+      <Select
+        labelId={labelId}
+        id={id}
+        value={value || ""}
+        label="Phase"
+        onChange={(event) => onChange(event.target.value as "aller" | "retour")}
+      >
+        <MenuItem value="aller">Phase Aller</MenuItem>
+        <MenuItem value="retour">Phase Retour</MenuItem>
+      </Select>
+    </FormControl>
+  );
+};

--- a/src/components/compositions/Filters/SearchInput.tsx
+++ b/src/components/compositions/Filters/SearchInput.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { TextField, type SxProps, type Theme } from "@mui/material";
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  sx?: SxProps<Theme>;
+}
+
+export const SearchInput: React.FC<SearchInputProps> = ({
+  value,
+  onChange,
+  placeholder = "Rechercher un joueur...",
+  sx = {},
+}) => {
+  return (
+    <TextField
+      fullWidth
+      size="small"
+      placeholder={placeholder}
+      value={value}
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+        onChange(event.target.value)
+      }
+      sx={sx}
+    />
+  );
+};

--- a/src/components/compositions/Filters/TabPanel.tsx
+++ b/src/components/compositions/Filters/TabPanel.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Box } from "@mui/material";
+
+export interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+  padding?: number;
+  idPrefix?: string;
+}
+
+export function TabPanel({
+  children,
+  value,
+  index,
+  padding = 5,
+  idPrefix = "compositions",
+  ...other
+}: TabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`${idPrefix}-tabpanel-${index}`}
+      aria-labelledby={`${idPrefix}-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: padding }}>{children}</Box>}
+    </div>
+  );
+}
+
+export default TabPanel;

--- a/src/hooks/usePlayerDrag.ts
+++ b/src/hooks/usePlayerDrag.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react";
+import { createDragImage } from "@/lib/compositions/drag-utils";
+import type { Player } from "@/types/team-management";
+import type { AssignmentValidationResult } from "@/lib/compositions/validation";
+
+interface UsePlayerDragOptions {
+  players: Player[];
+  selectedPhase: "aller" | "retour" | null;
+  getChampionshipTypeForPlayer: (playerId: string) => "masculin" | "feminin";
+  canDropPlayer?: (playerId: string, teamId: string) => AssignmentValidationResult;
+}
+
+export function usePlayerDrag({
+  players,
+  selectedPhase,
+  getChampionshipTypeForPlayer,
+  canDropPlayer,
+}: UsePlayerDragOptions) {
+  const [draggedPlayerId, setDraggedPlayerId] = useState<string | null>(null);
+  const [dragOverTeamId, setDragOverTeamId] = useState<string | null>(null);
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent, playerId: string) => {
+      const target = event.target as HTMLElement;
+      const clickedChip =
+        target.closest('[data-chip="remove"]') ||
+        target.closest('button[aria-label*="remove"]') ||
+        (target.tagName === "BUTTON" && target.textContent?.trim() === "×");
+
+      if (clickedChip || target.textContent?.trim() === "×") {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      event.dataTransfer.setData("playerId", playerId);
+      event.dataTransfer.effectAllowed = "move";
+      setDraggedPlayerId(playerId);
+      setDragOverTeamId(null);
+      document.documentElement.classList.add("dragging");
+
+      const player = players.find((p) => p.id === playerId);
+      if (!player) {
+        return;
+      }
+
+      const championshipType = getChampionshipTypeForPlayer(playerId);
+      const tempDiv = createDragImage(player, {
+        championshipType,
+        phase: (selectedPhase || "aller") as "aller" | "retour",
+      });
+      document.body.appendChild(tempDiv);
+      void tempDiv.offsetHeight;
+      event.dataTransfer.setDragImage(tempDiv, 0, 0);
+      setTimeout(() => {
+        if (document.body.contains(tempDiv)) {
+          document.body.removeChild(tempDiv);
+        }
+      }, 0);
+    },
+    [getChampionshipTypeForPlayer, players, selectedPhase]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedPlayerId(null);
+    setDragOverTeamId(null);
+    document.documentElement.classList.remove("dragging");
+  }, []);
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent, teamId: string) => {
+      event.preventDefault();
+      setDragOverTeamId(teamId);
+
+      if (draggedPlayerId && canDropPlayer) {
+        const validation = canDropPlayer(draggedPlayerId, teamId);
+        event.dataTransfer.dropEffect = validation.canAssign ? "move" : "none";
+      } else {
+        event.dataTransfer.dropEffect = "move";
+      }
+    },
+    [canDropPlayer, draggedPlayerId]
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setDragOverTeamId(null);
+  }, []);
+
+  useEffect(() => {
+    const clearDrag = () => {
+      document.documentElement.classList.remove("dragging");
+      setDraggedPlayerId(null);
+      setDragOverTeamId(null);
+    };
+
+    window.addEventListener("drop", clearDrag);
+    window.addEventListener("dragend", clearDrag);
+
+    return () => {
+      window.removeEventListener("drop", clearDrag);
+      window.removeEventListener("dragend", clearDrag);
+    };
+  }, []);
+
+  return {
+    draggedPlayerId,
+    dragOverTeamId,
+    handleDragStart,
+    handleDragEnd,
+    handleDragOver,
+    handleDragLeave,
+    setDraggedPlayerId,
+    setDragOverTeamId,
+  };
+}
+
+export default usePlayerDrag;


### PR DESCRIPTION
## Summary
- move composition filters and tab panel into reusable components for both composition flows
- add a shared `usePlayerDrag` hook to centralize drag-and-drop behavior
- wire the new utilities into composition and default pages, simplifying search and selection controls

## Testing
- npm run lint
- npm run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a45f3e74832d88709e909d9b690e)