### PR TITLE
🛡️ Sentinel: [HIGH] Hardening Firestore rules and session verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Privilege Escalation via Firestore Field Tampering
+**Vulnerability:** Users could change their own `role` or `coachRequestStatus` fields in the `users` Firestore collection, and the application's session verification endpoint prioritized these Firestore values over secure Custom Claims.
+**Learning:** Mirroring auth claims in Firestore documents without strict security rules (`diff().affectedKeys()`) creates a privilege escalation path. Additionally, server-side code must always prioritize cryptographically signed data (like ID tokens or session cookies) over mutable database records for authorization.
+**Prevention:** Use Firestore security rules to block updates to sensitive fields and ensure the session verification logic treats the decoded token as the source of truth for user roles.

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,11 +30,20 @@ service cloud.firestore {
     // ============================================
     // Collection: users
     // ============================================
-    // Les utilisateurs peuvent créer/mettre à jour leur propre profil
+    // Les utilisateurs peuvent créer leur profil (avec rôle player par défaut)
+    // Les utilisateurs peuvent mettre à jour leur profil (sauf champs sensibles)
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, avec des valeurs par défaut sécurisées
+      allow create: if isAuthenticated() && request.auth.uid == userId
+        && request.resource.data.role == "player"
+        && (request.resource.data.coachRequestStatus == "none" || !("coachRequestStatus" in request.resource.data));
+
+      // Mise à jour : uniquement son propre profil, impossible de changer le rôle ou le statut coach
+      allow update: if isAuthenticated() && request.auth.uid == userId
+        && !request.resource.data.diff(resource.data).affectedKeys().hasAny([
+          'role', 'coachRequestStatus', 'coachRequestHandledBy', 'coachRequestHandledAt', 'coachRequestUpdatedAt'
+        ]);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +120,15 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture : admins/coaches ou le propriétaire de la disponibilité
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow create, update: if isAuthenticated() && (
+        isCoach() ||
+        (request.resource.data.playerId != null &&
+         request.resource.data.playerId == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.playerId)
+      );
+      allow delete: if isCoach();
     }
     
     // ============================================
@@ -130,17 +144,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture strictement réservées aux admins (contient des secrets FFTT et Discord)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -93,10 +93,11 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      // Priorité au rôle et statut du token (claims personnalisées) pour éviter l'escalade de privilèges via Firestore
+      role: (decoded.role as string | undefined) || (userData?.role as string | undefined) || "player",
       coachRequestStatus:
+        (decoded.coachRequestStatus as string | undefined) ||
         (userData?.coachRequestStatus as string | undefined) ||
-        decoded.coachRequestStatus ||
         "none",
       coachRequestMessage: (userData?.coachRequestMessage as string | undefined) || null,
       coachRequestUpdatedAt,


### PR DESCRIPTION
This PR addresses multiple security vulnerabilities related to privilege escalation and unauthorized access:

1. **Firestore Rules Hardening**:
   - Added `diff().affectedKeys()` checks to the `users` collection to prevent users from changing their own `role` or `coachRequestStatus`.
   - Restricted the `clubSettings` collection to admins only, as it contains sensitive FFTT passwords and Discord webhooks.
   - Secured the `availabilities` collection by ensuring only coaches or the owner of the record can modify it.

2. **Session Verification Logic**:
   - Updated `/api/session/verify` to prioritize roles and statuses from the cryptographically verified session token (Custom Claims) over Firestore data. This prevents a user from gaining elevated permissions even if they somehow managed to tamper with their Firestore document.

These changes follow the principle of defense-in-depth and ensure that sensitive operations and data are properly protected.

---
*PR created automatically by Jules for task [9625928796198300814](https://jules.google.com/task/9625928796198300814) started by @omichalo*