### PR TITLE
fix(compositions): autoriser plusieurs joueurs étrangers pour le championnat de Paris

### DIFF
--- a/src/app/compositions/_containers/CompositionsPageContainer.tsx
+++ b/src/app/compositions/_containers/CompositionsPageContainer.tsx
@@ -1711,7 +1711,9 @@ export function CompositionsPageContainer() {
           return prev;
         }
 
-        if (player.nationality === "ETR") {
+        // Pour le championnat de Paris : pas de limite sur les joueurs étrangers
+        const isParis = isParisChampionship(equipe);
+        if (!isParis && player.nationality === "ETR") {
           const targetTeamPlayersData = targetTeamPlayers
             .map((pid) => players.find((p) => p.id === pid))
             .filter((p): p is Player => p !== undefined);


### PR DESCRIPTION
## Summary

- Corrige le bug où le drop d'un joueur étranger était bloqué si l'équipe en contenait déjà un, même pour le championnat de Paris où cette limite ne s'applique pas
- La vérification "max 1 étranger" dans `handlePlayerDrop` est maintenant conditionnée par `isParisChampionship(equipe)`

## Contexte

- **Règle attendue** : Championnat de Paris → aucune limite sur les joueurs étrangers (ETR)
- **Symptôme** : Lors du drag-and-drop d'un joueur étranger vers une équipe qui en a déjà un : pas de message au survol, mais le joueur n'était pas ajouté à l'équipe

## Cause

`canAssignPlayerToTeam` (validators) autorisait correctement le drop pour Paris, mais `handlePlayerDrop` appliquait une vérification en doublon sans tenir compte du type de championnat.

## Test plan

- [ ] Compositions de journée, championnat de Paris : Déplacer un 2e joueur étranger sur une équipe qui en a déjà un → le joueur doit être ajouté
- [ ] Compositions de journée, championnat par équipes : Déplacer un 2e étranger sur une équipe qui en a déjà un → doit rester interdit
- [ ] Compositions par défaut, Paris : Comportement inchangé (déjà correct)