### PR TITLE
Add tests and stories for compositions helpers

### DIFF
--- a/docs/technical/STORE_AND_PROPS.md
+++ b/docs/technical/STORE_AND_PROPS.md
@@ -1,0 +1,21 @@
+# Gestion des stores et conventions de props
+
+## Structure du store des compositions
+
+Le store `teamManagementStore` centralise toutes les données liées aux compositions :
+
+- **Joueurs** : `players`, état de chargement/erreur associé et méthode `loadPlayers()` pour récupérer la liste via `FirestorePlayerService`.
+- **Équipes et matchs** : `equipesWithMatches` ainsi que `loadEquipesWithMatches()` qui appelle l'API `/api/teams/matches` puis trie les équipes par numéro.
+- **Disponibilités** : stockées par clé (`availabilityByKey`) générée par `getDayKey()`, avec suivi des états de chargement/erreur et des subscriptions temps réel.
+- **Compositions** : `compositionsByKey` avec indicateurs de chargement/erreur et `subscribeToComposition()` pour suivre les mises à jour d'une journée/phase donnée.
+- **Defaults** : `defaultsByChampionship` et `fetchCompositionDefaults()` pour récupérer les compositions par défaut par championnat et par phase.
+
+Chaque section du store possède son triplet `data/loading/error` ainsi qu'un dictionnaire de `subscriptions` lorsque la ressource est temps réel. Privilégier l'utilisation des sélecteurs fournis par le store pour éviter les re-render inutiles.
+
+## Conventions de props pour les composants de compositions
+
+- **Nommage explicite** : utiliser des props `value`/`onChange` typées (`phase`, `epreuve`, `searchQuery`) plutôt que des noms génériques.
+- **Accessoires optionnels** : préférer des props optionnelles documentées (`label`, `minWidth`, `containerProps`) avec des valeurs par défaut définies dans le composant.
+- **Contenu injecté** : pour les panneaux réutilisables comme `AvailablePlayersPanel`, passer le rendu des éléments via une prop de fonction (`renderPlayerItem`) et autoriser des blocs additionnels (`actions`, `headerContent`) pour conserver la flexibilité sans multiplier les variantes.
+- **Messages paramétrables** : exposer les textes d'état (vides, erreurs, placeholders) en props (`emptyMessage`, `noResultMessage`) afin de garder les composants indépendants du contexte métier.
+- **Styles extensibles** : ouvrir les props `sx` ou `containerProps` quand les composants s'intègrent dans des layouts variés, tout en conservant un style par défaut cohérent.

--- a/src/__tests__/brulageService.test.ts
+++ b/src/__tests__/brulageService.test.ts
@@ -78,15 +78,23 @@ describe("BrulageService", () => {
     });
 
     it("should reject composition with too many female players", () => {
-      // Créer une joueuse supplémentaire pour le test
-      const femalePlayer: Player = {
-        ...mockPlayers[1],
-        id: "4",
-        firstName: "Sophie",
-        lastName: "Bernard",
-      };
+      // Créer deux joueuses supplémentaires pour le test
+      const extraFemalePlayers: Player[] = [
+        {
+          ...mockPlayers[1],
+          id: "4",
+          firstName: "Sophie",
+          lastName: "Bernard",
+        },
+        {
+          ...mockPlayers[1],
+          id: "5",
+          firstName: "Julie",
+          lastName: "Lambert",
+        },
+      ];
 
-      const playersWithExtraFemale = [...mockPlayers, femalePlayer];
+      const playersWithExtraFemale = [...mockPlayers, ...extraFemalePlayers];
       const serviceWithExtraFemale = new BrulageService(
         mockBurnRecords,
         playersWithExtraFemale
@@ -95,8 +103,8 @@ describe("BrulageService", () => {
       const compositionWithThreeFemales = {
         A: "2", // Marie
         B: "4", // Sophie
-        C: "1",
-        D: "3",
+        C: "5", // Julie
+        D: "1",
       };
 
       const result = serviceWithExtraFemale.validateComposition(

--- a/src/__tests__/compositions/championship-utils.test.ts
+++ b/src/__tests__/compositions/championship-utils.test.ts
@@ -1,0 +1,81 @@
+import { getPlayersByType, getTeamsByType } from "@/lib/compositions/championship-utils";
+import type { EquipeWithMatches } from "@/hooks/useTeamData";
+import type { Player } from "@/types/team-management";
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  id: "p1",
+  name: "Doe",
+  firstName: "John",
+  license: "123",
+  typeLicence: "T",
+  gender: "M",
+  nationality: "FR",
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  preferredTeams: { masculine: [], feminine: [] },
+  participation: {},
+  ...overrides,
+});
+
+const createEquipe = (
+  id: string,
+  matches: Array<Partial<EquipeWithMatches["matches"][number]>>
+): EquipeWithMatches => ({
+  team: {
+    id,
+    name: `Team ${id}`,
+    division: "D1",
+    gender: "M",
+    level: 1,
+    isActive: true,
+  },
+  matches: matches.map((match, index) => ({
+    id: `m-${id}-${index}`,
+    opponent: "",
+    phase: "aller",
+    score: "0-0",
+    journee: 1,
+    result: "",
+    ...match,
+  })),
+});
+
+describe("championship-utils", () => {
+  describe("getTeamsByType", () => {
+    it("should split teams between masculine and feminine based on matches", () => {
+      const equipes: EquipeWithMatches[] = [
+        createEquipe("1", [{ isFemale: true }]),
+        createEquipe("2", [{ isFemale: false }]),
+        createEquipe("3", [{ isFemale: true }]),
+      ];
+
+      const result = getTeamsByType(equipes);
+
+      expect(result.feminin.map((team) => team.team.id)).toEqual(["1", "3"]);
+      expect(result.masculin.map((team) => team.team.id)).toEqual(["2"]);
+    });
+  });
+
+  describe("getPlayersByType", () => {
+    it("should return all players for masculine championship", () => {
+      const players = [createPlayer({ id: "p1" }), createPlayer({ id: "p2", gender: "F" })];
+
+      const result = getPlayersByType(players, "masculin");
+
+      expect(result).toHaveLength(2);
+    });
+
+    it("should only return female players for feminine championship", () => {
+      const players = [
+        createPlayer({ id: "p1", gender: "M" }),
+        createPlayer({ id: "p2", gender: "F" }),
+        createPlayer({ id: "p3", gender: "F" }),
+      ];
+
+      const result = getPlayersByType(players, "feminin");
+
+      expect(result.map((player) => player.id)).toEqual(["p2", "p3"]);
+    });
+  });
+});

--- a/src/__tests__/compositions/drag-utils.test.ts
+++ b/src/__tests__/compositions/drag-utils.test.ts
@@ -1,0 +1,37 @@
+import { createDragImage } from "@/lib/compositions/drag-utils";
+import type { Player } from "@/types/team-management";
+
+describe("createDragImage", () => {
+  const basePlayer: Player = {
+    id: "p1",
+    name: "Doe",
+    firstName: "Jane",
+    license: "123",
+    typeLicence: "T",
+    gender: "F",
+    nationality: "C",
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    preferredTeams: { masculine: [], feminine: [] },
+    participation: {},
+    points: 850,
+    highestFeminineTeamNumberByPhase: { aller: 3 },
+  };
+
+  it("renders drag preview with player name and badges", () => {
+    const element = createDragImage(basePlayer, { championshipType: "feminin", phase: "aller" });
+
+    expect(element.textContent).toContain("Jane Doe");
+    expect(element.textContent).toContain("EUR");
+    expect(element.textContent).toContain("Brûlé Éq. 3");
+  });
+
+  it("falls back to default labels when data is missing", () => {
+    const element = createDragImage({ ...basePlayer, points: undefined, nationality: "FR", highestFeminineTeamNumberByPhase: {} });
+
+    expect(element.textContent).toContain("Points non disponibles");
+    expect(element.textContent).not.toContain("EUR");
+    expect(element.textContent).not.toContain("Brûlé");
+  });
+});

--- a/src/__tests__/compositions/validators.test.ts
+++ b/src/__tests__/compositions/validators.test.ts
@@ -1,0 +1,63 @@
+import {
+  calculateFutureBurnout,
+  calculateFutureBurnoutParis,
+  isMatchPlayed,
+} from "@/lib/compositions/validators";
+import type { Match } from "@/types";
+
+describe("validators helpers", () => {
+  describe("calculateFutureBurnout", () => {
+    it("returns the future burned team when adding a second match", () => {
+      expect(calculateFutureBurnout(undefined, 4, "masculin")).toBeNull();
+      expect(calculateFutureBurnout({ 4: 1 }, 4, "masculin")).toBe(4);
+    });
+
+    it("returns the second team number when player becomes burned", () => {
+      const result = calculateFutureBurnout({ 4: 1, 6: 1 }, 4, "masculin");
+      expect(result).toBe(4);
+    });
+  });
+
+  describe("calculateFutureBurnoutParis", () => {
+    it("returns null when there are no prior matches", () => {
+      expect(calculateFutureBurnoutParis(undefined, 5, "masculin")).toBeNull();
+    });
+
+    it("returns highest team number where player will be burned", () => {
+      const result = calculateFutureBurnoutParis({ 3: 3, 5: 1 }, 5, "masculin");
+      expect(result).toBe(5);
+    });
+  });
+
+  describe("isMatchPlayed", () => {
+    const baseMatch: Match = {
+      id: "1",
+      opponent: "",
+      phase: "aller",
+      score: "0-0",
+      journee: 1,
+      result: "À VENIR",
+    };
+
+    it("detects played matches from players list", () => {
+      const match: Match = {
+        ...baseMatch,
+        joueursSQY: [{ licence: "123" }],
+      };
+      expect(isMatchPlayed(match)).toBe(true);
+    });
+
+    it("detects played matches from a valid score", () => {
+      const match: Match = {
+        ...baseMatch,
+        score: "3-1",
+        result: "Victoire",
+      };
+      expect(isMatchPlayed(match)).toBe(true);
+    });
+
+    it("returns false when score and players are missing", () => {
+      expect(isMatchPlayed(baseMatch)).toBe(false);
+    });
+  });
+});

--- a/src/components/compositions/__stories__/AvailablePlayersPanel.stories.tsx
+++ b/src/components/compositions/__stories__/AvailablePlayersPanel.stories.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState, type ReactElement } from "react";
+import { ListItem, ListItemText } from "@mui/material";
+import { AvailablePlayersPanel } from "../AvailablePlayersPanel";
+import type { Player } from "@/types/team-management";
+
+const createPlayer = (id: string, name: string, points?: number): Player => ({
+  id,
+  name,
+  firstName: "Test",
+  license: `LIC-${id}`,
+  typeLicence: "T",
+  gender: id.endsWith("F") ? "F" : "M",
+  nationality: "FR",
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  preferredTeams: { masculine: [], feminine: [] },
+  participation: {},
+  ...(points !== undefined ? { points } : {}),
+});
+
+const players: Player[] = [
+  createPlayer("1", "Martin", 980),
+  createPlayer("2F", "Alice", 720),
+  createPlayer("3", "Dubois"),
+];
+
+const meta = {
+  title: "Compositions/Panels/AvailablePlayersPanel",
+  component: AvailablePlayersPanel,
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+
+type Story = { render: () => ReactElement };
+
+const AvailablePlayersPanelPreview = () => {
+  const [query, setQuery] = useState("");
+  const filteredPlayers = useMemo(
+    () =>
+      players.filter((player) =>
+        `${player.firstName} ${player.name}`
+          .toLowerCase()
+          .includes(query.toLowerCase())
+      ),
+    [query]
+  );
+
+  return (
+    <AvailablePlayersPanel
+      title="Joueurs disponibles"
+      subtitle="Filtrez et visualisez les joueurs prêts à être assignés"
+      searchQuery={query}
+      onSearchChange={setQuery}
+      totalCount={players.length}
+      filteredPlayers={filteredPlayers}
+      renderPlayerItem={(player) => (
+        <ListItem key={player.id} divider>
+          <ListItemText
+            primary={`${player.firstName} ${player.name}`}
+            secondary={player.points ? `${player.points} points` : "Points inconnus"}
+          />
+        </ListItem>
+      )}
+      emptyMessage="Aucun joueur disponible"
+      noResultMessage={(value) => `Aucun joueur ne correspond à "${value}"`}
+      actions={<span>Actions personnalisées</span>}
+      containerProps={{ maxWidth: 420 }}
+    />
+  );
+};
+
+export const Default: Story = {
+  render: () => <AvailablePlayersPanelPreview />,
+};

--- a/src/components/compositions/__stories__/Chips.stories.tsx
+++ b/src/components/compositions/__stories__/Chips.stories.tsx
@@ -1,0 +1,30 @@
+import { Box } from "@mui/material";
+import { CompositionsSummary } from "../CompositionsSummary";
+
+const meta = {
+  title: "Compositions/Chips",
+  component: CompositionsSummary,
+  args: {
+    totalTeams: 6,
+    completedTeams: 3,
+    incompleteTeams: 2,
+    invalidTeams: 1,
+    matchesPlayed: 4,
+    discordMessagesSent: 2,
+    discordMessagesTotal: 4,
+    percentage: 50,
+    completionLabel: "terminé",
+  },
+};
+
+export default meta;
+
+type StoryProps = typeof meta.args;
+
+export const Overview = {
+  render: (props: StoryProps) => (
+    <Box sx={{ maxWidth: 720 }}>
+      <CompositionsSummary {...props} />
+    </Box>
+  ),
+};

--- a/src/components/compositions/__stories__/Filters.stories.tsx
+++ b/src/components/compositions/__stories__/Filters.stories.tsx
@@ -1,0 +1,59 @@
+import { useState, type ReactElement } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import { EpreuveSelect } from "../Filters/EpreuveSelect";
+import { PhaseSelect } from "../Filters/PhaseSelect";
+import { SearchInput } from "../Filters/SearchInput";
+import { TabPanel } from "../Filters/TabPanel";
+import { TeamPicker } from "../Filters/TeamPicker";
+
+const meta = {
+  title: "Compositions/Filters",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = { render: () => ReactElement };
+
+const FiltersPlaygroundComponent = () => {
+  const [search, setSearch] = useState("");
+  const [phase, setPhase] = useState<"aller" | "retour" | null>("aller");
+  const [epreuve, setEpreuve] = useState<
+    "championnat_equipes" | "championnat_paris" | null
+  >("championnat_equipes");
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Box sx={{ width: 500 }}>
+      <Stack spacing={2}>
+        <Typography variant="h6">Filtres disponibles</Typography>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Rechercher un joueur"
+        />
+        <Stack direction="row" spacing={2}>
+          <PhaseSelect value={phase} onChange={setPhase} />
+          <EpreuveSelect value={epreuve} onChange={setEpreuve} />
+        </Stack>
+        <TeamPicker value={tab} onChange={(_, value) => setTab(value)} />
+        <TabPanel value={tab} index={0}>
+          <Typography variant="body2" color="text.secondary">
+            Liste des équipes masculines (onglet actif: {tab})
+          </Typography>
+        </TabPanel>
+        <TabPanel value={tab} index={1}>
+          <Typography variant="body2" color="text.secondary">
+            Liste des équipes féminines (onglet actif: {tab})
+          </Typography>
+        </TabPanel>
+      </Stack>
+    </Box>
+  );
+};
+
+export const FiltersPlayground: Story = {
+  render: () => <FiltersPlaygroundComponent />,
+};


### PR DESCRIPTION
## Summary
- add unit tests for composition helpers and validators
- document store structure and prop conventions for composition components
- create Storybook stories for reusable filter, chip, and panel components

## Testing
- npm test -- --runInBand
- npm run type-check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930bd036ca0832d8bd3fe76711a338b)