### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Firestore access control vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - [CRITICAL] Permissive Firestore Rules leading to Privilege Escalation and Secret Exposure
+**Vulnerability:** The `/users` collection allowed users to modify their own `role` field. The `/availabilities` collection allowed any authenticated user to write to any document. The `/clubSettings` collection allowed any authenticated user to read sensitive secrets (FFTT password, Discord webhooks).
+**Learning:** Security rules were missing field-level validation and proper role-based access control, assuming frontend logic would prevent unauthorized actions.
+**Prevention:** Always enforce "least privilege" in Firestore rules. Use `affectedKeys()` to protect sensitive fields and restrict read/write access to the minimum required roles (e.g., `isAdmin()` for settings, `isCoach()` for shared management data).

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,8 +33,15 @@ service cloud.firestore {
     // Les utilisateurs peuvent créer/mettre à jour leur propre profil
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, avec des valeurs par défaut sécurisées
+      allow create: if isAuthenticated() && request.auth.uid == userId
+                    && request.resource.data.role == 'player'
+                    && (request.resource.data.coachRequestStatus == 'none' || request.resource.data.coachRequestStatus == 'pending');
+
+      // Mise à jour : uniquement son propre profil, sans pouvoir modifier les champs de privilèges
+      allow update: if isAuthenticated() && request.auth.uid == userId
+                    && !request.resource.data.diff(resource.data).affectedKeys()
+                        .hasAny(['role', 'coachRequestStatus', 'coachRequestHandledAt', 'coachRequestHandledBy']);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +118,10 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture uniquement pour les admins/coaches (les joueurs utilisent le bot Discord ou passent par un admin)
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow write: if isCoach();
     }
     
     // ============================================
@@ -130,17 +137,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture réservées aux administrateurs (contient des secrets comme FFTT password et Discord webhooks)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================


### PR DESCRIPTION
🛡️ Sentinel here. I've audited the Firestore security rules and found several critical vulnerabilities that I've now fixed.

### 🚨 Severity: CRITICAL/HIGH

### 💡 Vulnerabilities:
1. **Privilege Escalation**: Users could set their own `role` to `admin` in their Firestore document.
2. **Broken Access Control**: Any authenticated user could overwrite ANY availability document, potentially sabotaging team organization.
3. **Sensitive Data Exposure**: `clubSettings` containing FFTT passwords and Discord webhooks were readable by any logged-in player.

### 🔧 Fix:
- Added field-level validation for the `users` collection to prevent self-elevation.
- Restricted `availabilities` write access to the `coach` role.
- Restricted `clubSettings` and `club_settings` read/write access to the `admin` role.

### ✅ Verification:
- Ran `npm test` and `npm run lint` (passed).
- Verified `firestore.rules` content manually.
- Recorded the pattern in `.jules/sentinel.md` for future prevention.


---
*PR created automatically by Jules for task [14263597574010554444](https://jules.google.com/task/14263597574010554444) started by @omichalo*