### PR TITLE
fix(zustand): correction des boucles infinies avec React 19

### DIFF
--- a/src/components/FirebaseAuthRestorer.tsx
+++ b/src/components/FirebaseAuthRestorer.tsx
@@ -22,7 +22,11 @@ export function FirebaseAuthRestorer() {
 
         // Récupérer un custom token depuis le serveur
         const res = await fetch("/api/session/firebase-token", {
+          method: "POST",
           credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+          },
         });
 
         if (!res.ok) {

--- a/src/hooks/usePlayers.ts
+++ b/src/hooks/usePlayers.ts
@@ -1,17 +1,18 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useTeamManagementStore } from "@/stores/teamManagementStore";
 
 export const usePlayers = () => {
-  const { players, playersLoading, playersError, loadPlayers } =
-    useTeamManagementStore((state) => ({
-      players: state.players,
-      playersLoading: state.playersLoading,
-      playersError: state.playersError,
-      loadPlayers: state.loadPlayers,
-    }));
+  const players = useTeamManagementStore((state) => state.players);
+  const playersLoading = useTeamManagementStore((state) => state.playersLoading);
+  const playersError = useTeamManagementStore((state) => state.playersError);
+  const loadPlayers = useTeamManagementStore((state) => state.loadPlayers);
+  
+  // Utiliser une ref pour éviter les appels multiples
+  const hasLoadedRef = useRef(false);
 
   useEffect(() => {
-    if (!players.length && !playersLoading && !playersError) {
+    if (!hasLoadedRef.current && !players.length && !playersLoading && !playersError) {
+      hasLoadedRef.current = true;
       void loadPlayers();
     }
   }, [loadPlayers, players.length, playersError, playersLoading]);

--- a/src/lib/zustand.ts
+++ b/src/lib/zustand.ts
@@ -37,9 +37,74 @@ export function create<T>(creator: StateCreator<T>): ZustandStore<T> {
   };
 
   let state = creator(setState, getState, { getState, setState, subscribe });
+  
+  // Capture le state initial pour le SSR (une seule fois)
+  const serverStateSnapshot = state;
+  
+  // Cache global pour les fonctions getServerSnapshot stables par selector
+  const serverSnapshotFunctions = new Map<string, () => unknown>();
+  
+  // Cache global pour les valeurs de getSnapshot avec comparaison shallow
+  // Structure: Map<selectorKey, { lastValue: unknown, lastState: T }>
+  const snapshotCache = new Map<string, { lastValue: unknown; lastState: T }>();
+  
+  // Fonction de comparaison shallow pour les objets
+  function shallowEqual(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (typeof a !== "object" || typeof b !== "object") return false;
+    
+    const keysA = Object.keys(a as Record<string, unknown>);
+    const keysB = Object.keys(b as Record<string, unknown>);
+    
+    if (keysA.length !== keysB.length) return false;
+    
+    for (const key of keysA) {
+      if (!(key in (b as Record<string, unknown>))) return false;
+      if ((a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key]) {
+        return false;
+      }
+    }
+    
+    return true;
+  }
 
   const useStore = (<U = T>(selector: (value: T) => U = (value) => value as unknown as U) => {
-    return useSyncExternalStore(subscribe, () => selector(state), () => selector(state));
+    // Créer une clé stable pour le selector en utilisant son code source
+    const selectorKey = selector.toString();
+    
+    // getSnapshot doit retourner une valeur stable (mise en cache)
+    // pour éviter les boucles infinies
+    const getSnapshot = (): U => {
+      const currentValue = selector(state);
+      const cached = snapshotCache.get(selectorKey);
+      
+      // Si le state n'a pas changé et la valeur est identique (shallow), retourner la valeur en cache
+      if (cached && cached.lastState === state && shallowEqual(cached.lastValue, currentValue)) {
+        return cached.lastValue as U;
+      }
+      
+      // Mettre à jour le cache
+      snapshotCache.set(selectorKey, { lastValue: currentValue, lastState: state });
+      return currentValue;
+    };
+    
+    // getServerSnapshot doit être une fonction stable (mise en cache)
+    // pour éviter les boucles infinies - React exige que la même fonction soit réutilisée
+    let getServerSnapshot = serverSnapshotFunctions.get(selectorKey) as (() => U) | undefined;
+    
+    if (!getServerSnapshot) {
+      // Première fois : créer une fonction stable qui retourne toujours la valeur initiale
+      const initialValue = selector(serverStateSnapshot);
+      getServerSnapshot = () => initialValue;
+      serverSnapshotFunctions.set(selectorKey, getServerSnapshot);
+    }
+    
+    return useSyncExternalStore(
+      subscribe,
+      getSnapshot,
+      getServerSnapshot
+    );
   }) as ZustandStore<T>;
 
   useStore.getState = getState;


### PR DESCRIPTION
## Description

Correction des erreurs de boucles infinies liées à l'utilisation de `useSyncExternalStore` avec React 19 dans l'implémentation personnalisée de Zustand.

## Problèmes résolus

1. **Erreur `getSnapshot`** : "The result of getSnapshot should be cached to avoid an infinite loop"
2. **Erreur `getServerSnapshot`** : "The result of getServerSnapshot should be cached to avoid an infinite loop"
3. **Erreur React** : "Maximum update depth exceeded"
4. **Erreur 405** : `FirebaseAuthRestorer` utilisait GET au lieu de POST

## Modifications

### `src/lib/zustand.ts`
- Ajout d'un cache global pour `getSnapshot` avec comparaison shallow
- Mise en cache stable de `getServerSnapshot` au niveau du store (pas dans la closure)
- Fonction `shallowEqual` pour comparer les objets retournés par les selectors
- Utilisation de la stringification du selector comme clé de cache

### `src/components/FirebaseAuthRestorer.tsx`
- Changement de GET vers POST pour correspondre à la route API
- Ajout des headers Content-Type

### `src/hooks/usePlayers.ts`
- Sélection individuelle des valeurs du store au lieu de créer un objet
- Ajout d'une ref pour éviter les appels multiples à `loadPlayers`

## Impact

Ces corrections permettent à l'application de fonctionner correctement avec React 19 sans erreurs de boucles infinies dans la console.