### PR TITLE
feat(compositions): popover compositions adverses et classement poule

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -4,3 +4,7 @@
 # Ignore la clé privée fictive dans .env.example (ligne 37)
 # C'est une valeur d'exemple pour la documentation, pas un vrai secret
 eb060e5f5844f3ccd9789aa132ae5c6bd66dc6b6:.env.example:private-key:37
+
+# Ignore l'exemple DISCORD_APPLICATION_ID dans scripts/register-discord-command.ts
+# C'est un placeholder de documentation, pas un vrai secret
+ebdea02acda725d0eaaf2806c298bc3fa3fa44d9:scripts/register-discord-command.ts:discord-client-id:79

--- a/src/app/api/fftt/opponent-compositions/route.ts
+++ b/src/app/api/fftt/opponent-compositions/route.ts
@@ -1,0 +1,529 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import {
+  getFFTTConfig,
+  createFFTTAPI,
+  determinePhaseFromDivision,
+} from "@/lib/shared/fftt-utils";
+import type { FFTTRencontre, FFTTDetailsRencontre, FFTTJoueur } from "@/lib/shared/fftt-types";
+
+export const runtime = "nodejs";
+
+/** Normalise un nom d'équipe pour la comparaison (majuscules, trim, espaces réduits). */
+function normalizeTeamName(name: string): string {
+  return (name || "").trim().replace(/\s+/g, " ").toUpperCase();
+}
+
+/** Indique si le nom d'équipe correspond exactement à l'adversaire (même équipe, pas une autre du même club). */
+function teamNameEqualsOpponent(
+  equipeName: string,
+  opponentName: string
+): boolean {
+  if (!opponentName || !opponentName.trim()) return false;
+  return normalizeTeamName(equipeName) === normalizeTeamName(opponentName);
+}
+
+function extractClubFromLien(lien: string, param: string): string {
+  const regex = new RegExp(`${param}=([^&]+)`);
+  const m = lien.match(regex);
+  return m ? m[1] : "";
+}
+
+/** Normalise un nom pour la comparaison (trim, majuscules, espaces simples). */
+function normalizePlayerName(s: string): string {
+  return (s || "").trim().replace(/\s+/g, " ").toUpperCase();
+}
+
+/** Retourne true si la chaîne adversaire (API) correspond au joueur (nom, prenom). */
+function adversaireMatchesPlayer(
+  adversaire: string,
+  nom: string,
+  prenom: string
+): boolean {
+  const a = normalizePlayerName(adversaire);
+  if (!a) return false;
+  const prenomNorm = (prenom ?? "").trim().toUpperCase();
+  const nomNorm = (nom ?? "").trim().toUpperCase();
+  const full1 = `${prenomNorm} ${nomNorm}`.trim();
+  const full2 = `${nomNorm} ${prenomNorm}`.trim();
+  return a === full1 || a === full2 || a === nomNorm || a === prenomNorm;
+}
+
+/** Calcule victoires/défaites par joueur à partir des parties et du côté adverse (A ou B). */
+function computeVictoiresDefaites(
+  composition: OpponentMatchComposition["composition"],
+  parties: FFTTDetailsRencontre["parties"],
+  opponentSide: "A" | "B"
+): Map<number, { victoires: number; defaites: number }> {
+  const byIndex = new Map<number, { victoires: number; defaites: number }>();
+  for (let i = 0; i < composition.length; i++) {
+    byIndex.set(i, { victoires: 0, defaites: 0 });
+  }
+  for (const p of parties) {
+    const opponentName = opponentSide === "A" ? p.adversaireA : p.adversaireB;
+    const scoreOpp = opponentSide === "A" ? p.scoreA : p.scoreB;
+    const scoreOther = opponentSide === "A" ? p.scoreB : p.scoreA;
+    const win = scoreOpp > scoreOther;
+    const idx = composition.findIndex((j) =>
+      adversaireMatchesPlayer(opponentName, j.nom, j.prenom)
+    );
+    if (idx >= 0) {
+      const cur = byIndex.get(idx)!;
+      if (win) cur.victoires += 1;
+      else cur.defaites += 1;
+      byIndex.set(idx, cur);
+    }
+  }
+  return byIndex;
+}
+
+type FFTTApi = {
+  getJoueurDetailsByLicence: (licence: string) => Promise<unknown>;
+  getJoueursByNom: (nom: string, prenom?: string) => Promise<Array<{ licence: string; points?: number | null }>>;
+};
+
+/** Entrée de diagnostic pour un joueur lors de l'enrichissement. */
+export interface OpponentCompositionsEnrichmentDebug {
+  nom: string;
+  prenom: string;
+  licence: string | null | undefined;
+  hadPointsBefore: boolean;
+  calledApi: boolean;
+  /** Clés de l'objet retourné par getJoueurDetailsByLicence (pour vérifier la structure). */
+  apiResponseKeys?: string[];
+  pointsAfter: number | null;
+  error?: string;
+  /** Recherche par nom effectuée (getJoueursByNom) car licence manquante. */
+  searchByName?: boolean;
+  /** Nombre de joueurs retournés par getJoueursByNom. */
+  searchByNameResultCount?: number;
+  /** Licence trouvée via getJoueursByNom (avant appel getJoueurDetailsByLicence). */
+  licenceFromSearch?: string;
+}
+
+/** Entrée de diagnostic pour un match (identification de l'équipe adverse + joueurs bruts). */
+export interface OpponentCompositionsMatchDebug {
+  date: string;
+  otherTeamName: string;
+  detailsNomEquipeA: string;
+  detailsNomEquipeB: string;
+  opponentName: string;
+  /** Côté retenu pour l'adversaire : A, B ou fallback. */
+  sidePicked: "A" | "B" | "fallback";
+  /** Joueurs tels que retournés par getDetailsRencontreByLien (avant enrichissement). */
+  joueursFromDetails: Array<{ nom: string; prenom: string; licence: string | undefined; points: number | null | undefined }>;
+  enrichment: OpponentCompositionsEnrichmentDebug[];
+}
+
+/**
+ * Enrichit les points manquants via getJoueurDetailsByLicence (contournement connu API FFTT).
+ * Si la licence est absente, tente getJoueursByNom(nom, prenom) pour la récupérer, puis getJoueurDetailsByLicence.
+ * Si debugCollector est fourni, y pousse une entrée par joueur pour analyser le souci.
+ */
+async function enrichCompositionPoints(
+  api: FFTTApi,
+  composition: OpponentMatchComposition["composition"],
+  debugCollector?: OpponentCompositionsEnrichmentDebug[]
+): Promise<OpponentMatchComposition["composition"]> {
+  const enriched = await Promise.all(
+    composition.map(async (j) => {
+      let hasPoints =
+        typeof j.points === "number" && Number.isFinite(j.points);
+      let licence = j.licence?.trim() || undefined;
+      const nom = (j.nom ?? "").trim();
+      const prenom = (j.prenom ?? "").trim();
+
+      const debugEntry: OpponentCompositionsEnrichmentDebug = {
+        nom: j.nom ?? "",
+        prenom: j.prenom ?? "",
+        licence: licence ?? j.licence,
+        hadPointsBefore: hasPoints,
+        calledApi: false,
+        pointsAfter: hasPoints ? (j.points as number) : null,
+      };
+
+      // Fallback : si pas de points et pas de licence, chercher par nom
+      if (!hasPoints && !licence && nom) {
+        try {
+          const byNom = await api.getJoueursByNom(nom, prenom || undefined);
+          debugEntry.searchByName = true;
+          debugEntry.searchByNameResultCount = byNom?.length ?? 0;
+          if (Array.isArray(byNom) && byNom.length > 0) {
+            const first = byNom[0];
+            if (first?.licence) {
+              licence = String(first.licence).trim();
+              debugEntry.licenceFromSearch = licence;
+              debugEntry.licence = licence;
+              const pts =
+                typeof first.points === "number" && Number.isFinite(first.points)
+                  ? first.points
+                  : null;
+              if (pts != null) {
+                hasPoints = true;
+                debugEntry.pointsAfter = pts;
+                debugCollector?.push(debugEntry);
+                return { ...j, ...(licence ? { licence } : {}), points: pts };
+              }
+            }
+          }
+        } catch (err) {
+          debugEntry.error = err instanceof Error ? err.message : String(err);
+          debugCollector?.push(debugEntry);
+          return j;
+        }
+      }
+
+      const shouldCallApi = !hasPoints && Boolean(licence);
+      debugEntry.calledApi = shouldCallApi;
+      if (j.licence !== licence) debugEntry.licence = licence;
+
+      if (!shouldCallApi) {
+        debugCollector?.push(debugEntry);
+        return licence !== j.licence
+          ? { ...j, ...(licence ? { licence } : {}), points: j.points ?? null }
+          : j;
+      }
+
+      try {
+        const details = await api.getJoueurDetailsByLicence(licence!);
+        const raw = details as Record<string, unknown> | null | undefined;
+        if (debugCollector && raw && typeof raw === "object") {
+          debugEntry.apiResponseKeys = Object.keys(raw);
+        }
+        const pointsValue =
+          raw && typeof raw.points === "number" && Number.isFinite(raw.points)
+            ? raw.points
+            : raw && typeof raw.pointsLicence === "number" && Number.isFinite(raw.pointsLicence)
+              ? raw.pointsLicence
+              : null;
+        const points = pointsValue ?? j.points ?? null;
+        debugEntry.pointsAfter = points;
+        debugCollector?.push(debugEntry);
+        return { ...j, ...(licence ? { licence } : {}), points };
+      } catch (err) {
+        debugEntry.error = err instanceof Error ? err.message : String(err);
+        debugEntry.pointsAfter = j.points ?? null;
+        debugCollector?.push(debugEntry);
+        return { ...j, ...(licence ? { licence } : {}) };
+      }
+    })
+  );
+  return enriched;
+}
+
+export interface OpponentMatchComposition {
+  date: string;
+  journee?: number;
+  /** Nom de l'autre équipe (adversaire de l'adversaire dans ce match). */
+  otherTeamName: string;
+  /** Score du match (ex: "4-2"). */
+  score?: string | undefined;
+  /** Composition utilisée par l'équipe adverse dans ce match. */
+  composition: Array<{
+    nom: string;
+    prenom: string;
+    points?: number | null;
+    licence?: string;
+    /** Nombre de victoires dans ce match (parties individuelles). */
+    victoires?: number;
+    /** Nombre de défaites dans ce match (parties individuelles). */
+    defaites?: number;
+  }>;
+}
+
+/**
+ * GET /api/fftt/opponent-compositions?teamId=xxx&phase=aller|retour&opponentName=xxx
+ * Récupère les compositions de l'équipe adverse lors de ses précédents matchs (données FFTT, pas stockées).
+ * Réservé aux coachs et admins.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return NextResponse.json(
+        { error: "Accès refusé" },
+        { status: 403 }
+      );
+    }
+
+    const teamId = req.nextUrl.searchParams.get("teamId")?.trim();
+    const phaseParam = req.nextUrl.searchParams.get("phase");
+    const phase =
+      phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
+    const opponentName = req.nextUrl.searchParams.get("opponentName")?.trim();
+    const debugMode =
+      req.nextUrl.searchParams.get("debug") === "1" ||
+      req.nextUrl.searchParams.get("debug") === "true";
+
+    if (!teamId || !phase || !opponentName) {
+      return NextResponse.json(
+        { error: "Paramètres teamId, phase et opponentName requis" },
+        { status: 400 }
+      );
+    }
+
+    const { clubCode } = getFFTTConfig();
+    const api = createFFTTAPI();
+    await api.initialize();
+
+    const equipes = (await api.getEquipesByClub(clubCode)) as Array<{
+      idEquipe: number;
+      libelle: string;
+      division: string;
+      lienDivision: string;
+      idEpreuve?: number;
+      libelleEpreuve?: string;
+      isFemale?: boolean;
+    }>;
+
+    const phaseFromId = teamId.endsWith("_aller")
+      ? "aller"
+      : teamId.endsWith("_retour")
+        ? "retour"
+        : null;
+    const idEquipeStr = phaseFromId
+      ? teamId.replace(/_(aller|retour)$/, "")
+      : teamId;
+
+    const ourEquipe = equipes.find((e) => {
+      if (e.idEquipe.toString() !== idEquipeStr) return false;
+      return determinePhaseFromDivision(e.division) === (phaseFromId ?? phase);
+    });
+
+    if (!ourEquipe?.lienDivision) {
+      return NextResponse.json(
+        { error: "Équipe ou division non trouvée" },
+        { status: 404 }
+      );
+    }
+
+    const rencontres = (await api.getRencontrePouleByLienDivision(
+      ourEquipe.lienDivision
+    )) as unknown[];
+
+    const opponentMatches = rencontres.filter((r: unknown) => {
+      const renc = r as FFTTRencontre;
+      return (
+        teamNameEqualsOpponent(renc.nomEquipeA, opponentName) ||
+        teamNameEqualsOpponent(renc.nomEquipeB, opponentName)
+      );
+    }) as FFTTRencontre[];
+
+    const results: OpponentMatchComposition[] = [];
+    const matchDebugList: OpponentCompositionsMatchDebug[] = [];
+
+    for (const rencontre of opponentMatches.slice(0, 10)) {
+      const club1 = extractClubFromLien(rencontre.lien, "clubnum_1");
+      const club2 = extractClubFromLien(rencontre.lien, "clubnum_2");
+      let details: FFTTDetailsRencontre | null = null;
+      try {
+        const raw = await api.getDetailsRencontreByLien(
+          rencontre.lien,
+          club1,
+          club2
+        );
+        if (raw && typeof raw === "object") {
+          const d = raw as unknown as Record<string, unknown>;
+          const toJoueurs = (arr: unknown): FFTTJoueur[] => {
+            const mapOne = (x: Record<string, unknown>): FFTTJoueur => {
+              const j: FFTTJoueur = {
+                licence: String(x.licence ?? ""),
+                nom: String(x.nom ?? ""),
+                prenom: String(x.prenom ?? ""),
+                points:
+                  typeof x.points === "number"
+                    ? x.points
+                    : (x.points as number | null) ?? null,
+              };
+              if (x.sexe) j.sexe = String(x.sexe);
+              return j;
+            };
+            if (Array.isArray(arr)) {
+              return arr.map((j: unknown) => mapOne(j as Record<string, unknown>));
+            }
+            if (typeof arr === "object" && arr !== null) {
+              return Object.values(arr).map((j: unknown) =>
+                mapOne(j as Record<string, unknown>)
+              );
+            }
+            return [];
+          };
+          details = {
+            nomEquipeA: String(d.nomEquipeA ?? ""),
+            nomEquipeB: String(d.nomEquipeB ?? ""),
+            joueursA: toJoueurs(d.joueursA),
+            joueursB: toJoueurs(d.joueursB),
+            parties: Array.isArray(d.parties)
+              ? (d.parties as Array<Record<string, unknown>>).map((p) => ({
+                  adversaireA: String(p.adversaireA ?? ""),
+                  adversaireB: String(p.adversaireB ?? ""),
+                  scoreA: typeof p.scoreA === "number" ? p.scoreA : 0,
+                  scoreB: typeof p.scoreB === "number" ? p.scoreB : 0,
+                  setDetails: String(p.setDetails ?? ""),
+                }))
+              : [],
+          };
+        }
+      } catch {
+        // Ignorer les erreurs de détail (match sans détail)
+      }
+
+      // Déterminer la composition adverse à partir des DÉTAILS (nomEquipeA/B), pas de la rencontre,
+      // car l'ordre A/B peut différer entre la liste des rencontres et la réponse getDetailsRencontreByLien.
+      const matchOpponentA = teamNameEqualsOpponent(rencontre.nomEquipeA, opponentName);
+      let otherTeamName = matchOpponentA ? rencontre.nomEquipeB : rencontre.nomEquipeA;
+      let composition: OpponentMatchComposition["composition"] = [];
+      if (details) {
+        const opponentIsA = teamNameEqualsOpponent(details.nomEquipeA, opponentName);
+        const opponentIsB = teamNameEqualsOpponent(details.nomEquipeB, opponentName);
+        let sidePicked: "A" | "B" | "fallback" = "fallback";
+        let rawJoueurs: Array<{ nom: string; prenom: string; licence: string | undefined; points: number | null | undefined }> = [];
+
+        const toCompositionItem = (
+          j: { nom: string; prenom: string; licence: string | undefined; points: number | null | undefined }
+        ): { nom: string; prenom: string; points: number | null; licence?: string } => ({
+          nom: j.nom,
+          prenom: j.prenom,
+          points: j.points ?? null,
+          ...(j.licence != null && j.licence !== "" ? { licence: j.licence } : {}),
+        });
+
+        if (opponentIsA && !opponentIsB) {
+          sidePicked = "A";
+          rawJoueurs = details.joueursA.map((j) => ({
+            nom: j.nom ?? "",
+            prenom: j.prenom ?? "",
+            licence: j.licence,
+            points: j.points ?? null,
+          }));
+          composition = rawJoueurs.map(toCompositionItem);
+          otherTeamName = details.nomEquipeB;
+        } else if (opponentIsB && !opponentIsA) {
+          sidePicked = "B";
+          rawJoueurs = details.joueursB.map((j) => ({
+            nom: j.nom ?? "",
+            prenom: j.prenom ?? "",
+            licence: j.licence,
+            points: j.points ?? null,
+          }));
+          composition = rawJoueurs.map(toCompositionItem);
+          otherTeamName = details.nomEquipeA;
+        } else {
+          const fallbackJoueurs = matchOpponentA ? details.joueursA : details.joueursB;
+          rawJoueurs = fallbackJoueurs.map((j) => ({
+            nom: j.nom ?? "",
+            prenom: j.prenom ?? "",
+            licence: j.licence,
+            points: j.points ?? null,
+          }));
+          composition = rawJoueurs.map(toCompositionItem);
+          otherTeamName = matchOpponentA ? details.nomEquipeB : details.nomEquipeA;
+        }
+
+        const enrichmentDebug: OpponentCompositionsEnrichmentDebug[] = [];
+        composition = await enrichCompositionPoints(
+          api,
+          composition,
+          debugMode ? enrichmentDebug : undefined
+        );
+
+        if (
+          details.parties.length > 0 &&
+          (sidePicked === "A" || sidePicked === "B")
+        ) {
+          const vd = computeVictoiresDefaites(
+            composition,
+            details.parties,
+            sidePicked
+          );
+          composition = composition.map((j, idx) => {
+            const stats = vd.get(idx);
+            return {
+              ...j,
+              ...(stats
+                ? {
+                    victoires: stats.victoires,
+                    defaites: stats.defaites,
+                  }
+                : {}),
+            };
+          });
+        }
+
+        if (debugMode) {
+          const date =
+            rencontre.dateReelle ?? rencontre.datePrevue ?? new Date();
+          const dateStr =
+            typeof date === "string"
+              ? date
+              : (date as Date).toISOString().slice(0, 10);
+          matchDebugList.push({
+            date: dateStr,
+            otherTeamName,
+            detailsNomEquipeA: details.nomEquipeA ?? "",
+            detailsNomEquipeB: details.nomEquipeB ?? "",
+            opponentName,
+            sidePicked,
+            joueursFromDetails: rawJoueurs,
+            enrichment: enrichmentDebug,
+          });
+        }
+      }
+
+      const date =
+        rencontre.dateReelle ?? rencontre.datePrevue ?? new Date();
+      const dateStr =
+        typeof date === "string"
+          ? date
+          : (date as Date).toISOString().slice(0, 10);
+      const score =
+        rencontre.scoreEquipeA != null && rencontre.scoreEquipeB != null
+          ? `${rencontre.scoreEquipeA}-${rencontre.scoreEquipeB}`
+          : undefined;
+
+      results.push({
+        date: dateStr,
+        otherTeamName,
+        ...(score !== undefined ? { score } : {}),
+        composition,
+      });
+    }
+
+    const body: { matches: OpponentMatchComposition[]; _debug?: unknown } = {
+      matches: results,
+    };
+    if (debugMode) {
+      body._debug = {
+        opponentName,
+        phase,
+        teamId,
+        matchCount: results.length,
+        matches: matchDebugList,
+      };
+    }
+    return NextResponse.json(body);
+  } catch (error) {
+    console.error(
+      "Erreur API opponent-compositions:",
+      error instanceof Error ? error.message : error
+    );
+    return NextResponse.json(
+      { error: "Erreur lors de la récupération des compositions adverses" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/fftt/pool-ranking/route.ts
+++ b/src/app/api/fftt/pool-ranking/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import {
+  getFFTTConfig,
+  createFFTTAPI,
+  extractTeamNumber,
+  determinePhaseFromDivision,
+  isFemaleTeam,
+} from "@/lib/shared/fftt-utils";
+
+export const runtime = "nodejs";
+
+export interface PoolRankingEntry {
+  classement: number;
+  nomEquipe: string;
+  matchJouees: number;
+  points: number;
+  victoires: number;
+  defaites: number;
+  egalites: number;
+  /** Points (ou sets) marqués par l'équipe */
+  pf?: number;
+  /** Points (ou sets) encaissés par l'équipe */
+  pg?: number;
+  /** Différence (pf - pg) */
+  pp?: number;
+}
+
+type FFTTEquipeLike = {
+  idEquipe: number;
+  libelle: string;
+  division: string;
+  lienDivision: string;
+  libelleEpreuve?: string;
+  idEpreuve?: number;
+  isFemale?: boolean;
+};
+
+/**
+ * GET /api/fftt/pool-ranking?teamId=xxx&phase=aller|retour
+ * Récupère le classement de la poule pour une équipe (données FFTT, pas stockées en base).
+ * Si phase est fourni (aller|retour), utilise l'équipe FFTT dont la division correspond à cette phase.
+ * Réservé aux coachs et admins.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return NextResponse.json(
+        { error: "Accès refusé" },
+        { status: 403 }
+      );
+    }
+
+    const teamId = req.nextUrl.searchParams.get("teamId");
+    if (!teamId || !teamId.trim()) {
+      return NextResponse.json(
+        { error: "Paramètre teamId requis" },
+        { status: 400 }
+      );
+    }
+
+    const phaseParam = req.nextUrl.searchParams.get("phase");
+    const phase =
+      phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
+
+    const { clubCode } = getFFTTConfig();
+    const api = createFFTTAPI();
+    await api.initialize();
+
+    const equipes = (await api.getEquipesByClub(clubCode)) as FFTTEquipeLike[];
+    const teamIdTrim = teamId.trim();
+    const phaseFromId = teamIdTrim.endsWith("_aller")
+      ? "aller"
+      : teamIdTrim.endsWith("_retour")
+        ? "retour"
+        : null;
+    const idEquipeStr = phaseFromId
+      ? teamIdTrim.replace(/_(aller|retour)$/, "")
+      : teamIdTrim;
+
+    let equipe = equipes.find((e: FFTTEquipeLike) => {
+      if (e.idEquipe.toString() !== idEquipeStr) return false;
+      if (phaseFromId) {
+        return determinePhaseFromDivision(e.division) === phaseFromId;
+      }
+      return true;
+    });
+
+    if (!equipe || !equipe.lienDivision) {
+      return NextResponse.json(
+        { error: "Équipe ou division non trouvée" },
+        { status: 404 }
+      );
+    }
+
+    // Si une phase est demandée et que l'équipe trouvée ne correspond pas à cette phase,
+    // chercher l'équipe du même numéro (et même type M/F) dont la division correspond à la phase.
+    if (phase) {
+      const equipePhase = determinePhaseFromDivision(equipe.division);
+      if (equipePhase !== phase) {
+        const teamNumber = extractTeamNumber(equipe.libelle);
+        const isFemale = (e: FFTTEquipeLike) =>
+          e.isFemale !== undefined
+            ? e.isFemale
+            : isFemaleTeam(
+                e.libelle,
+                e.division,
+                e.libelleEpreuve,
+                e.idEpreuve
+              );
+        const equipeIsFemale = isFemale(equipe);
+        const samePhaseEquipe = equipes.find((e: FFTTEquipeLike) => {
+          if (!e.lienDivision) return false;
+          if (extractTeamNumber(e.libelle) !== teamNumber) return false;
+          if (isFemale(e) !== equipeIsFemale) return false;
+          return determinePhaseFromDivision(e.division) === phase;
+        });
+        if (samePhaseEquipe) {
+          equipe = samePhaseEquipe;
+        }
+      }
+    }
+
+    // L'API FFTT xml_result_equ attend D1 = id de la division (dans lienDivision).
+    // La librairie ajoute params après lienDivision ; si on passe 1, ça écrase le D1
+    // du lien et l'API reçoit "D1=1, action=classement" sans le reste → erreur.
+    const d1Match = equipe.lienDivision.match(/D1=(\d+)/);
+    const d1 = d1Match ? parseInt(d1Match[1], 10) : 1;
+
+    const raw = await api.getClassementPouleByLienDivision(
+      d1,
+      "classement",
+      null,
+      equipe.lienDivision
+    );
+
+    if (!Array.isArray(raw)) {
+      return NextResponse.json(
+        { error: "Classement non disponible" },
+        { status: 404 }
+      );
+    }
+
+    // FFTT / lib : dans la réponse, pg = points marqués (Pour), pp = points encaissés (Contre).
+    // On envoie donc Pour = pg, Contre = pp, Diff = pg - pp. Si pg/pp = victoires/défaites, on masque.
+    const entries: PoolRankingEntry[] = (raw as Array<{
+      classement: number;
+      nomEquipe: string;
+      matchJouees: number;
+      points: number;
+      victoires: number;
+      defaites: number;
+      egalites: number;
+      pf?: number;
+      pg?: number;
+      pp?: number;
+    }>).map((row) => {
+      const apiPg = row.pg ?? 0;
+      const apiPp = row.pp ?? 0;
+      const isVictoiresDefaites =
+        apiPg === row.victoires && apiPp === row.defaites;
+      const out: PoolRankingEntry = {
+        classement: row.classement,
+        nomEquipe: row.nomEquipe,
+        matchJouees: row.matchJouees,
+        points: row.points,
+        victoires: row.victoires,
+        defaites: row.defaites,
+        egalites: row.egalites,
+      };
+      if (!isVictoiresDefaites && (apiPg > 0 || apiPp > 0)) {
+        out.pf = apiPg;
+        out.pg = apiPp;
+        out.pp = apiPg - apiPp;
+      }
+      return out;
+    });
+
+    const res = NextResponse.json(
+      { ranking: entries, division: equipe.division },
+      { status: 200 }
+    );
+    res.headers.set(
+      "Cache-Control",
+      "no-store, no-cache, must-revalidate, max-age=0"
+    );
+    return res;
+  } catch (error) {
+    console.error("[api/fftt/pool-ranking]", error);
+    const message =
+      error instanceof Error ? error.message : "Erreur lors du chargement du classement";
+    return NextResponse.json(
+      { error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/compositions/_containers/CompositionsPageContainer.tsx
+++ b/src/app/compositions/_containers/CompositionsPageContainer.tsx
@@ -46,6 +46,7 @@ import { Player } from "@/types/team-management";
 import { ChampionshipType, Match } from "@/types";
 import { AuthGuard } from "@/components/AuthGuard";
 import { USER_ROLES } from "@/lib/auth/roles";
+import { divisionIndicatesPhase2 } from "@/lib/shared/fftt-utils";
 import {
   EpreuveType,
   getIdEpreuve,
@@ -85,6 +86,8 @@ import { TeamPicker } from "@/components/compositions/Filters/TeamPicker";
 import { TabPanel } from "@/components/compositions/Filters/TabPanel";
 import { ConfirmationDialog } from "@/components/compositions/dialogs/ConfirmationDialog";
 import { DiscordResendDialog } from "@/components/compositions/dialogs/DiscordResendDialog";
+import { PoolRankingPopover } from "@/components/compositions/PoolRankingPopover";
+import { PreviousMatchesOpponents } from "@/components/compositions/PreviousMatchesOpponents";
 
 // Composant pour afficher les suggestions de mentions
 function MentionSuggestions({
@@ -461,16 +464,24 @@ export function CompositionsPageContainer() {
 
   // Déterminer la phase en cours
   // Grouper les équipes par type (masculin/féminin)
-  // Filtrer les équipes selon l'épreuve sélectionnée
+  // Filtrer les équipes selon l'épreuve sélectionnée et la phase (Phase 1 pour aller, Phase 2 pour retour)
   const filteredEquipes = useMemo(() => {
     if (!selectedEpreuve) {
       return equipes;
     }
     return equipes.filter((equipe) => {
       const epreuve = getMatchEpreuve(equipe.matches[0] || {}, equipe.team);
-      return epreuve === selectedEpreuve;
+      if (epreuve !== selectedEpreuve) return false;
+      if (selectedEpreuve !== "championnat_equipes") return true;
+      const division = equipe.team.division ?? "";
+      // Aller : afficher uniquement les équipes dont la division n'indique pas Phase 2.
+      // Retour : afficher uniquement les équipes dont la division indique explicitement Phase 2
+      // (évite d'afficher des équipes Phase 1 ou sans phase dans le libellé).
+      if (selectedPhase === "aller") return !divisionIndicatesPhase2(division);
+      if (selectedPhase === "retour") return divisionIndicatesPhase2(division);
+      return true;
     });
-  }, [equipes, selectedEpreuve]);
+  }, [equipes, selectedEpreuve, selectedPhase]);
 
   const {
     journeesByPhase,
@@ -2209,8 +2220,9 @@ export function CompositionsPageContainer() {
             startIcon={<ContentCopy />}
             disabled={!canCopyDefaultsButton}
             onClick={handleApplyDefaultsClick}
+            title="Copier les compositions par défaut pour toutes les équipes"
           >
-            Copier les compos par défaut (toutes équipes)
+            Copier compos par défaut
           </Button>
           <Button
             variant="outlined"
@@ -2671,6 +2683,28 @@ export function CompositionsPageContainer() {
                                             </IconButton>
                                           </span>
                                         </Tooltip>
+                                      )}
+                                      <Tooltip title="Voir le classement de la poule">
+                                        <span>
+                                          <PoolRankingPopover
+                                            teamId={equipe.team.id}
+                                            teamName={equipe.team.name}
+                                            phase={selectedPhase}
+                                            opponentTeamName={
+                                              match?.opponent ?? match?.opponentClub ?? null
+                                            }
+                                          />
+                                        </span>
+                                      </Tooltip>
+                                      {(match?.opponent ?? match?.opponentClub) && (
+                                        <PreviousMatchesOpponents
+                                          teamId={equipe.team.id}
+                                          phase={selectedPhase}
+                                          opponentName={
+                                            match?.opponent ?? match?.opponentClub ?? null
+                                          }
+                                          maxMatches={10}
+                                        />
                                       )}
                                     </Box>
                                   }
@@ -3494,6 +3528,28 @@ export function CompositionsPageContainer() {
                                         </span>
                                       </Tooltip>
                                     )}
+                                    <Tooltip title="Voir le classement de la poule">
+                                      <span>
+                                        <PoolRankingPopover
+                                          teamId={equipe.team.id}
+                                          teamName={equipe.team.name}
+                                          phase={selectedPhase}
+                                          opponentTeamName={
+                                            match?.opponent ?? match?.opponentClub ?? null
+                                          }
+                                        />
+                                      </span>
+                                    </Tooltip>
+                                    {(match?.opponent ?? match?.opponentClub) && (
+                                      <PreviousMatchesOpponents
+                                        teamId={equipe.team.id}
+                                        phase={selectedPhase}
+                                        opponentName={
+                                          match?.opponent ?? match?.opponentClub ?? null
+                                        }
+                                        maxMatches={10}
+                                      />
+                                    )}
                                   </Box>
                                 }
                                 renderPlayerIndicators={(player) => {
@@ -4049,7 +4105,7 @@ export function CompositionsPageContainer() {
                                           />
                                         )}
                                     </Box>
-                                  </CardContent>
+                                    </CardContent>
                                 </Card>
                               )}
                           </Box>

--- a/src/components/compositions/PoolRankingPopover.tsx
+++ b/src/components/compositions/PoolRankingPopover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import {
   IconButton,
   Popover,
@@ -106,6 +106,12 @@ export function PoolRankingPopover({
     } finally {
       setLoading(false);
     }
+  }, [teamId, phase]);
+
+  useEffect(() => {
+    setRanking(null);
+    setDivision(null);
+    setError(null);
   }, [teamId, phase]);
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {

--- a/src/components/compositions/PoolRankingPopover.tsx
+++ b/src/components/compositions/PoolRankingPopover.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import React, { useState, useCallback, useMemo } from "react";
+import {
+  IconButton,
+  Popover,
+  Typography,
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  CircularProgress,
+  Alert,
+  useTheme,
+  Tooltip,
+} from "@mui/material";
+import { EmojiEvents as LeaderboardIcon } from "@mui/icons-material";
+
+export interface PoolRankingEntry {
+  classement: number;
+  nomEquipe: string;
+  matchJouees: number;
+  points: number;
+  victoires: number;
+  defaites: number;
+  egalites: number;
+  /** Points (ou sets) marqués */
+  pf?: number;
+  /** Points (ou sets) encaissés */
+  pg?: number;
+  /** Différence (pour - contre) */
+  pp?: number;
+}
+
+interface PoolRankingPopoverProps {
+  teamId: string;
+  teamName: string;
+  /** Phase sélectionnée (aller | retour) pour afficher le classement de la bonne poule */
+  phase?: "aller" | "retour" | null;
+  /** Nom de l'adversaire du match de la journée sélectionnée (pour mise en évidence) */
+  opponentTeamName?: string | null;
+}
+
+/** Normalise le nom d'équipe (retire " - Phase 1/2" pour comparaison avec le classement FFTT). */
+function normalizeTeamName(name: string): string {
+  return name
+    .replace(/\s*-\s*Phase\s*[12]\s*$/i, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toUpperCase();
+}
+
+/** Vérifie si le nom d'équipe du classement FFTT correspond à notre équipe (SQY PING). */
+function isOurTeam(nomEquipe: string, teamName: string): boolean {
+  const n = nomEquipe.toUpperCase().replace(/\s+/g, " ").trim();
+  if (!n.includes("SQY PING")) return false;
+  const t = normalizeTeamName(teamName);
+  if (t.length === 0) return true;
+  return n.includes(t) || t.includes(n);
+}
+
+/** Vérifie si le nom d'équipe du classement correspond à l'adversaire (match partiel). */
+function isOpponentRow(nomEquipe: string, opponentTeamName: string | null | undefined): boolean {
+  if (!opponentTeamName || !opponentTeamName.trim()) return false;
+  const a = nomEquipe.toLowerCase();
+  const b = opponentTeamName.toLowerCase().trim();
+  return a.includes(b) || b.split(/\s+/).some((part) => part.length > 2 && a.includes(part));
+}
+
+export function PoolRankingPopover({
+  teamId,
+  teamName,
+  phase,
+  opponentTeamName,
+}: PoolRankingPopoverProps) {
+  const theme = useTheme();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [ranking, setRanking] = useState<PoolRankingEntry[] | null>(null);
+  const [division, setDivision] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRanking = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ teamId });
+      if (phase === "aller" || phase === "retour") {
+        params.set("phase", phase);
+      }
+      const res = await fetch(
+        `/api/fftt/pool-ranking?${params.toString()}`
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Erreur ${res.status}`);
+      }
+      const data = await res.json();
+      setRanking(data.ranking ?? []);
+      setDivision(data.division ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Impossible de charger le classement");
+      setRanking(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId, phase]);
+
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    if (ranking === null && !loading) {
+      void fetchRanking();
+    }
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+
+  const rowHighlight = useMemo(
+    () => ({
+      ourTeam: {
+        bgcolor: theme.palette.primary.main + "14",
+        borderLeft: `3px solid ${theme.palette.primary.main}`,
+        "& .MuiTableCell-root": { fontWeight: 600 },
+      },
+      opponent: {
+        bgcolor: theme.palette.secondary.main + "12",
+        borderLeft: `3px solid ${theme.palette.secondary.main}`,
+        "& .MuiTableCell-root": { fontWeight: 500 },
+      },
+    }),
+    [theme.palette.primary.main, theme.palette.secondary.main]
+  );
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={handleOpen}
+        aria-label="Voir le classement de la poule"
+        color="default"
+        sx={{ ml: 0.25 }}
+      >
+        <LeaderboardIcon fontSize="small" />
+      </IconButton>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        PaperProps={{
+          elevation: 8,
+          sx: {
+            minWidth: 460,
+            width: "max-content",
+            maxWidth: "min(95vw, 580px)",
+            maxHeight: "min(75vh, 620px)",
+            borderRadius: 2,
+            overflow: "hidden",
+          },
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%", maxHeight: "min(75vh, 620px)" }}>
+          <Box
+            sx={{
+              px: 2,
+              py: 1.5,
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+            }}
+          >
+            <Typography variant="subtitle1" fontWeight={600}>
+              {teamName}
+            </Typography>
+            {division && (
+              <Typography variant="caption" sx={{ opacity: 0.9, display: "block", mt: 0.25 }}>
+                {division}
+              </Typography>
+            )}
+          </Box>
+          <Box sx={{ flex: 1, overflow: "auto", p: 2 }}>
+            {loading && (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+                <CircularProgress size={32} />
+              </Box>
+            )}
+            {error && (
+              <Alert severity="warning" sx={{ mt: 1 }}>
+                {error}
+              </Alert>
+            )}
+            {!loading && !error && ranking && ranking.length > 0 && (
+              <>
+                <Table size="small" stickyHeader sx={{ "& .MuiTableRow-root:hover": { bgcolor: "action.hover" } }}>
+                  <TableHead>
+                    <TableRow sx={{ bgcolor: "grey.100" }}>
+                      <TableCell sx={{ fontWeight: 700, color: "grey.700", width: 48 }}>Rang</TableCell>
+                      <TableCell sx={{ fontWeight: 700, color: "grey.700" }}>Équipe</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700, color: "grey.700", width: 44 }}>Pts</TableCell>
+                      <TableCell align="center" sx={{ fontWeight: 700, color: "grey.700", width: 36 }}>J</TableCell>
+                      <TableCell align="center" sx={{ fontWeight: 700, color: "grey.700", width: 52 }}>V/N/D</TableCell>
+                      {(ranking[0]?.pf !== undefined || ranking[0]?.pg !== undefined) && (
+                        <>
+                          <Tooltip title="Points (ou sets) marqués / encaissés">
+                            <TableCell align="center" sx={{ fontWeight: 700, color: "grey.700", width: 64 }}>
+                              Pour/Contre
+                            </TableCell>
+                          </Tooltip>
+                          {ranking[0]?.pp !== undefined && (
+                            <Tooltip title="Différence (pour − contre)">
+                              <TableCell align="center" sx={{ fontWeight: 700, color: "grey.700", width: 44 }}>
+                                Diff
+                              </TableCell>
+                            </Tooltip>
+                          )}
+                        </>
+                      )}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {ranking.map((row, index) => {
+                      const ourTeam = isOurTeam(row.nomEquipe, teamName);
+                      const opponent = isOpponentRow(row.nomEquipe, opponentTeamName);
+                      const showPourContre = ranking[0]?.pf !== undefined || ranking[0]?.pg !== undefined;
+                      const showDiff = ranking[0]?.pp !== undefined;
+                      return (
+                        <TableRow
+                          key={`${row.classement}-${row.nomEquipe}`}
+                          sx={{
+                            bgcolor: index % 2 === 1 ? "grey.50" : "transparent",
+                            ...(ourTeam ? rowHighlight.ourTeam : {}),
+                            ...(opponent && !ourTeam ? rowHighlight.opponent : {}),
+                          }}
+                        >
+                          <TableCell sx={{ ...(ourTeam || opponent ? { fontWeight: 600 } : {}) }}>
+                            {row.classement}
+                          </TableCell>
+                          <TableCell
+                            sx={{
+                              maxWidth: 280,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              ...(ourTeam || opponent ? { fontWeight: 600 } : {}),
+                            }}
+                          >
+                            {row.nomEquipe}
+                          </TableCell>
+                          <TableCell align="right">{row.points}</TableCell>
+                          <TableCell align="center">{row.matchJouees}</TableCell>
+                          <TableCell align="center">
+                            {row.victoires}/{row.egalites}/{row.defaites}
+                          </TableCell>
+                          {showPourContre && (
+                            <TableCell align="center">
+                              {row.pf !== undefined || row.pg !== undefined
+                                ? `${row.pf ?? "–"}/${row.pg ?? "–"}`
+                                : "–"}
+                            </TableCell>
+                          )}
+                          {showDiff && (
+                            <TableCell align="center" sx={{ ...(ourTeam || opponent ? { fontWeight: 600 } : {}) }}>
+                              {row.pp !== undefined ? (row.pp > 0 ? `+${row.pp}` : String(row.pp)) : "–"}
+                            </TableCell>
+                          )}
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </>
+            )}
+            {!loading && !error && ranking && ranking.length === 0 && (
+              <Typography variant="body2" color="text.secondary" sx={{ py: 3, textAlign: "center" }}>
+                Aucun classement disponible.
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/src/components/compositions/PreviousMatchesOpponents.tsx
+++ b/src/components/compositions/PreviousMatchesOpponents.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import React, { useState, useCallback, useEffect } from "react";
+import {
+  Box,
+  Typography,
+  Popover,
+  Collapse,
+  IconButton,
+  CircularProgress,
+  Alert,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+} from "@mui/material";
+import { ExpandMore, ExpandLess, BugReport as BugReportIcon, History as HistoryIcon } from "@mui/icons-material";
+
+/** Type du diagnostic renvoyé par l’API quand ?debug=1. */
+export interface OpponentCompositionsDebug {
+  opponentName: string;
+  phase: string;
+  teamId: string;
+  matchCount: number;
+  matches: Array<{
+    date: string;
+    otherTeamName: string;
+    detailsNomEquipeA: string;
+    detailsNomEquipeB: string;
+    opponentName: string;
+    sidePicked: "A" | "B" | "fallback";
+    joueursFromDetails: Array<{
+      nom: string;
+      prenom: string;
+      licence: string | undefined;
+      points: number | null | undefined;
+    }>;
+    enrichment: Array<{
+      nom: string;
+      prenom: string;
+      licence: string | null | undefined;
+      hadPointsBefore: boolean;
+      calledApi: boolean;
+      apiResponseKeys?: string[];
+      pointsAfter: number | null;
+      error?: string;
+    }>;
+  }>;
+}
+
+export interface OpponentMatchComposition {
+  date: string;
+  journee?: number;
+  otherTeamName: string;
+  score?: string;
+  composition: Array<{
+    nom: string;
+    prenom: string;
+    points?: number | null;
+    licence?: string;
+    victoires?: number;
+    defaites?: number;
+  }>;
+}
+
+export interface PreviousMatchesOpponentsProps {
+  /** ID de notre équipe (ex: sqyping_team_12345_aller) */
+  teamId: string;
+  /** Phase sélectionnée (aller | retour) pour la poule FFTT */
+  phase: "aller" | "retour" | null;
+  /** Nom de l'équipe adverse du match de la journée (pour afficher ses compositions passées) */
+  opponentName: string | null;
+  /** Nombre max de matchs à afficher (défaut 5) */
+  maxMatches?: number;
+}
+
+/** Format date FR */
+function formatDate(dateStr: string): string {
+  try {
+    const [y, m, d] = dateStr.split("-");
+    if (y && m && d) {
+      return `${d}/${m}/${y}`;
+    }
+  } catch {
+    // ignore
+  }
+  return dateStr;
+}
+
+type PlayerKey = string;
+
+/** Clé unique pour un joueur (licence si dispo, sinon nom|prenom). */
+function playerKey(j: { nom: string; prenom: string; licence?: string }): PlayerKey {
+  const licence = (j.licence ?? "").trim();
+  if (licence) return licence;
+  return `${(j.nom ?? "").trim()}|${(j.prenom ?? "").trim()}`;
+}
+
+/** Format joueur : prénom + NOM (optionnel: pts). */
+function formatPlayerLabel(j: {
+  nom: string;
+  prenom: string;
+  points?: number | null;
+  licence?: string;
+}): string {
+  const prenom = (j.prenom ?? "").trim();
+  const nom = (j.nom ?? "").trim().toUpperCase();
+  const namePart =
+    prenom && nom ? `${prenom} ${nom}` : prenom || nom || "—";
+  const pts =
+    typeof j.points === "number"
+      ? ` — ${j.points} pts`
+      : "";
+  return `${namePart}${pts}`;
+}
+
+/** Trouve l'index du joueur dans la composition d'un match (0-based). Retourne -1 si absent. */
+function findPlayerPositionInMatch(
+  key: PlayerKey,
+  composition: OpponentMatchComposition["composition"]
+): number {
+  return composition.findIndex((j) => playerKey(j) === key);
+}
+
+/** Tableau joueurs × journées : une ligne par joueur, une colonne par match. */
+function CompositionsTable({ matches }: { matches: OpponentMatchComposition[] }) {
+  const { allPlayers, cellByPlayerAndMatch } = React.useMemo(() => {
+    const keyToPlayer = new Map<
+      PlayerKey,
+      { nom: string; prenom: string; points: number | null; licence?: string }
+    >();
+    for (const m of matches) {
+      for (const j of m.composition) {
+        const k = playerKey(j);
+        if (!keyToPlayer.has(k)) {
+          keyToPlayer.set(k, {
+            nom: j.nom,
+            prenom: j.prenom,
+            points: j.points ?? null,
+            ...(j.licence ? { licence: j.licence } : {}),
+          });
+        }
+      }
+    }
+    const allPlayers = Array.from(keyToPlayer.entries()).map(([key, p]) => ({ key, ...p }));
+    const cellByPlayerAndMatch = new Map<
+      string,
+      { position: number; victoires: number; defaites: number }
+    >();
+    for (const { key } of allPlayers) {
+      for (let matchIdx = 0; matchIdx < matches.length; matchIdx++) {
+        const compo = matches[matchIdx].composition;
+        const pos = findPlayerPositionInMatch(key, compo);
+        const cellKey = `${key}|${matchIdx}`;
+        if (pos >= 0) {
+          const j = compo[pos];
+          const victoires = typeof j.victoires === "number" ? j.victoires : 0;
+          const defaites = typeof j.defaites === "number" ? j.defaites : 0;
+          cellByPlayerAndMatch.set(cellKey, {
+            position: pos + 1,
+            victoires,
+            defaites,
+          });
+        }
+      }
+    }
+    return { allPlayers, cellByPlayerAndMatch };
+  }, [matches]);
+
+  if (allPlayers.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+        Aucune composition disponible.
+      </Typography>
+    );
+  }
+
+  return (
+    <Table size="small" stickyHeader sx={{ "& .MuiTableCell-root": { fontSize: "0.8125rem" } }}>
+      <TableHead>
+        <TableRow sx={{ bgcolor: "grey.100" }}>
+          <TableCell sx={{ fontWeight: 700, color: "grey.700", minWidth: 200 }}>
+            Joueur
+          </TableCell>
+          {matches.map((m, idx) => (
+            <TableCell
+              key={idx}
+              align="center"
+              sx={{
+                fontWeight: 700,
+                color: "grey.700",
+                minWidth: 80,
+                whiteSpace: "nowrap",
+              }}
+            >
+              <Tooltip
+                title={
+                  <Box component="span" sx={{ display: "block" }}>
+                    <strong>{m.otherTeamName}</strong>
+                    <br />
+                    {formatDate(m.date)}
+                    {m.score != null ? ` — ${m.score}` : ""}
+                  </Box>
+                }
+                placement="top"
+              >
+                <span style={{ cursor: "help", textDecoration: "underline dotted" }}>
+                  J{m.journee ?? idx + 1}
+                </span>
+              </Tooltip>
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {allPlayers.map(({ key, nom, prenom, points, licence }) => (
+          <TableRow key={key} hover sx={{ "&:nth-of-type(even)": { bgcolor: "grey.50" } }}>
+            <TableCell sx={{ fontWeight: 500 }}>
+              {formatPlayerLabel({
+                nom,
+                prenom,
+                points,
+                ...(licence ? { licence } : {}),
+              })}
+            </TableCell>
+            {matches.map((_, matchIdx) => {
+              const cell = cellByPlayerAndMatch.get(`${key}|${matchIdx}`);
+              if (!cell) {
+                return (
+                  <TableCell key={matchIdx} align="center" sx={{ color: "text.secondary" }}>
+                    —
+                  </TableCell>
+                );
+              }
+              return (
+                <TableCell key={matchIdx} align="center">
+                  <Box component="span" sx={{ display: "block", lineHeight: 1.2 }}>
+                    <span title="Position dans la composition">Pos. {cell.position}</span>
+                    <Typography
+                      component="span"
+                      variant="caption"
+                      display="block"
+                      color="text.secondary"
+                      sx={{ fontSize: "0.7rem" }}
+                      title="Victoires - Défaites (parties individuelles)"
+                    >
+                      {cell.victoires}V-{cell.defaites}D
+                    </Typography>
+                  </Box>
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function PreviousMatchesOpponents({
+  teamId,
+  phase,
+  opponentName,
+  maxMatches = 10,
+}: PreviousMatchesOpponentsProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const [matches, setMatches] = useState<OpponentMatchComposition[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [debugData, setDebugData] = useState<OpponentCompositionsDebug | null>(null);
+  const [showDebug, setShowDebug] = useState(false);
+
+  const isDebugMode = typeof window !== "undefined" && window.location.search.includes("debug=1");
+
+  const fetchCompositions = useCallback(async () => {
+    if (!opponentName?.trim() || !phase || !teamId?.trim()) {
+      setMatches(null);
+      setDebugData(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setDebugData(null);
+    try {
+      const params = new URLSearchParams({
+        teamId: teamId.trim(),
+        phase,
+        opponentName: opponentName.trim(),
+      });
+      if (isDebugMode) {
+        params.set("debug", "1");
+      }
+      const res = await fetch(`/api/fftt/opponent-compositions?${params}`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || `Erreur ${res.status}`);
+        setMatches(null);
+        return;
+      }
+      const data = (await res.json()) as {
+        matches: OpponentMatchComposition[];
+        _debug?: OpponentCompositionsDebug;
+      };
+      const list = Array.isArray(data.matches) ? data.matches : [];
+      setMatches(list.slice(0, maxMatches));
+      if (data._debug) {
+        setDebugData(data._debug);
+      }
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Erreur lors du chargement"
+      );
+      setMatches(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId, phase, opponentName, maxMatches, isDebugMode]);
+
+  useEffect(() => {
+    setMatches(null);
+    setDebugData(null);
+    setError(null);
+  }, [teamId, phase, opponentName]);
+
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setTooltipOpen(false);
+    setAnchorEl(event.currentTarget);
+    if (matches === null && !loading) {
+      void fetchCompositions();
+    }
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+
+  if (!opponentName?.trim()) {
+    return null;
+  }
+
+  const popoverContent = (
+    <Box sx={{ mt: 1 }}>
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+      {error && (
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          {error}
+        </Alert>
+      )}
+      {!loading && !error && matches !== null && matches.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+          Aucun match précédent trouvé pour cette équipe dans la poule.
+        </Typography>
+      )}
+      {!loading && !error && matches && matches.length > 0 && (
+        <CompositionsTable matches={matches} />
+      )}
+
+      {debugData && (
+        <Box sx={{ mt: 2 }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              cursor: "pointer",
+              color: "text.secondary",
+              "&:hover": { color: "primary.main" },
+            }}
+            onClick={() => setShowDebug((d) => !d)}
+            role="button"
+            aria-expanded={showDebug}
+          >
+            <BugReportIcon fontSize="small" />
+            <Typography variant="caption" fontWeight={600}>
+              Diagnostic (analyse du souci)
+            </Typography>
+            <IconButton size="small">
+              {showDebug ? <ExpandLess /> : <ExpandMore />}
+            </IconButton>
+          </Box>
+          <Collapse in={showDebug}>
+            <Box
+              sx={{
+                mt: 1,
+                p: 1.5,
+                bgcolor: "grey.100",
+                borderRadius: 1,
+                fontSize: "0.75rem",
+                fontFamily: "monospace",
+                overflow: "auto",
+                maxHeight: 400,
+              }}
+            >
+              <Typography variant="caption" component="div" sx={{ fontWeight: 600, mb: 1 }}>
+                Contexte : opponentName=&quot;{debugData.opponentName}&quot;, phase={debugData.phase}, teamId={debugData.teamId}, {debugData.matchCount} match(s).
+              </Typography>
+              {debugData.matches.map((md, idx) => (
+                <Box key={idx} sx={{ mb: 2 }}>
+                  <Typography variant="caption" component="div" sx={{ fontWeight: 600 }}>
+                    Match {idx + 1} : {md.date} — {md.otherTeamName}
+                  </Typography>
+                  <Typography variant="caption" component="div" color="text.secondary">
+                    details: A=&quot;{md.detailsNomEquipeA}&quot;, B=&quot;{md.detailsNomEquipeB}&quot; → sidePicked={md.sidePicked}
+                  </Typography>
+                  <Typography variant="caption" component="div" sx={{ mt: 0.5 }}>
+                    Joueurs (getDetailsRencontreByLien) : {md.joueursFromDetails.length} —{" "}
+                    {md.joueursFromDetails.map((j) => `${j.prenom} ${j.nom} (licence=${j.licence ?? "—"}, points=${j.points ?? "—"})`).join(" ; ")}
+                  </Typography>
+                  <Typography variant="caption" component="div" sx={{ mt: 0.5 }}>
+                    Enrichissement : {md.enrichment.map((e) => `${e.prenom} ${e.nom}: licence=${e.licence ?? "—"}, hadPointsBefore=${e.hadPointsBefore}, calledApi=${e.calledApi}${e.apiResponseKeys ? `, apiKeys=[${e.apiResponseKeys.join(", ")}]` : ""}, pointsAfter=${e.pointsAfter ?? "—"}${e.error ? `, error=${e.error}` : ""}`).join(" | ")}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Collapse>
+        </Box>
+      )}
+    </Box>
+  );
+
+  return (
+    <>
+      <Tooltip
+        title="Compositions de l'équipe adverse lors de ses précédents matchs"
+        open={open ? false : tooltipOpen}
+        onOpen={() => {
+          if (!open) setTooltipOpen(true);
+        }}
+        onClose={() => setTooltipOpen(false)}
+      >
+        <span>
+          <IconButton
+            size="small"
+            onClick={handleOpen}
+            aria-label="Compositions de l'équipe adverse lors de ses précédents matchs"
+            color="default"
+            sx={{ ml: 0.25 }}
+          >
+            <HistoryIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        PaperProps={{
+          elevation: 8,
+          sx: {
+            minWidth: 560,
+            width: "max-content",
+            maxWidth: "min(95vw, 880px)",
+            maxHeight: "min(75vh, 560px)",
+            borderRadius: 2,
+            overflow: "hidden",
+          },
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%", maxHeight: "min(75vh, 560px)" }}>
+          <Box
+            sx={{
+              px: 2,
+              py: 1.5,
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+            }}
+          >
+            <Typography variant="subtitle1" fontWeight={600}>
+              Compositions adverses
+            </Typography>
+            <Typography variant="caption" sx={{ opacity: 0.9, display: "block", mt: 0.25 }}>
+              {opponentName}
+            </Typography>
+          </Box>
+          <Box sx={{ flex: 1, overflow: "auto", p: 2 }}>
+            {popoverContent}
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/src/hooks/useJourneesData.ts
+++ b/src/hooks/useJourneesData.ts
@@ -6,6 +6,7 @@ import {
   getDefaultDivision,
   getDefaultEpreuve,
   getJourneesByPhaseForDivision,
+  getJourneesByPhaseMerged,
   type JourneeData,
   type JourneesByEpreuvePhaseDivision,
 } from "@/lib/shared/journee-dates-utils";
@@ -46,7 +47,13 @@ export function useJourneesData(
   const phaseToUse =
     selectedEpreuve === "championnat_paris" ? "aller" : selectedPhase;
 
-  const journeesByPhase = useMemo(() => {
+  const journeesByPhase = useMemo((): Map<"aller" | "retour", Map<number, JourneeData>> => {
+    if (!selectedEpreuve) return new Map();
+    // Championnat par équipes : fusionner les dates de toutes les divisions de la phase
+    // (samedi + dimanche pour une même journée, ex. 09/01 et 10/01 pour J7).
+    if (selectedEpreuve === "championnat_equipes") {
+      return getJourneesByPhaseMerged(journeesData, selectedEpreuve);
+    }
     const division = getDefaultDivision(
       journeesData,
       selectedEpreuve,

--- a/src/hooks/usePhasePreselect.ts
+++ b/src/hooks/usePhasePreselect.ts
@@ -13,11 +13,11 @@ export interface UsePhasePreselectParams {
 }
 
 /**
- * Hook partagé pour pré-sélectionner la phase (aller/retour) sur les pages
- * compositions et compositions par défaut. Algorithme unifié :
+ * Hook partagé pour pré-sélectionner la phase (aller/retour) au chargement initial.
  * - Paris : phase forcée à "aller".
- * - Championnat par équipes : phase du prochain match à jouer, avec fallbacks
- *   (currentPhase, "aller") et sync si la sélection diffère une fois les équipes chargées.
+ * - Championnat par équipes : au premier rendu (selectedPhase === null), on met la phase
+ *   du prochain match à jouer, ou currentPhase, ou "aller". La sélection utilisateur
+ *   n'est jamais écrasée ensuite.
  */
 export function usePhasePreselect({
   equipes,
@@ -49,14 +49,6 @@ export function usePhasePreselect({
 
     if (selectedPhase === null) {
       setSelectedPhase(phase);
-      return;
-    }
-
-    if (
-      phaseOfNext != null &&
-      selectedPhase !== phaseOfNext
-    ) {
-      setSelectedPhase(phaseOfNext);
     }
   }, [
     currentPhase,

--- a/src/lib/shared/fftt-utils.ts
+++ b/src/lib/shared/fftt-utils.ts
@@ -103,10 +103,21 @@ export const extractClubName = (libelle: string): string => {
 };
 
 // Utilitaires pour déterminer la phase et le résultat
+// Regex pour couvrir "Phase 2", "Phase2", "Phase  2", etc.
+const PHASE_2_PATTERN = /phase\s*2/i;
+const PHASE_1_PATTERN = /phase\s*1/i;
+
+/** Indique si le libellé de division correspond à la phase 2 (retour). */
+export const divisionIndicatesPhase2 = (division: string): boolean =>
+  PHASE_2_PATTERN.test(division);
+
+/** Indique si le libellé de division correspond à la phase 1 (aller). */
+export const divisionIndicatesPhase1 = (division: string): boolean =>
+  PHASE_1_PATTERN.test(division);
+
 export const determinePhaseFromDivision = (division: string): string => {
-  const d = division.toLowerCase();
-  if (d.includes("phase 1")) return "aller";
-  if (d.includes("phase 2")) return "retour";
+  if (divisionIndicatesPhase2(division)) return "retour";
+  if (divisionIndicatesPhase1(division)) return "aller";
   return "aller";
 };
 
@@ -426,7 +437,7 @@ export const createBaseMatch = (
   return {
     id: extractRencontreId(rencontre.lien), // Utiliser uniquement le renc_id comme ID stable
     ffttId: rencontre.lien,
-    teamId: equipe.idEquipe.toString(), // Ajouter l&apos;ID de l&apos;équipe pour le mapping
+    teamId: `${equipe.idEquipe}_${determinePhaseFromDivision(equipe.division)}`,
     teamNumber,
     opponent: opponentClub,
     opponentClub,
@@ -452,7 +463,75 @@ export const createBaseMatch = (
     rencontreId: extractRencontreId(rencontre.lien),
     equipeIds: extractEquipeIds(rencontre.lien),
     lienDetails: rencontre.lien,
-    resultatsIndividuels: undefined,
+    ...(detailsRencontre
+      ? {
+          resultatsIndividuels: (() => {
+            const joueursAToRecord = (
+              arr: Array<{ nom: string; prenom: string; points?: number | null }>
+            ): Record<string, { nom: string; prenom: string; points?: number }> =>
+              Object.fromEntries(
+                arr.map((j) => {
+                  const key = `${(j.prenom || "").trim()} ${(j.nom || "").trim()}`.trim();
+                  return [
+                    key,
+                    {
+                      nom: j.nom || "",
+                      prenom: j.prenom || "",
+                      ...(typeof j.points === "number" ? { points: j.points } : {}),
+                    },
+                  ];
+                })
+              );
+            const joueursA =
+              Array.isArray(detailsRencontre.joueursA) &&
+              detailsRencontre.joueursA.length > 0
+                ? joueursAToRecord(
+                    detailsRencontre.joueursA as Array<{
+                      nom: string;
+                      prenom: string;
+                      points?: number | null;
+                    }>
+                  )
+                : undefined;
+            const joueursB =
+              Array.isArray(detailsRencontre.joueursB) &&
+              detailsRencontre.joueursB.length > 0
+                ? joueursAToRecord(
+                    detailsRencontre.joueursB as Array<{
+                      nom: string;
+                      prenom: string;
+                      points?: number | null;
+                    }>
+                  )
+                : undefined;
+            const parties = Array.isArray(detailsRencontre.parties)
+              ? detailsRencontre.parties.map((p) => ({
+                  joueurA: p.adversaireA ?? "",
+                  joueurB: p.adversaireB ?? "",
+                  scoreA: p.scoreA,
+                  scoreB: p.scoreB,
+                  adversaireA: p.adversaireA,
+                  adversaireB: p.adversaireB,
+                  ...(p.setDetails
+                    ? {
+                        setDetails:
+                          typeof p.setDetails === "string"
+                            ? p.setDetails.split(/\s*-\s*/).filter(Boolean)
+                            : [],
+                      }
+                    : {}),
+                }))
+              : undefined;
+            return {
+              nomEquipeA: detailsRencontre.nomEquipeA,
+              nomEquipeB: detailsRencontre.nomEquipeB,
+              ...(joueursA ? { joueursA } : {}),
+              ...(joueursB ? { joueursB } : {}),
+              ...(parties && parties.length > 0 ? { parties } : {}),
+            };
+          })(),
+        }
+      : { resultatsIndividuels: undefined }),
     createdAt: new Date(),
     updatedAt: new Date(),
     // Informations des joueurs pour les conditions de brûlage

--- a/src/lib/shared/journee-dates-utils.ts
+++ b/src/lib/shared/journee-dates-utils.ts
@@ -1,3 +1,7 @@
+import {
+  divisionIndicatesPhase1,
+  divisionIndicatesPhase2,
+} from "./fftt-utils";
 import type { EpreuveType } from "./epreuve-utils";
 import { getMatchEpreuve } from "./epreuve-utils";
 
@@ -170,6 +174,8 @@ export function buildJourneesByEpreuvePhaseDivision(
   });
 
   // Calculer la division par défaut (celle avec la prochaine journée la plus proche)
+  // Pour "aller" on n'accepte que les divisions dont le libellé correspond (phase 1),
+  // pour "retour" idem (phase 2), afin d'éviter d'afficher les dates de l'autre phase.
   const now = new Date();
   now.setHours(0, 0, 0, 0);
   const defaultDivisionByEpreuvePhase = new Map<string, string>();
@@ -179,12 +185,21 @@ export function buildJourneesByEpreuvePhaseDivision(
     { division: string; debut: Date }
   >();
 
+  const divisionMatchesPhase = (division: string, phase: "aller" | "retour"): boolean => {
+    if (phase === "aller") return !divisionIndicatesPhase2(division);
+    return !divisionIndicatesPhase1(division);
+  };
+
   for (const [key, entry] of journeeDatesByKey) {
     const debutNorm = new Date(entry.debut);
     debutNorm.setHours(0, 0, 0, 0);
     if (debutNorm < now) continue;
 
-    const epreuvePhaseKey = key.split("|").slice(0, 2).join("|");
+    const parts = key.split("|");
+    const epreuvePhaseKey = parts.slice(0, 2).join("|");
+    const phase = parts[1] as "aller" | "retour";
+    if (!divisionMatchesPhase(entry.division, phase)) continue;
+
     const current = epreuvePhaseToClosest.get(epreuvePhaseKey);
     if (!current || debutNorm < current.debut) {
       epreuvePhaseToClosest.set(epreuvePhaseKey, {
@@ -198,15 +213,18 @@ export function buildJourneesByEpreuvePhaseDivision(
     defaultDivisionByEpreuvePhase.set(key, val.division);
   });
 
-  // Fallback : si aucune division n'a de match futur, prendre la première division
+  // Fallback : si aucune division n'a de match futur (ou aucune ne matche la phase),
+  // prendre une division qui a des données pour cette phase et dont le libellé correspond.
   data.forEach((epreuveMap, epreuve) => {
     for (const phase of ["aller", "retour"] as const) {
       const key = `${epreuve}|${phase}`;
       if (!defaultDivisionByEpreuvePhase.has(key)) {
         const phaseMap = epreuveMap.get(phase);
         const divisions = phaseMap ? Array.from(phaseMap.keys()) : [];
-        if (divisions.length > 0) {
-          defaultDivisionByEpreuvePhase.set(key, divisions[0]);
+        const matching = divisions.filter((div) => divisionMatchesPhase(div, phase));
+        const toUse = matching.length > 0 ? matching : divisions;
+        if (toUse.length > 0) {
+          defaultDivisionByEpreuvePhase.set(key, toUse[0]!);
         }
       }
     }
@@ -251,8 +269,65 @@ export function getJourneesByPhaseForDivision(
 }
 
 /**
+ * Retourne les journées par phase en fusionnant les dates de toutes les divisions
+ * qui correspondent à la phase (Phase 1 pour aller, Phase 2 pour retour).
+ * Permet d'afficher 09/01 et 10/01 pour une même journée quand les matchs sont
+ * répartis sur samedi/dimanche dans différentes poules.
+ */
+export function getJourneesByPhaseMerged(
+  journeesData: JourneesByEpreuvePhaseDivision,
+  epreuve: EpreuveType | null
+): Map<"aller" | "retour", Map<number, JourneeData>> {
+  const empty = new Map<
+    "aller" | "retour",
+    Map<number, JourneeData>
+  >() as Map<"aller" | "retour", Map<number, JourneeData>>;
+  if (!epreuve) return empty;
+
+  const epreuveMap = journeesData.data.get(epreuve);
+  if (!epreuveMap) return empty;
+
+  const result = new Map<"aller" | "retour", Map<number, JourneeData>>();
+  for (const phase of ["aller", "retour"] as const) {
+    const phaseMap = epreuveMap.get(phase);
+    if (!phaseMap) {
+      result.set(phase, new Map());
+      continue;
+    }
+    const mergedByJournee = new Map<number, JourneeData>();
+    phaseMap.forEach((divisionMap, division) => {
+      const matchesPhase =
+        phase === "aller"
+          ? !divisionIndicatesPhase2(division)
+          : !divisionIndicatesPhase1(division);
+      if (!matchesPhase) return;
+      divisionMap.forEach((journeeData, journeeNum) => {
+        const existing = mergedByJournee.get(journeeNum);
+        const datesSet = new Set(
+          (existing?.dates ?? []).concat(journeeData.dates).map((d) => d.toDateString())
+        );
+        const dates = Array.from(datesSet)
+          .map((s) => new Date(s))
+          .sort((a, b) => a.getTime() - b.getTime());
+        mergedByJournee.set(journeeNum, {
+          journee: journeeNum,
+          phase,
+          dates,
+        });
+      });
+    });
+    result.set(phase, mergedByJournee);
+  }
+  return result;
+}
+
+/**
  * Retourne la division par défaut pour une épreuve et une phase.
  * C'est la division dont la prochaine journée est la plus proche.
+ * Si aucune n'a de match futur pour cette phase, on prend une division qui a
+ * des journées dans cette phase, en privilégiant celles dont le libellé
+ * correspond (Phase 1 pour aller, Phase 2 pour retour) pour éviter d'afficher
+ * les samedis de l'autre phase.
  */
 export function getDefaultDivision(
   journeesData: JourneesByEpreuvePhaseDivision,
@@ -263,8 +338,28 @@ export function getDefaultDivision(
   const key = `${epreuve}|${phase}`;
   const div = journeesData.defaultDivisionByEpreuvePhase.get(key);
   if (div) return div;
-  const divisions = journeesData.divisionsByEpreuve.get(epreuve);
-  return divisions && divisions.length > 0 ? divisions[0] : null;
+  const phaseMap = journeesData.data.get(epreuve)?.get(phase);
+  if (!phaseMap) return null;
+  const withData = Array.from(phaseMap.keys()).filter(
+    (divisionKey) => (phaseMap.get(divisionKey)?.size ?? 0) > 0
+  );
+  if (withData.length === 0) return null;
+  // Pour la phase aller : exclure les divisions Phase 2 (évite d'afficher les dates retour).
+  // Pour la phase retour : exclure les divisions Phase 1.
+  const forAller =
+    phase === "aller"
+      ? withData.filter((d) => !divisionIndicatesPhase2(d))
+      : withData;
+  const forRetour =
+    phase === "retour"
+      ? withData.filter((d) => !divisionIndicatesPhase1(d))
+      : withData;
+  const candidates = phase === "aller" ? (forAller.length > 0 ? forAller : withData) : (forRetour.length > 0 ? forRetour : withData);
+  const preferred =
+    phase === "aller"
+      ? candidates.find((d) => divisionIndicatesPhase1(d))
+      : candidates.find((d) => divisionIndicatesPhase2(d));
+  return preferred ?? candidates[0] ?? null;
 }
 
 /**

--- a/src/lib/shared/team-matches-sync.ts
+++ b/src/lib/shared/team-matches-sync.ts
@@ -6,7 +6,7 @@ import {
   FFTTDetailsRencontre,
   FFTTJoueur,
 } from "./fftt-types";
-import { createBaseMatch, isFemaleTeam } from "./fftt-utils";
+import { createBaseMatch, isFemaleTeam, determinePhaseFromDivision } from "./fftt-utils";
 import type { Firestore, DocumentReference } from "firebase-admin/firestore";
 import { Timestamp, FieldValue } from "firebase-admin/firestore";
 
@@ -142,12 +142,21 @@ export interface MatchData {
   equipeIds: { equipe1: string; equipe2: string };
   lienDetails: string;
   resultatsIndividuels?:
-    | Array<{
-        joueurA: string;
-        joueurB: string;
-        scoreA: number;
-        scoreB: number;
-      }>
+    | {
+        parties?: Array<{
+          joueurA: string;
+          joueurB: string;
+          scoreA: number;
+          scoreB: number;
+          adversaireA?: string;
+          adversaireB?: string;
+          setDetails?: string[];
+        }>;
+        nomEquipeA?: string;
+        nomEquipeB?: string;
+        joueursA?: Record<string, { nom: string; prenom: string; points?: number }>;
+        joueursB?: Record<string, { nom: string; prenom: string; points?: number }>;
+      }
     | undefined;
   joueursSQY?:
     | Array<{
@@ -199,11 +208,24 @@ export class TeamMatchesSyncService {
       // Récupérer les équipes du club
       const equipes = await this.ffttApi.getEquipesByClub(this.clubCode);
 
-      // Trouver l&apos;équipe spécifique
-      const equipeFound = equipes.find(
-        (eq: FFTTEquipe) =>
-          eq.idEquipe.toString() === teamId.replace("sqyping_team_", "")
-      );
+      // Résoudre teamId : format "idEquipe_aller" / "idEquipe_retour" ou ancien "idEquipe"
+      const cleanId = teamId.replace("sqyping_team_", "");
+      const phaseSuffix = cleanId.includes("_aller")
+        ? "aller"
+        : cleanId.includes("_retour")
+          ? "retour"
+          : null;
+      const idEquipeStr = phaseSuffix
+        ? cleanId.replace(/_(aller|retour)$/, "")
+        : cleanId;
+
+      const equipeFound = equipes.find((eq: FFTTEquipe) => {
+        if (eq.idEquipe.toString() !== idEquipeStr) return false;
+        if (phaseSuffix) {
+          return determinePhaseFromDivision(eq.division) === phaseSuffix;
+        }
+        return true;
+      });
 
       if (!equipeFound) {
         throw new Error(`Équipe ${teamId} non trouvée`);
@@ -817,9 +839,9 @@ export class TeamMatchesSyncService {
           Array.isArray(match.joueursSQY) &&
           match.joueursSQY.length > 0;
         const hasResults =
-          match.resultatsIndividuels &&
-          Array.isArray(match.resultatsIndividuels) &&
-          match.resultatsIndividuels.length > 0;
+          match.resultatsIndividuels?.parties &&
+          Array.isArray(match.resultatsIndividuels.parties) &&
+          match.resultatsIndividuels.parties.length > 0;
         // Parser le score depuis le champ score (format "24-18")
         let hasScore = false;
         if (match.score) {
@@ -853,9 +875,9 @@ export class TeamMatchesSyncService {
           Array.isArray(match.joueursSQY) &&
           match.joueursSQY.length > 0;
         const hasResults =
-          match.resultatsIndividuels &&
-          Array.isArray(match.resultatsIndividuels) &&
-          match.resultatsIndividuels.length > 0;
+          match.resultatsIndividuels?.parties &&
+          Array.isArray(match.resultatsIndividuels.parties) &&
+          match.resultatsIndividuels.parties.length > 0;
         // Parser le score depuis le champ score (format "24-18")
         let hasScore = false;
         if (match.score) {
@@ -1605,7 +1627,7 @@ export class TeamMatchesSyncService {
           console.warn(
             `⚠️ ${
               missingTeamIds.length
-            } équipes référencées dans les matchs n'existent pas dans Firestore: ${missingTeamIds.join(
+            } équipes référencées dans les matchs n'existent pas dans Firestore (exécuter d'abord la sync équipes) : ${missingTeamIds.join(
               ", "
             )}`
           );

--- a/src/lib/shared/team-sync.ts
+++ b/src/lib/shared/team-sync.ts
@@ -1,5 +1,5 @@
 import { FFTTAPI } from "@omichalo/ffttapi-node";
-import { getFFTTConfig, isFemaleTeam } from "./fftt-utils";
+import { getFFTTConfig, isFemaleTeam, determinePhaseFromDivision } from "./fftt-utils";
 import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import type { FFTTEquipe } from "./fftt-types";
@@ -108,9 +108,13 @@ export class TeamSyncService {
       for (const equipe of filteredEquipes) {
         console.log(`🏆 Traitement de l&apos;équipe ${equipe.libelle}...`);
 
-        // Créer l&apos;équipe
+        // ID unique par phase : Phase 1 et Phase 2 ont des idEquipe identiques côté FFTT,
+        // on suffixe par _aller / _retour pour éviter d'écraser 26 équipes Phase 1.
+        const phase = determinePhaseFromDivision(equipe.division);
+        const teamId = `${equipe.idEquipe}_${phase}`;
+
         const teamData: TeamData = {
-          id: equipe.idEquipe.toString(), // Utiliser directement l&apos;ID FFTT comme clé
+          id: teamId,
           ffttId: equipe.idEquipe.toString(),
           name: equipe.libelle,
           division: equipe.division,
@@ -211,6 +215,22 @@ export class TeamSyncService {
             Math.floor(i / batchSize) + 1
           } sauvegardé (${saved} équipes)`
         );
+      }
+
+      // Supprimer les anciens docs équipe (id sans suffixe _aller/_retour)
+      // pour éviter doublons : 33 anciens + 59 nouveaux → 59 après nettoyage
+      const baseIdsToRemove = new Set(
+        teamsData
+          .filter((t) => /_(aller|retour)$/.test(t.id))
+          .map((t) => t.id.replace(/_(aller|retour)$/, ""))
+      );
+      for (const baseId of baseIdsToRemove) {
+        const ref = db.collection("teams").doc(baseId);
+        const snap = await ref.get();
+        if (snap.exists) {
+          await ref.delete();
+          console.log(`🗑️ Ancien doc équipe supprimé: ${baseId}`);
+        }
       }
 
       // Mettre à jour les métadonnées


### PR DESCRIPTION
## Description

- **API `/api/fftt/opponent-compositions`** : récupère les compositions de l’équipe adverse lors de ses précédents matchs (données FFTT). Fallback `getJoueursByNom` si licence manquante. Filtre strict par nom d’équipe (`teamNameEqualsOpponent`) pour n’afficher que l’équipe exacte (pas AS 2 quand on regarde AS 1). Calcul victoires/défaites par joueur à partir des parties individuelles.
- **API `/api/fftt/pool-ranking`** : classement de la poule FFTT.
- **PoolRankingPopover** : affichage du classement en popover au clic sur une icône (comme avant).
- **PreviousMatchesOpponents** : affichage des compositions adverses en popover au clic sur une icône (historique). Tableau joueurs × journées (position + 1V-2D par match). Réinitialisation des données au changement de journée. Tooltip contrôlé pour éviter le chevauchement avec le popover.
- **CompositionsPageContainer** : intégration des deux popovers (classement + compositions adverses) à côté du nom de l’équipe, pour chaque carte équipe.

## Type de changement

- [x] Feature (nouvelle fonctionnalité)

## Checklist qualité

### Code
- [x] Le code respecte les règles du projet
- [x] Pas de `any` implicite, TypeScript strict respecté
- [x] Pas de code mort, imports inutilisés, ou console.log permanents
- [x] Pas de TODO dans le code
- [x] Les tests existants passent toujours

### Sécurité
- [x] Routes API protégées (auth coach/admin)
- [x] Validation des inputs (teamId, phase, opponentName)
- [x] Pas de données sensibles exposées

### Tests & Validation
- [x] `npm run check:dev` passe en local
- [x] `npm run check` passe en local (lint + type-check + build)

## Tests effectués

- Ouverture des popovers classement et compositions adverses sur la page compositions.
- Changement de journée : nom d’équipe et joueurs se mettent à jour.
- Vérification que seuls les matchs de l’équipe exacte sont affichés (pas de mélange AS 1 / AS 2).