### PR TITLE
fix(discord): mettre le message dans content pour garantir l'affichage

### DIFF
--- a/src/lib/discord/poll-builder.ts
+++ b/src/lib/discord/poll-builder.ts
@@ -181,14 +181,10 @@ export function buildAvailabilityPollMessage(
       }>;
     }>;
   } = {
+    content: description,
     embeds: [embed],
     components,
   };
-
-  // Ajouter la mention au début du message si fournie
-  if (mention) {
-    result.content = mention;
-  }
 
   return result;
 }


### PR DESCRIPTION
## Description

Le texte du sondage était uniquement dans l'embed Discord et pouvait ne pas s'afficher sur certains clients (message vide avec uniquement la mention et les boutons).

**Solution** : mettre le message complet dans le champ `content` du message, qui est toujours affiché par Discord.

## Type de changement

- [x] Fix (correction de bug)

## Tests effectués

- `npm run check` passe