### PR TITLE
fix(discord,sync): sondage femmes + journées phase retour

### DIFF
--- a/src/lib/discord/poll-interactions.ts
+++ b/src/lib/discord/poll-interactions.ts
@@ -371,6 +371,7 @@ export async function handleRespondButton(
       });
     } else {
       // Femme : 2 select menus (vendredi et samedi)
+      // Discord n'autorise qu'un seul select menu par ACTION_ROW → 2 lignes distinctes
       const venAvailable = currentResponse?.fridayAvailable;
       const satAvailable = currentResponse?.saturdayAvailable;
       const hasVenResponse = venAvailable !== undefined;
@@ -386,7 +387,7 @@ export async function handleRespondButton(
           flags: 64,
           components: [
             {
-              type: 1, // ACTION_ROW
+              type: 1, // ACTION_ROW (1 select par ligne max)
               components: [
                 {
                   type: 3, // SELECT_MENU
@@ -394,6 +395,11 @@ export async function handleRespondButton(
                   options: venOptions,
                   placeholder: "Vendredi",
                 },
+              ],
+            },
+            {
+              type: 1, // ACTION_ROW
+              components: [
                 {
                   type: 3, // SELECT_MENU
                   custom_id: `availability_${pollId}_women_sat_select`,
@@ -596,6 +602,7 @@ export async function handleModifyButton(
     });
     } else {
       // Femme : 2 select menus (vendredi et samedi)
+      // Discord n'autorise qu'un seul select menu par ACTION_ROW → 2 lignes distinctes
       const venAvailable = currentResponse?.fridayAvailable;
       const satAvailable = currentResponse?.saturdayAvailable;
       const hasVenResponse = venAvailable !== undefined;
@@ -611,7 +618,7 @@ export async function handleModifyButton(
           flags: 64,
           components: [
             {
-              type: 1,
+              type: 1, // ACTION_ROW (1 select par ligne max)
               components: [
                 {
                   type: 3, // SELECT_MENU
@@ -619,6 +626,11 @@ export async function handleModifyButton(
                   options: venOptions,
                   placeholder: "Vendredi",
                 },
+              ],
+            },
+            {
+              type: 1, // ACTION_ROW
+              components: [
                 {
                   type: 3, // SELECT_MENU
                   custom_id: `availability_${pollId}_women_sat_select`,
@@ -1135,7 +1147,7 @@ export async function handleWomenSelect(
         const venOptions = createSelectOptions(false, fridayAvailable);
         const satOptions = createSelectOptions(false, saturdayAvailable);
 
-        // Mettre à jour le message éphémère
+        // Mettre à jour le message éphémère (1 select par ACTION_ROW)
         await updateEphemeralMessage(
           applicationId,
           interactionToken,
@@ -1144,7 +1156,7 @@ export async function handleWomenSelect(
           }\n\n💡 Vous pouvez modifier votre réponse en sélectionnant une autre option.`,
           [
             {
-              type: 1,
+              type: 1, // ACTION_ROW
               components: [
                 {
                   type: 3,
@@ -1152,6 +1164,11 @@ export async function handleWomenSelect(
                   options: venOptions,
                   placeholder: "Vendredi",
                 },
+              ],
+            },
+            {
+              type: 1, // ACTION_ROW
+              components: [
                 {
                   type: 3,
                   custom_id: `availability_${pollId}_women_sat_select`,

--- a/src/lib/shared/fftt-utils.ts
+++ b/src/lib/shared/fftt-utils.ts
@@ -104,8 +104,9 @@ export const extractClubName = (libelle: string): string => {
 
 // Utilitaires pour déterminer la phase et le résultat
 export const determinePhaseFromDivision = (division: string): string => {
-  if (division.includes("Phase 1")) return "aller";
-  if (division.includes("Phase 2")) return "retour";
+  const d = division.toLowerCase();
+  if (d.includes("phase 1")) return "aller";
+  if (d.includes("phase 2")) return "retour";
   return "aller";
 };
 

--- a/src/lib/shared/team-matches-sync.ts
+++ b/src/lib/shared/team-matches-sync.ts
@@ -443,7 +443,7 @@ export class TeamMatchesSyncService {
           "🔄 Enrichissement des matchs avec les licences des joueurs..."
         );
         enrichedMatches = await Promise.all(
-          allMatches.map((match) =>
+          matchesWithRecalculatedJournees.map((match) =>
             this.enrichSQYPlayersFromClub(match, db, playersCache)
           )
         );
@@ -1819,7 +1819,12 @@ export class TeamMatchesSyncService {
       const teamId =
         match.teamId?.trim() ||
         `team_${match.teamNumber}_${match.isFemale ? "F" : "M"}`;
-      const phase = (match.phase || "aller").toLowerCase();
+      const rawPhase = (match.phase || "aller").toLowerCase();
+      // Normaliser "phase 2" / "phase2" → retour pour grouper correctement
+      const phase =
+        rawPhase === "retour" || rawPhase.includes("phase 2") || rawPhase.includes("phase2")
+          ? "retour"
+          : "aller";
       const teamPhaseKey = `${teamId}|${phase}`;
       if (!matchesByTeamAndPhase.has(teamPhaseKey)) {
         matchesByTeamAndPhase.set(teamPhaseKey, []);


### PR DESCRIPTION
## Description

- **Discord** : Correction du bouton « Répondre » pour les licences féminines sur le sondage de disponibilité (championnat par équipes). L’API Discord n’autorise qu’**un seul select menu par ACTION_ROW** ; on mettait Vendredi et Samedi dans la même ligne → « Echec de l'interaction ». Chaque select est maintenant dans sa propre ACTION_ROW (handleRespondButton, handleModifyButton, updateEphemeralMessage dans handleWomenSelect).

- **Sync journées phase retour** : La phase retour affichait « Journée 8 » au lieu de « Journée 1 » en local après une sync, car :
  1. On enrichissait et sauvegardait **allMatches** (journées brutes 8,9,10) au lieu des **matchs recalculés** (1,2,3 par phase) → correction du flux pour utiliser `matchesWithRecalculatedJournees`.
  2. `determinePhaseFromDivision` était sensible à la casse (« Phase 2 » uniquement) → passage en insensible à la casse.
  3. Dans `recalculateJourneesByDate`, normalisation de la clé de regroupement pour accepter « phase 2 » / « phase2 » → même groupe « retour ».

## Type de changement

- [x] Fix (correction de bug)

## Checklist qualité

### Code
- [x] Le code respecte les règles du projet
- [x] Pas de `any` implicite, TypeScript strict respecté
- [x] Pas de code mort, imports inutilisés, ou console.log permanents
- [x] Pas de TODO dans le code
- [x] Les tests existants passent toujours

### Tests & Validation
- [x] `npm run check:dev` passe en local
- [x] `npm run check` passe en local (lint + type-check + build)

### Discord (si applicable)
- [x] Corrections testées (1 select par ACTION_ROW pour les femmes)

## Tests effectués

- Lint + type-check en pre-commit et avant push.
- Vérification du flux sync : enrichissement et sauvegarde des matchs recalculés ; phase insensible à la casse et regroupement par phase.

## Notes additionnelles

- `.gitleaksignore` modifié en local n’est pas inclus dans ce PR (changement non lié).