### PR TITLE
🛡️ Sentinel: Harden Firestore security rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Hardening Firestore Security Rules
+**Vulnerability:** Overly permissive Firestore rules allowed any authenticated user to read sensitive club settings (including Discord webhooks) and potentially escalate their own privileges by modifying the 'role' or 'coachRequestStatus' fields in their user profile document.
+**Learning:** Even when using Custom Claims for authorization in middleware, the Firestore documents can still be a target for privilege escalation if the application uses them as a fallback or for UI logic. Sensitive collections like 'clubSettings' must be restricted to admins only if they contain secrets.
+**Prevention:** Use `request.resource.data.diff(resource.data).affectedKeys().hasAny([...])` to block direct updates to sensitive fields in Firestore rules. Always restrict read access to collections containing secrets to the absolute minimum required role (typically 'admin').

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,11 +30,18 @@ service cloud.firestore {
     // ============================================
     // Collection: users
     // ============================================
-    // Les utilisateurs peuvent créer/mettre à jour leur propre profil
-    // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
+    // Les utilisateurs peuvent créer leur profil avec des rôles par défaut
+    // La modification du rôle et du statut de demande coach est réservée aux admins via l'Admin SDK
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, avec des valeurs par défaut
+      allow create: if isAuthenticated() && request.auth.uid == userId
+        && request.resource.data.get('role', 'player') == 'player'
+        && request.resource.data.get('coachRequestStatus', 'none') == 'none';
+
+      // Mise à jour : uniquement son propre profil, mais interdire la modification de role et coachRequestStatus
+      // 🛡️ Sentinel: Empêcher l'escalade de privilèges via modification directe de 'role' ou 'coachRequestStatus'
+      allow update: if isAuthenticated() && request.auth.uid == userId
+        && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role', 'coachRequestStatus']);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +118,10 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture uniquement pour les admins/coaches (les joueurs utilisent Discord + Admin SDK)
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow write: if isCoach();
     }
     
     // ============================================
@@ -130,17 +137,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture réservées aux administrateurs (contient des secrets comme webhooks Discord)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Overly permissive Firestore rules allowed any authenticated user to read sensitive club settings (including Discord webhooks) and potentially escalate their own privileges by modifying the 'role' or 'coachRequestStatus' fields in their user profile document.
🎯 Impact: Unauthorized users could gain access to Discord webhooks or appear as coaches/admins in parts of the UI that rely on the Firestore user document.
🔧 Fix: Updated `firestore.rules` to use `affectedKeys()` for preventing sensitive field updates and tightened access to 'availabilities' and 'clubSettings' collections.
✅ Verification: Ran `npm run lint`, `npm test`, and `npm run build`. Verified rule logic manually.

---
*PR created automatically by Jules for task [14126890111356154669](https://jules.google.com/task/14126890111356154669) started by @omichalo*