### PR TITLE
fix: correction du chip dupliqué 'A joué Paris' et déplacement des exports runtime

### DIFF
--- a/src/app/compositions/_containers/CompositionsPageContainer.tsx
+++ b/src/app/compositions/_containers/CompositionsPageContainer.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-// Force dynamic rendering to avoid static generation errors
-export const dynamic = "force-dynamic";
-export const runtime = "nodejs";
-
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import Link from "next/link";
 import {

--- a/src/app/compositions/_containers/DefaultCompositionsContainer.tsx
+++ b/src/app/compositions/_containers/DefaultCompositionsContainer.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-export const runtime = "nodejs";
-
 import React, { useState, useMemo, useEffect, useCallback } from "react";                                                     
 import Link from "next/link";
 import {

--- a/src/app/compositions/defaults/page.tsx
+++ b/src/app/compositions/defaults/page.tsx
@@ -2,7 +2,8 @@
 
 import { DefaultCompositionsContainer } from "../_containers/DefaultCompositionsContainer";
 
-export { dynamic, runtime } from "../_containers/DefaultCompositionsContainer";
+// Force dynamic rendering to avoid static generation errors
+export const dynamic = "force-dynamic";
 
 export default function DefaultCompositionsPage() {
   return <DefaultCompositionsContainer />;

--- a/src/app/compositions/page.tsx
+++ b/src/app/compositions/page.tsx
@@ -2,7 +2,8 @@
 
 import { CompositionsPageContainer } from "./_containers/CompositionsPageContainer";
 
-export { dynamic, runtime } from "./_containers/CompositionsPageContainer";
+// Force dynamic rendering to avoid static generation errors
+export const dynamic = "force-dynamic";
 
 export default function CompositionsPage() {
   return <CompositionsPageContainer />;

--- a/src/app/joueurs/page.tsx
+++ b/src/app/joueurs/page.tsx
@@ -1092,16 +1092,6 @@ export default function JoueursPage() {
                               title="Ce joueur a participé à au moins un match au championnat de Paris"
                             />
                           )}
-                          {player.hasPlayedAtLeastOneMatchParis && (
-                            <Chip
-                              icon={<SportsTennisIcon />}
-                              label="A joué Paris"
-                              size="small"
-                              color="secondary"
-                              variant="outlined"
-                              title="Ce joueur a participé à au moins un match au championnat de Paris"
-                            />
-                          )}
                         </Box>
                       </TableCell>
                       <TableCell>{player.license}</TableCell>
@@ -1588,16 +1578,6 @@ export default function JoueursPage() {
                               title="Ce joueur a participé à au moins un match au championnat de Paris"
                             />
                           )}
-                          {player.hasPlayedAtLeastOneMatchParis && (
-                            <Chip
-                              icon={<SportsTennisIcon />}
-                              label="A joué Paris"
-                              size="small"
-                              color="secondary"
-                              variant="outlined"
-                              title="Ce joueur a participé à au moins un match au championnat de Paris"
-                            />
-                          )}
                         </Box>
                       </TableCell>
                       <TableCell>
@@ -1831,16 +1811,6 @@ export default function JoueursPage() {
                               color="success"
                               variant="outlined"
                               title="Ce joueur a participé à au moins un match"
-                            />
-                          )}
-                          {player.hasPlayedAtLeastOneMatchParis && (
-                            <Chip
-                              icon={<SportsTennisIcon />}
-                              label="A joué Paris"
-                              size="small"
-                              color="secondary"
-                              variant="outlined"
-                              title="Ce joueur a participé à au moins un match au championnat de Paris"
                             />
                           )}
                           {player.hasPlayedAtLeastOneMatchParis && (


### PR DESCRIPTION
## Description

Corrections de bugs et améliorations de la configuration Next.js.

## Modifications

### Bug fix
- **Suppression du chip dupliqué 'A joué Paris'** : Le chip apparaissait deux fois sur la page  pour les joueurs ayant participé au championnat de Paris.

### Configuration Next.js
- **Déplacement de `export const dynamic`** : Déplacé depuis les containers vers les fichiers `page.tsx` pour respecter les conventions Next.js.
- **Suppression de `export const runtime`** : Retiré des composants client (non applicable aux Client Components).

## Fichiers modifiés

- `src/app/joueurs/page.tsx` : Suppression du chip dupliqué
- `src/app/compositions/page.tsx` : Déplacement de `dynamic`
- `src/app/compositions/defaults/page.tsx` : Déplacement de `dynamic`
- `src/app/compositions/_containers/CompositionsPageContainer.tsx` : Suppression des exports
- `src/app/compositions/_containers/DefaultCompositionsContainer.tsx` : Suppression des exports

## Tests

- ✅ Lint et type-check passent
- ✅ Aucune régression détectée