### PR TITLE
🛡️ Sentinel: Fix privilege escalation and data integrity issues

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Privilege Escalation via Firestore Role Manipulation
+**Vulnerability:** Users could upgrade their own role to 'admin' by directly updating their Firestore document because security rules only checked authorship, not field-level changes.
+**Learning:** Even if security rules use Custom Claims for authorization, the application code might fallback to Firestore data for UI or other decisions, creating a privilege escalation path.
+**Prevention:** Always prioritize secure Custom Claims in the backend for role resolution, and use Firestore rules to prevent clients from modifying sensitive fields like 'role'.

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,11 +30,18 @@ service cloud.firestore {
     // ============================================
     // Collection: users
     // ============================================
-    // Les utilisateurs peuvent créer/mettre à jour leur propre profil
+    // Les utilisateurs peuvent créer leur profil avec des valeurs par défaut sécurisées
+    // Ils peuvent mettre à jour leur profil mais pas leur rôle ni le statut de leur demande coach
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, rôle 'player' par défaut
+      allow create: if isAuthenticated() && request.auth.uid == userId
+        && request.resource.data.role == 'player'
+        && (request.resource.data.get('coachRequestStatus', 'none') == 'none');
+
+      // Mise à jour : uniquement son propre profil, sans pouvoir changer son rôle ni son statut
+      allow update: if isAuthenticated() && request.auth.uid == userId
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['role', 'coachRequestStatus']));
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +118,10 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture réservée aux admins et coachs pour garantir l'intégrité des données
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow write: if isCoach();
     }
     
     // ============================================

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -93,10 +93,12 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      // Prioritize role and status from secure custom claims (decoded token)
+      // and only use Firestore as a fallback for missing data
+      role: decoded.role || (userData?.role as string | undefined) || "player",
       coachRequestStatus:
-        (userData?.coachRequestStatus as string | undefined) ||
         decoded.coachRequestStatus ||
+        (userData?.coachRequestStatus as string | undefined) ||
         "none",
       coachRequestMessage: (userData?.coachRequestMessage as string | undefined) || null,
       coachRequestUpdatedAt,


### PR DESCRIPTION
This PR addresses a privilege escalation vulnerability where users could potentially upgrade their own role to 'admin' by modifying their Firestore document. It also secures the 'availabilities' collection from unauthorized modifications by regular players.

Key changes:
1. **Firestore Rules**: Added field-level restrictions to the 'users' collection to block client-side updates to 'role' and 'coachRequestStatus' fields.
2. **Availability Protection**: Restrict write access to 'availabilities' to only 'coach' and 'admin' roles.
3. **API Security**: Modified '/api/session/verify' to prioritize the 'role' and 'coachRequestStatus' from the cryptographically signed session token (custom claims) instead of the mutable Firestore document.

These changes ensure that even if a user manages to change their role in the database, the application will still respect the secure role assigned by an administrator via custom claims.

---
*PR created automatically by Jules for task [8559803072024681955](https://jules.google.com/task/8559803072024681955) started by @omichalo*