### PR TITLE
feat(discord): option pour fermer le sondage avec ou sans message

### DIFF
--- a/src/app/api/discord/availability-polls/[pollId]/close/route.ts
+++ b/src/app/api/discord/availability-polls/[pollId]/close/route.ts
@@ -94,75 +94,76 @@ export async function POST(
       });
     }
 
-    // Récupérer le messageTemplate optionnel depuis le body
+    // Récupérer le body : sendMessage (optionnel, défaut true) et messageTemplate (optionnel)
+    let sendMessage = true;
     let messageTemplate: string | undefined;
     try {
       const body = await req.json();
+      if (typeof body.sendMessage === "boolean") {
+        sendMessage = body.sendMessage;
+      }
       messageTemplate = body.messageTemplate;
     } catch {
-      // Body vide ou invalide, pas de message personnalisé
+      // Body vide ou invalide : fermer sans message par défaut serait dangereux pour l'UX existante,
+      // donc sendMessage reste true et pas de message personnalisé
     }
 
-    // Récupérer la mention configurée pour ce type de championnat
-    const { getFirestoreAdmin } = await import("@/lib/firebase-admin");
-    const db = getFirestoreAdmin();
-    const configDoc = await db
-      .collection("discordAvailabilityConfig")
-      .doc("default")
-      .get();
-    const config = configDoc.exists ? configDoc.data() : null;
+    if (sendMessage) {
+      // Récupérer la mention configurée pour ce type de championnat
+      const { getFirestoreAdmin } = await import("@/lib/firebase-admin");
+      const db = getFirestoreAdmin();
+      const configDoc = await db
+        .collection("discordAvailabilityConfig")
+        .doc("default")
+        .get();
+      const config = configDoc.exists ? configDoc.data() : null;
 
-    // Déterminer le type de championnat (par équipes ou Paris)
-    // idEpreuve === 15980 = Championnat de Paris IDF (Excellence)
-    // Sinon = Championnat de France par Équipes
-    const isTeamChampionship = idEpreuve === undefined || idEpreuve !== 15980;
-    const mention = isTeamChampionship
-      ? config?.equipesMention || null
-      : config?.parisMention || null;
+      // Déterminer le type de championnat (par équipes ou Paris)
+      const isTeamChampionship =
+        idEpreuve === undefined || idEpreuve !== 15980;
+      const mention = isTeamChampionship
+        ? config?.equipesMention || null
+        : config?.parisMention || null;
 
-    // Construire le message final (avec mention si fournie)
-    const defaultCloseMessage =
-      "Les inscriptions sont terminées pour cette journée.\n\nSi vous voulez vous ajoutez, il faut envoyer un message à Joffrey en privé.";
-    let finalMessage =
-      typeof messageTemplate === "string" && messageTemplate.trim().length > 0
-        ? messageTemplate.trim()
-        : defaultCloseMessage;
+      // Construire le message final (avec mention si fournie)
+      const defaultCloseMessage =
+        "Les inscriptions sont terminées pour cette journée.\n\nSi vous voulez vous ajoutez, il faut envoyer un message à Joffrey en privé.";
+      let finalMessage =
+        typeof messageTemplate === "string" &&
+        messageTemplate.trim().length > 0
+          ? messageTemplate.trim()
+          : defaultCloseMessage;
 
-    // Ajouter "Bonjour {mention}" au début si la mention est configurée et qu'elle n'est pas déjà présente
-    if (mention) {
-      const bonjourWithMention = `Bonjour ${mention}`;
-      const mentionAlreadyPresent =
-        finalMessage.trim().startsWith(bonjourWithMention.trim()) ||
-        finalMessage.trim().startsWith(mention.trim());
-      if (!mentionAlreadyPresent) {
-        finalMessage = `${bonjourWithMention}\n\n${finalMessage}`;
+      if (mention) {
+        const bonjourWithMention = `Bonjour ${mention}`;
+        const mentionAlreadyPresent =
+          finalMessage.trim().startsWith(bonjourWithMention.trim()) ||
+          finalMessage.trim().startsWith(mention.trim());
+        if (!mentionAlreadyPresent) {
+          finalMessage = `${bonjourWithMention}\n\n${finalMessage}`;
+        }
       }
-    }
 
-    // Envoyer le message dans le même channel
-    const closeMessage = {
-      content: finalMessage,
-    };
-
-    const sendMessageResponse = await fetch(
-      `https://discord.com/api/v10/channels/${poll.channelId}/messages`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bot ${DISCORD_TOKEN}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(closeMessage),
-      }
-    );
-
-    if (!sendMessageResponse.ok) {
-      const errorText = await sendMessageResponse.text();
-      console.error(
-        "[Discord Poll Close] Erreur lors de l'envoi du message:",
-        errorText
+      const closeMessage = { content: finalMessage };
+      const sendMessageResponse = await fetch(
+        `https://discord.com/api/v10/channels/${poll.channelId}/messages`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bot ${DISCORD_TOKEN}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(closeMessage),
+        }
       );
-      // Continuer quand même pour fermer le sondage
+
+      if (!sendMessageResponse.ok) {
+        const errorText = await sendMessageResponse.text();
+        console.error(
+          "[Discord Poll Close] Erreur lors de l'envoi du message:",
+          errorText
+        );
+      }
     }
 
     // Désactiver les boutons dans le message Discord

--- a/src/components/disponibilites/DiscordPollManager.tsx
+++ b/src/components/disponibilites/DiscordPollManager.tsx
@@ -14,6 +14,8 @@ import {
   Chip,
   Tooltip,
   TextField,
+  FormControlLabel,
+  Switch,
   Popper,
   Paper,
   List,
@@ -76,6 +78,7 @@ export function DiscordPollManager({
   const [currentPoll, setCurrentPoll] = useState<DiscordPoll | null>(null);
   const [messageTemplate, setMessageTemplate] = useState<string>("");
   const [closeMessageTemplate, setCloseMessageTemplate] = useState<string>("");
+  const [closeWithMessage, setCloseWithMessage] = useState<boolean>(true);
   // Utiliser les dates passées en props si disponibles, sinon permettre la saisie manuelle
   const [fridayDate, setFridayDate] = useState<string>(propFridayDate || "");
   const [saturdayDate, setSaturdayDate] = useState<string>(
@@ -750,9 +753,8 @@ export function DiscordPollManager({
 
   const handleClosePoll = useCallback(() => {
     if (!currentPoll) return;
-    // Ouvrir la pop-in de fermeture au lieu de window.confirm
     setCloseDialogOpen(true);
-    // Initialiser le message par défaut si vide
+    setCloseWithMessage(true);
     if (!closeMessageTemplate) {
       setCloseMessageTemplate(getDefaultCloseMessage());
     }
@@ -766,9 +768,9 @@ export function DiscordPollManager({
     setSuccess(null);
 
     try {
-      // Envoyer le messageTemplate seulement s'il a été modifié (différent du message par défaut)
       const defaultCloseMsg = getDefaultCloseMessage();
       const finalCloseMessageTemplate =
+        closeWithMessage &&
         closeMessageTemplate.trim() &&
         closeMessageTemplate.trim() !== defaultCloseMsg.trim()
           ? closeMessageTemplate.trim()
@@ -783,6 +785,7 @@ export function DiscordPollManager({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
+            sendMessage: closeWithMessage,
             messageTemplate: finalCloseMessageTemplate,
           }),
         }
@@ -794,6 +797,7 @@ export function DiscordPollManager({
         setSuccess("Sondage fermé avec succès");
         setCloseDialogOpen(false);
         setCloseMessageTemplate("");
+        setCloseWithMessage(true);
         // Mettre à jour le sondage actuel d'abord
         await fetchCurrentPoll();
         // Vérifier immédiatement les sondages actifs
@@ -808,6 +812,7 @@ export function DiscordPollManager({
     }
   }, [
     currentPoll,
+    closeWithMessage,
     closeMessageTemplate,
     getDefaultCloseMessage,
     fetchCurrentPoll,
@@ -1281,6 +1286,19 @@ export function DiscordPollManager({
     </Box>
           </Box>
 
+          <FormControlLabel
+            control={
+              <Switch
+                checked={closeWithMessage}
+                onChange={(_, checked) => setCloseWithMessage(checked)}
+                color="primary"
+              />
+            }
+            label="Envoyer un message dans le canal Discord lors de la fermeture"
+            sx={{ mt: 2, display: "block" }}
+          />
+
+          {closeWithMessage && (
           <Box sx={{ mt: 3, position: "relative" }}>
             <TextField
               fullWidth
@@ -1404,12 +1422,14 @@ export function DiscordPollManager({
               />
             )}
           </Box>
+          )}
         </DialogContent>
         <DialogActions>
           <Button
             onClick={() => {
               setCloseDialogOpen(false);
               setCloseMessageTemplate("");
+              setCloseWithMessage(true);
             }}
             disabled={closing}
           >


### PR DESCRIPTION
- API close: nouveau paramètre sendMessage (booléen) pour contrôler l'envoi
- DiscordPollManager: switch pour choisir d'envoyer un message ou non

# Pull Request

## Description

<!-- Décrire brièvement les changements apportés -->

## Type de changement

- [ ] Feature (nouvelle fonctionnalité)
- [ ] Fix (correction de bug)
- [ ] Refactor (refactorisation)
- [ ] Docs (documentation)
- [ ] Style (formatage, pas de changement de code)
- [ ] Test (ajout/modification de tests)
- [ ] Chore (tâches de maintenance)

## Checklist qualité

### Code
- [ ] Le code respecte les règles du projet (voir `.cursor/rules/`)
- [ ] Pas de `any` implicite, TypeScript strict respecté
- [ ] Pas de code mort, imports inutilisés, ou console.log permanents
- [ ] Pas de TODO dans le code (remplacer par des issues GitHub si nécessaire)
- [ ] Les tests existants passent toujours
- [ ] Nouveaux tests ajoutés si nécessaire

### Sécurité
- [ ] Routes API protégées (CSRF, rate limiting si nécessaire)
- [ ] Headers de sécurité ajoutés sur les routes sensibles
- [ ] Cookies sécurisés configurés correctement
- [ ] Validation des inputs utilisateur (Zod ou équivalent)
- [ ] Pas de données sensibles exposées (logs, erreurs, etc.)
- [ ] Cohérence client/serveur pour les vérifications de rôles

### Firebase
- [ ] Firestore rules mises à jour si nécessaire (least privilege)
- [ ] Firebase Functions validées si modifiées
- [ ] Tests emulators si applicable

### Tests & Validation
- [ ] `npm run check:dev` passe en local
- [ ] `npm run check` passe en local (lint + type-check + build)
- [ ] Tests unitaires/integration ajoutés ou mis à jour
- [ ] Smoke tests passent si applicables (`npm run smoke:web`, `npm run emulators:smoke`)

### Documentation
- [ ] README mis à jour si nécessaire
- [ ] Documentation technique ajoutée si nouvelle fonctionnalité
- [ ] ADR créé si décision architecturale importante

### Discord (si applicable)
- [ ] Commandes Discord testées si modifiées
- [ ] Scripts Discord fonctionnent (`npm run discord:register-command`)

## Tests effectués

<!-- Décrire les tests manuels effectués -->

## Screenshots (si applicable)

<!-- Ajouter des captures d'écran pour les changements UI -->

## Notes additionnelles

<!-- Informations complémentaires pour les reviewers -->

