### PR TITLE
🛡️ Sentinel: Fix potential privilege escalation in session verification and Firestore rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Privilege Escalation via Firestore Data Priority
+**Vulnerability:** The `/api/session/verify` endpoint prioritized user roles and status from Firestore documents over Firebase Custom Claims. Additionally, Firestore security rules allowed users to modify their own `role` and `coachRequestStatus` fields.
+**Learning:** In a hybrid auth system (Custom Claims + Firestore), if the Firestore document is used as the source of truth without strict write protections, users can escalate their privileges by modifying their own document.
+**Prevention:** Always prioritize Custom Claims in session verification as they are signed by the server. Use Firestore security rules with `affectedKeys()` to block client-side updates to sensitive fields.

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,8 +33,15 @@ service cloud.firestore {
     // Les utilisateurs peuvent créer/mettre à jour leur propre profil
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // 🛡️ Sentinel: Users can create their own profile but cannot self-assign roles.
+      allow create: if isAuthenticated() && request.auth.uid == userId
+                    && (!('role' in request.resource.data) || request.resource.data.role == 'player')
+                    && (!('coachRequestStatus' in request.resource.data) || request.resource.data.coachRequestStatus == 'none');
+
+      // 🛡️ Sentinel: Users can update their own profile but cannot change sensitive fields like 'role' or 'coachRequestStatus'.
+      // These fields must only be updated by the server (Admin SDK) via specific API routes.
+      allow update: if isAuthenticated() && request.auth.uid == userId
+                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role', 'coachRequestStatus']);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -93,10 +93,12 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      // 🛡️ Sentinel: Prioritize role and status from Custom Claims (decoded token)
+      // over Firestore data to prevent privilege escalation if the document is tampered with.
+      role: (decoded.role as string | undefined) || (userData?.role as string | undefined) || "player",
       coachRequestStatus:
+        (decoded.coachRequestStatus as string | undefined) ||
         (userData?.coachRequestStatus as string | undefined) ||
-        decoded.coachRequestStatus ||
         "none",
       coachRequestMessage: (userData?.coachRequestMessage as string | undefined) || null,
       coachRequestUpdatedAt,


### PR DESCRIPTION
This PR addresses a potential privilege escalation vulnerability and strengthens the application's defense-in-depth posture.

🚨 **Severity: HIGH**

💡 **Vulnerability:** 
1. The `/api/session/verify` endpoint was prioritizing Firestore document data over Firebase Custom Claims for determining user roles.
2. Firestore security rules allowed users to update their own `role` and `coachRequestStatus` fields.

🎯 **Impact:** 
A malicious user could modify their own `users` document in Firestore to change their role to `admin`. While some parts of the app (like `middleware.ts`) correctly used Custom Claims, any logic relying on the `/api/session/verify` response or directly on the Firestore document would have been vulnerable to privilege escalation.

🔧 **Fix:**
1. Updated `src/app/api/session/verify/route.ts` to prioritize roles and status from the decoded session token (Custom Claims), which is the trusted source of truth.
2. Updated `firestore.rules` to use `affectedKeys()` and field-level validation to prevent users from self-assigning roles or changing their request status.
3. Added security-focused comments to explain the changes.

✅ **Verification:**
- Ran `npm test` to ensure no regressions in existing logic.
- Ran `npm run lint` and `npm run build` to verify code quality and build stability.
- Verified file changes manually.

Recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9155216400422143064](https://jules.google.com/task/9155216400422143064) started by @omichalo*