### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix CSRF secret leakage and tighten Firestore rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - CSRF Secret Leakage and Permissive Firestore Rules
+**Vulnerability:** The CSRF token generation was leaking the `CSRF_SECRET` to the client by simply base64 encoding it with the user ID and timestamp. Additionally, Firestore rules were too permissive, allowing any authenticated user to read sensitive club settings (including passwords) and modify other players' availabilities or their own roles.
+**Learning:** The CSRF utility used a placeholder implementation that was never upgraded to a secure version. Firestore rules were initially set to allow wide access to facilitate development but weren't tightened for production.
+**Prevention:** Always use cryptographically secure HMACs for token generation. Enforce the principle of least privilege in Firestore rules by using `request.resource.data.diff()` to restrict field-level updates and verifying ownership of specific data.

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,11 +30,18 @@ service cloud.firestore {
     // ============================================
     // Collection: users
     // ============================================
-    // Les utilisateurs peuvent créer/mettre à jour leur propre profil
+    // Les utilisateurs peuvent créer leur profil (rôle player par défaut)
+    // Ils peuvent mettre à jour leur profil mais pas leur rôle ni leur statut coach
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, rôle player obligatoire
+      allow create: if isAuthenticated() && request.auth.uid == userId
+                    && request.resource.data.role == "player"
+                    && (request.resource.data.coachRequestStatus == "none" || !("coachRequestStatus" in request.resource.data));
+
+      // Mise à jour : uniquement son propre profil, interdit de modifier le rôle ou le statut coach
+      allow update: if isAuthenticated() && request.auth.uid == userId
+                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role', 'coachRequestStatus']);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +118,17 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture : les joueurs ne peuvent mettre à jour que leurs propres disponibilités
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow create: if isCoach() || (isAuthenticated() && (
+        (request.resource.data.playerId == request.auth.uid) ||
+        (request.resource.data.players.keys().hasOnly([request.auth.uid]))
+      ));
+      allow update: if isCoach() || (isAuthenticated() && (
+        (request.resource.data.playerId == request.auth.uid) ||
+        (request.resource.data.players.diff(resource.data.players).affectedKeys().hasOnly([request.auth.uid]))
+      ));
     }
     
     // ============================================
@@ -130,17 +144,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Accès strictement réservé aux admins car contient des données sensibles (tokens, passwords)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================

--- a/src/lib/auth/csrf-utils.ts
+++ b/src/lib/auth/csrf-utils.ts
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import crypto from "crypto";
 
 /**
  * Génère un token CSRF basé sur l'UID de l'utilisateur et un secret.
@@ -15,10 +16,15 @@ export async function generateCSRFToken(uid: string): Promise<string> {
     );
   }
   
-  // Créer un token simple basé sur l'UID et un timestamp
-  // En production, utilisez une bibliothèque comme `crypto` pour un hash plus sécurisé
-  const timestamp = Date.now();
-  const token = Buffer.from(`${uid}:${timestamp}:${secret}`).toString("base64");
+  // Créer un token basé sur l'UID, un timestamp et une signature HMAC
+  // 🛡️ Sentinel: Utilisation d'un HMAC pour éviter de fuiter le secret dans le token
+  const timestamp = Date.now().toString();
+  const hmac = crypto.createHmac("sha256", secret);
+  hmac.update(`${uid}:${timestamp}`);
+  const signature = hmac.digest("hex");
+
+  // Le token contient l'UID, le timestamp et la signature, mais PAS le secret
+  const token = Buffer.from(`${uid}:${timestamp}:${signature}`).toString("base64");
   
   return token;
 }
@@ -55,21 +61,31 @@ export async function validateCSRFToken(
       return false;
     }
 
-    // Décoder le token fourni pour extraire l'UID et le timestamp
+    // Décoder le token fourni pour extraire l'UID, le timestamp et la signature
     try {
       const decoded = Buffer.from(providedToken, "base64").toString("utf-8");
-      const [tokenUid, timestamp] = decoded.split(":");
+      const [tokenUid, timestamp, signature] = decoded.split(":");
       
+      if (!tokenUid || !timestamp || !signature) {
+        return false;
+      }
+
       // Si un UID est fourni, vérifier qu'il correspond
       if (uid && tokenUid !== uid) {
         return false;
       }
 
-      // Re-générer le token attendu avec le secret
-      const expectedToken = Buffer.from(`${tokenUid}:${timestamp}:${secret}`).toString("base64");
+      // 🛡️ Sentinel: Re-vérifier la signature HMAC
+      const hmac = crypto.createHmac("sha256", secret);
+      hmac.update(`${tokenUid}:${timestamp}`);
+      const expectedSignature = hmac.digest("hex");
       
-      // Comparer les tokens
-      return providedToken === expectedToken && providedToken === csrfCookie;
+      if (signature !== expectedSignature) {
+        return false;
+      }
+
+      // Comparer avec le cookie pour s'assurer de la cohérence
+      return providedToken === csrfCookie;
     } catch {
       // Si le décodage échoue, le token est invalide
       return false;


### PR DESCRIPTION
🚨 Severity: CRITICAL/HIGH
💡 Vulnerability: 
1. CSRF token generation was leaking the `CSRF_SECRET` via simple Base64 encoding.
2. Firestore rules allowed any authenticated user to read sensitive `clubSettings` (including passwords) and modify other players' availabilities.
3. Users could modify their own `role` and `coachRequestStatus` in Firestore.

🎯 Impact: 
1. CSRF protection could be bypassed if the secret was extracted.
2. Unauthorized access to sensitive credentials and Discord webhooks.
3. Data integrity risk for availabilities.
4. Potential UI-level privilege escalation.

🔧 Fix: 
1. Implemented HMAC-SHA256 for CSRF token generation and validation in `src/lib/auth/csrf-utils.ts`.
2. Restricted `clubSettings` to admins only in `firestore.rules`.
3. Enforced ownership checks for `availabilities` updates in `firestore.rules`.
4. Blocked manual updates to `role` and `coachRequestStatus` in Firestore rules.

✅ Verification: 
1. Manual code review confirmed HMAC implementation and rule logic.
2. `npm test` passed successfully.

---
*PR created automatically by Jules for task [16646244750521148487](https://jules.google.com/task/16646244750521148487) started by @omichalo*