### PR TITLE
feat(compositions): indicateur Message envoyé en tête de carte d'équipe

### DIFF
--- a/src/app/compositions/_containers/CompositionsPageContainer.tsx
+++ b/src/app/compositions/_containers/CompositionsPageContainer.tsx
@@ -34,6 +34,7 @@ import {
   AlternateEmail,
   Warning,
   Accessible as AccessibleIcon,
+  CheckCircle,
 } from "@mui/icons-material";
 import { useTeamData, type EquipeWithMatches } from "@/hooks/useTeamData";
 import { useAvailabilities } from "@/hooks/useAvailabilities";
@@ -2635,6 +2636,29 @@ export function CompositionsPageContainer() {
                                         gap: 1,
                                       }}
                                     >
+                                      {discordSentStatus[equipe.team.id]
+                                        ?.sent && (
+                                        <Chip
+                                          icon={
+                                            <CheckCircle sx={{ fontSize: 16 }} />
+                                          }
+                                          label="Message envoyé"
+                                          size="small"
+                                          color="success"
+                                          variant="filled"
+                                          sx={{ fontWeight: 600 }}
+                                          title={
+                                            discordSentStatus[equipe.team.id]
+                                              ?.sentAt
+                                              ? `Envoyé le ${new Date(
+                                                  discordSentStatus[
+                                                    equipe.team.id
+                                                  ].sentAt!
+                                                ).toLocaleString("fr-FR")}`
+                                              : "Message Discord déjà envoyé"
+                                          }
+                                        />
+                                      )}
                                       {validationError && (
                                         <Chip
                                           label="Invalide"
@@ -3481,6 +3505,29 @@ export function CompositionsPageContainer() {
                                       gap: 1,
                                     }}
                                   >
+                                    {discordSentStatus[equipe.team.id]
+                                      ?.sent && (
+                                      <Chip
+                                        icon={
+                                          <CheckCircle sx={{ fontSize: 16 }} />
+                                        }
+                                        label="Message envoyé"
+                                        size="small"
+                                        color="success"
+                                        variant="filled"
+                                        sx={{ fontWeight: 600 }}
+                                        title={
+                                          discordSentStatus[equipe.team.id]
+                                            ?.sentAt
+                                            ? `Envoyé le ${new Date(
+                                                discordSentStatus[
+                                                  equipe.team.id
+                                                ].sentAt!
+                                              ).toLocaleString("fr-FR")}`
+                                            : "Message Discord déjà envoyé"
+                                        }
+                                      />
+                                    )}
                                     {validationError && (
                                       <Chip
                                         label="Invalide"


### PR DESCRIPTION
## Description

Ajout d'un indicateur visible **Message envoyé** sur la page Compositions : un badge vert avec icône CheckCircle en tête de chaque carte d'équipe lorsque le message Discord a déjà été envoyé pour cette équipe. L'indicateur reste visible même lorsque le panneau "Message Discord" est fermé. Tooltip avec la date d'envoi au survol.

## Type de changement

- [x] Feature (nouvelle fonctionnalité)

## Checklist qualité

### Code
- [x] Le code respecte les règles du projet
- [x] Pas de `any` implicite, TypeScript strict respecté
- [x] Pas de code mort, imports inutilisés, ou console.log permanents
- [x] Pas de TODO dans le code
- [x] Les tests existants passent toujours

### Tests & Validation
- [x] `npm run check:dev` passe en local
- [x] `npm run check` passe en local (lint + type-check + build)

## Tests effectués

Vérification visuelle : badge "Message envoyé" affiché en tête de carte quand le message Discord a été envoyé pour l'équipe (onglets Masculin et Féminin).