### PR TITLE
fix(compositions): distinction masculin/féminin dans la règle de brûlage jour 2

### DIFF
--- a/src/lib/compositions/validators/index.ts
+++ b/src/lib/compositions/validators/index.ts
@@ -3,6 +3,7 @@ import { ChampionshipType, Match } from "@/types";
 import { EquipeWithMatches } from "@/hooks/useTeamData";
 import { validateFFTTRules } from "@/lib/shared/fftt-utils";
 import { getMatchEpreuve, ID_EPREUVE_PARIS } from "@/lib/shared/epreuve-utils";
+import { getTeamsByType } from "@/lib/compositions/championship-utils";
 
 export type PhaseType = "aller" | "retour";
 
@@ -165,14 +166,20 @@ export const getTeamNumberForPlayerJournee1 = (
   playerId: string,
   phase: PhaseType,
   players: Player[],
-  equipes: EquipeWithMatches[]
+  equipes: EquipeWithMatches[],
+  championshipType?: ChampionshipType
 ): number | null => {
   const player = players.find((p) => p.id === playerId);
   if (!player) {
     return null;
   }
 
-  for (const equipe of equipes) {
+  // Filtrer les équipes par type si championshipType est fourni
+  const equipesToCheck = championshipType
+    ? getTeamsByType(equipes)[championshipType]
+    : equipes;
+
+  for (const equipe of equipesToCheck) {
     const matchJ1 = getMatchForTeamAndJournee(equipe, 1, phase);
     if (matchJ1 && isMatchPlayed(matchJ1)) {
       const playersFromMatch = getPlayersFromMatch(matchJ1, players);
@@ -192,13 +199,15 @@ export const didPlayerPlayJ1InLowerTeam = (
   targetTeamNumber: number,
   phase: PhaseType,
   players: Player[],
-  equipes: EquipeWithMatches[]
+  equipes: EquipeWithMatches[],
+  championshipType?: ChampionshipType
 ): boolean => {
   const playerJ1TeamNumber = getTeamNumberForPlayerJournee1(
     playerId,
     phase,
     players,
-    equipes
+    equipes,
+    championshipType
   );
 
   if (playerJ1TeamNumber === null) {
@@ -491,7 +500,8 @@ export const canAssignPlayerToTeam = (
         teamNumber,
         phaseValue,
         players,
-        equipes
+        equipes,
+        championshipType
       )
     );
 
@@ -500,7 +510,8 @@ export const canAssignPlayerToTeam = (
       teamNumber,
       phaseValue,
       players,
-      equipes
+      equipes,
+      championshipType
     );
 
     if (playerFromLowerTeam && playersFromLowerTeams.length > 1) {
@@ -720,7 +731,8 @@ export const validateTeamCompositionState = (
           teamNumber,
           phaseValue,
           players,
-          equipes
+          equipes,
+          championshipType
         )
       );
 


### PR DESCRIPTION
# Pull Request

## Description

Correction de la règle de brûlage entre journée 1 et journée 2 qui ne distinguait pas les équipes masculines et féminines. Un joueur ayant joué en journée 1 dans une équipe féminine pouvait être compté comme venant d'une équipe inférieure même s'il joue dans une équipe masculine (et vice versa).

**Corrections apportées :**
- Ajout du paramètre `championshipType` aux fonctions `getTeamNumberForPlayerJournee1` et `didPlayerPlayJ1InLowerTeam`
- Filtrage des équipes par type avant de vérifier la règle jour 2
- La règle vérifie maintenant uniquement les équipes du même type (masculin ou féminin)

## Type de changement

- [x] Fix (correction de bug)

## Checklist qualité

### Code
- [x] Le code respecte les règles du projet
- [x] Pas de `any` implicite, TypeScript strict respecté
- [x] Pas de code mort, imports inutilisés, ou console.log permanents
- [x] Pas de TODO dans le code
- [x] Les tests existants passent toujours

### Tests & Validation
- [x] `npm run check:dev` passe en local
- [x] `npm run check` passe en local (lint + type-check + build)

## Notes additionnelles

Cette correction garantit que la règle limitant à 1 joueur ayant joué en journée 1 dans une équipe inférieure s'applique correctement en tenant compte du type de championnat (masculin ou féminin).

Made with [Cursor](https://cursor.com)