### PR TITLE
Add PR strategy for multi-task refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ L'application sera accessible sur [http://localhost:3000](http://localhost:3000)
 ### Documentation technique
 
 - **[Workflow Git/GitHub](./.github/GIT_WORKFLOW.md)** : Workflow de développement et déploiement
+- **[Stratégie de pull requests multi-tâches](./docs/technical/PR_STRATEGY.md)** : Recommandations pour regrouper un refactoring complet dans une seule PR
 - **[Règles de statut des matchs](./docs/technical/MATCH_STATUS_RULES.md)** : Règles de gestion de l'affichage du statut des matchs
 - **[Suppression de code mort](./docs/technical/DEAD_CODE_REMOVAL.md)** : Documentation des suppressions de code mort
 - **[Tests de non-régression](./docs/technical/TESTS_NON_REGRESSION.md)** : Checklist des tests de non-régression

--- a/docs/technical/PR_STRATEGY.md
+++ b/docs/technical/PR_STRATEGY.md
@@ -1,0 +1,10 @@
+# Pull request strategy for multi-task refactors
+
+When a refactor spans multiple tightly-coupled tasks (shared store, component factorisation, validation alignment, etc.), group them into **one pull request** rather than opening a PR per task. This keeps review coherent and prevents partial merges from breaking related pages.
+
+## Guidelines
+- Start from a single branch dedicated to the refactor.
+- Sequence tasks as separate commits for clarity (e.g. store setup, UI factorisation, validations), but keep them in one PR.
+- Only split into multiple PRs if tasks are truly independent and can be deployed separately without feature gaps.
+- Explicitly call out in the PR description when several plan items are delivered together so reviewers can evaluate the whole scope.
+- If automation creates multiple PRs by default, disable/adjust it for this branch so only the combined PR remains.


### PR DESCRIPTION
## Summary
- document guidelines to keep tightly coupled refactors in a single pull request
- link the new PR strategy guide from the main README documentation section

## Testing
- eslint
- tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a2856e1c832d87c4a4b225354976)