### PR TITLE
Refactor availability filters and state management

### DIFF
--- a/src/components/disponibilites/AvailabilityStatusChip.tsx
+++ b/src/components/disponibilites/AvailabilityStatusChip.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Chip, ChipProps } from "@mui/material";
+
+export type AvailabilityStatus = "available" | "unavailable" | "pending" | "unknown";
+
+interface AvailabilityStatusChipProps extends Omit<ChipProps, "color" | "label"> {
+  status: AvailabilityStatus;
+  label?: string;
+}
+
+const statusConfig: Record<AvailabilityStatus, { color: ChipProps["color"]; label: string }> = {
+  available: { color: "success", label: "Disponible" },
+  unavailable: { color: "error", label: "Indisponible" },
+  pending: { color: "warning", label: "En attente" },
+  unknown: { color: "default", label: "Non renseigné" },
+};
+
+export const AvailabilityStatusChip: React.FC<AvailabilityStatusChipProps> = ({
+  status,
+  label,
+  ...props
+}) => {
+  const config = statusConfig[status];
+  const color = config.color ?? "default";
+  return (
+    <Chip
+      size="small"
+      color={color}
+      label={label ?? config.label}
+      {...props}
+    />
+  );
+};

--- a/src/lib/availability/utils.ts
+++ b/src/lib/availability/utils.ts
@@ -1,0 +1,169 @@
+import { AvailabilityResponse } from "@/lib/services/availability-service";
+import { ChampionshipType } from "@/types";
+
+export type PlayerAvailabilityByType = {
+  masculin?: AvailabilityResponse;
+  feminin?: AvailabilityResponse;
+};
+
+export type AvailabilityState = Record<string, PlayerAvailabilityByType>;
+
+export const sanitizeAvailabilityEntry = (
+  entry?: AvailabilityResponse | null
+): AvailabilityResponse | undefined => {
+  if (!entry) {
+    return undefined;
+  }
+
+  const sanitized: AvailabilityResponse = {};
+
+  if (typeof entry.available === "boolean") {
+    sanitized.available = entry.available;
+  }
+
+  if (typeof entry.comment === "string") {
+    const trimmed = entry.comment.trim();
+    if (trimmed.length > 0) {
+      sanitized.comment = trimmed;
+    }
+  }
+
+  if (sanitized.available === undefined && sanitized.comment === undefined) {
+    return undefined;
+  }
+
+  return sanitized;
+};
+
+export const availabilityEntriesEqual = (
+  current?: AvailabilityResponse | null,
+  next?: AvailabilityResponse | null,
+  skipNormalization: boolean = false
+): boolean => {
+  const normalizedCurrent = skipNormalization
+    ? current
+    : sanitizeAvailabilityEntry(current);
+  const normalizedNext = skipNormalization ? next : sanitizeAvailabilityEntry(next);
+
+  if (!normalizedCurrent && !normalizedNext) {
+    return true;
+  }
+  if (!normalizedCurrent || !normalizedNext) {
+    return false;
+  }
+
+  return (
+    normalizedCurrent.available === normalizedNext.available &&
+    normalizedCurrent.comment === normalizedNext.comment
+  );
+};
+
+export const updateAvailabilityState = (
+  previousState: AvailabilityState,
+  playerId: string,
+  championshipType: ChampionshipType,
+  computeNextEntry: (
+    currentEntry: AvailabilityResponse | undefined
+  ) => AvailabilityResponse | undefined,
+  skipNormalization: boolean = false
+): { nextState: AvailabilityState; changed: boolean } => {
+  const currentPlayerState = previousState[playerId];
+  const currentEntry = currentPlayerState?.[championshipType];
+
+  const computedEntry = computeNextEntry(currentEntry);
+
+  const normalizedCurrent = skipNormalization
+    ? currentEntry
+    : sanitizeAvailabilityEntry(currentEntry);
+  const normalizedNext = skipNormalization
+    ? computedEntry
+    : sanitizeAvailabilityEntry(computedEntry);
+
+  if (availabilityEntriesEqual(normalizedCurrent, normalizedNext, skipNormalization)) {
+    return { nextState: previousState, changed: false };
+  }
+
+  const nextState: AvailabilityState = { ...previousState };
+
+  if (skipNormalization) {
+    if (
+      !computedEntry ||
+      (computedEntry.available === undefined &&
+        (!computedEntry.comment || computedEntry.comment.trim().length === 0))
+    ) {
+      if (!currentPlayerState) {
+        return { nextState: previousState, changed: false };
+      }
+
+      const nextPlayerState: PlayerAvailabilityByType = {
+        ...currentPlayerState,
+      };
+      delete nextPlayerState[championshipType];
+
+      if (Object.keys(nextPlayerState).length === 0) {
+        delete nextState[playerId];
+      } else {
+        nextState[playerId] = nextPlayerState;
+      }
+
+      return { nextState, changed: true };
+    }
+
+    const nextPlayerState: PlayerAvailabilityByType = {
+      ...(currentPlayerState ?? {}),
+      [championshipType]: { ...computedEntry },
+    };
+
+    nextState[playerId] = nextPlayerState;
+
+    return { nextState, changed: true };
+  }
+
+  if (!normalizedNext) {
+    if (!currentPlayerState) {
+      return { nextState: previousState, changed: false };
+    }
+
+    const nextPlayerState: PlayerAvailabilityByType = {
+      ...currentPlayerState,
+    };
+    delete nextPlayerState[championshipType];
+
+    if (Object.keys(nextPlayerState).length === 0) {
+      delete nextState[playerId];
+    } else {
+      nextState[playerId] = nextPlayerState;
+    }
+
+    return { nextState, changed: true };
+  }
+
+  const sanitizedEntry: AvailabilityResponse = {
+    ...normalizedNext,
+  };
+
+  const nextPlayerState: PlayerAvailabilityByType = {
+    ...(currentPlayerState ?? {}),
+    [championshipType]: sanitizedEntry,
+  };
+
+  nextState[playerId] = nextPlayerState;
+
+  return { nextState, changed: true };
+};
+
+export const buildPlayersPayload = (
+  state: AvailabilityState,
+  championshipType: ChampionshipType
+): Record<string, AvailabilityResponse> => {
+  const payload: Record<string, AvailabilityResponse> = {};
+
+  Object.entries(state).forEach(([playerId, playerState]) => {
+    const entry = sanitizeAvailabilityEntry(playerState[championshipType]);
+    if (entry) {
+      payload[playerId] = entry;
+    }
+  });
+
+  return payload;
+};

--- a/src/stores/availabilityStore.ts
+++ b/src/stores/availabilityStore.ts
@@ -1,0 +1,118 @@
+import { create } from "zustand";
+import { AvailabilityResponse } from "@/lib/services/availability-service";
+import { EpreuveType } from "@/lib/shared/epreuve-utils";
+import {
+  AvailabilityState,
+  PlayerAvailabilityByType,
+  updateAvailabilityState,
+} from "@/lib/availability/utils";
+import { ChampionshipType } from "@/types";
+
+interface AvailabilityFilters {
+  selectedEpreuve: EpreuveType | null;
+  selectedJournee: number | null;
+  selectedPhase: "aller" | "retour" | null;
+  showAllPlayers: boolean;
+  searchQuery: string;
+}
+
+interface AvailabilityStoreState extends AvailabilityFilters {
+  availabilities: AvailabilityState;
+  setSelectedEpreuve: (epreuve: EpreuveType | null) => void;
+  setSelectedJournee: (journee: number | null) => void;
+  setSelectedPhase: (phase: "aller" | "retour" | null) => void;
+  setShowAllPlayers: (show: boolean) => void;
+  setSearchQuery: (query: string) => void;
+  setAvailabilities: (next: AvailabilityState) => void;
+  resetAvailabilities: () => void;
+  updateAvailabilityEntry: (
+    playerId: string,
+    championshipType: ChampionshipType,
+    computeNextEntry: (currentEntry: AvailabilityResponse | undefined) =>
+      | AvailabilityResponse
+      | undefined,
+    options?: { skipNormalization?: boolean }
+  ) => AvailabilityState | null;
+  removeAvailabilityEntry: (
+    playerId: string,
+    championshipType: ChampionshipType,
+    field: keyof AvailabilityResponse
+  ) => void;
+}
+
+export const useAvailabilityStore = create<AvailabilityStoreState>((set) => ({
+  selectedEpreuve: null,
+  selectedJournee: null,
+  selectedPhase: null,
+  showAllPlayers: false,
+  searchQuery: "",
+  availabilities: {},
+  setSelectedEpreuve: (epreuve) => set({ selectedEpreuve: epreuve }),
+  setSelectedJournee: (journee) => set({ selectedJournee: journee }),
+  setSelectedPhase: (phase) => set({ selectedPhase: phase }),
+  setShowAllPlayers: (showAllPlayers) => set({ showAllPlayers }),
+  setSearchQuery: (searchQuery) => set({ searchQuery }),
+  setAvailabilities: (next) => set({ availabilities: next }),
+  resetAvailabilities: () => set({ availabilities: {} }),
+  updateAvailabilityEntry: (
+    playerId,
+    championshipType,
+    computeNextEntry,
+    options
+  ) => {
+    let snapshot: AvailabilityState | null = null;
+    set((state) => {
+      const { nextState, changed } = updateAvailabilityState(
+        state.availabilities,
+        playerId,
+        championshipType,
+        computeNextEntry,
+        options?.skipNormalization
+      );
+      if (changed) {
+        snapshot = nextState;
+        return { availabilities: nextState };
+      }
+      return {};
+    });
+    return snapshot;
+  },
+  removeAvailabilityEntry: (playerId, championshipType, field) =>
+    set((state) => {
+      const currentPlayerState: PlayerAvailabilityByType | undefined =
+        state.availabilities[playerId];
+
+      if (!currentPlayerState?.[championshipType]) {
+        return {};
+      }
+
+      const currentEntry = currentPlayerState[championshipType];
+      const nextEntry = { ...currentEntry } as AvailabilityResponse;
+
+      if (field in nextEntry) {
+        delete nextEntry[field];
+      }
+
+      const hasData =
+        nextEntry.available !== undefined ||
+        (typeof nextEntry.comment === "string" && nextEntry.comment.trim().length > 0);
+
+      const nextPlayerState: PlayerAvailabilityByType = { ...currentPlayerState };
+
+      if (hasData) {
+        nextPlayerState[championshipType] = nextEntry;
+      } else {
+        delete nextPlayerState[championshipType];
+      }
+
+      const nextAvailabilities: AvailabilityState = { ...state.availabilities };
+
+      if (Object.keys(nextPlayerState).length === 0) {
+        delete nextAvailabilities[playerId];
+      } else {
+        nextAvailabilities[playerId] = nextPlayerState;
+      }
+
+      return { availabilities: nextAvailabilities };
+    }),
+}));


### PR DESCRIPTION
## Summary
- move availability normalization helpers to a shared utility module and expose a global availability store for filters and state
- refactor the availability page to use shared filter components, store selectors, and a team picker with searchable list
- add reusable availability status chips for visualizing player responses

## Testing
- npm run lint
- npm run type-check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b7602e04832d824f65d2052709dc)