### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix multiple privilege escalation and data exposure vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Privilege Escalation via Firestore and Session Verify]
+**Vulnerability:** Users could escalate their own privileges by modifying their 'role' field in their Firestore user document, which was then trusted by the session verification API.
+**Learning:** Firestore rules that allow a user to update their own document without field-level restrictions are dangerous when those documents contain authorization data. Furthermore, the application layer should always prioritize cryptographically signed claims (JWT/Custom Claims) over mutable database fields for security-critical information.
+**Prevention:** Use `affectedKeys().hasAny([...])` in Firestore rules to protect sensitive fields. Always prioritize decoded token claims in session verification logic.

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,8 +33,16 @@ service cloud.firestore {
     // Les utilisateurs peuvent créer/mettre à jour leur propre profil
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil avec rôle et statut par défaut
+      allow create: if isAuthenticated() && request.auth.uid == userId
+                    && request.resource.data.role == "player"
+                    && request.resource.data.coachRequestStatus == "none";
+
+      // Mise à jour : uniquement son propre profil, sans modifier les champs de rôle ou de statut
+      // Ces champs doivent être modifiés via des API sécurisées utilisant l'Admin SDK
+      allow update: if isAuthenticated() && request.auth.uid == userId
+                    && !request.resource.data.diff(resource.data).affectedKeys()
+                      .hasAny(["role", "coachRequestStatus", "coachRequestHandledBy", "coachRequestHandledAt", "coachRequestUpdatedAt", "playerId"]);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +119,10 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture uniquement pour les admins/coaches (les joueurs utilisent Discord)
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow write: if isCoach();
     }
     
     // ============================================
@@ -130,17 +138,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture strictement réservées aux admins pour protéger les secrets (webhooks, FFTT)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -93,10 +93,11 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      // Prioriser les données du token (custom claims) pour la sécurité et prévenir l'escalade de privilèges
+      role: (decoded.role as string | undefined) || (userData?.role as string | undefined) || "player",
       coachRequestStatus:
+        (decoded.coachRequestStatus as string | undefined) ||
         (userData?.coachRequestStatus as string | undefined) ||
-        decoded.coachRequestStatus ||
         "none",
       coachRequestMessage: (userData?.coachRequestMessage as string | undefined) || null,
       coachRequestUpdatedAt,


### PR DESCRIPTION
Identified and fixed a critical privilege escalation path where users could modify their own 'role' in Firestore and have it trusted by the session verification API. Also hardened access to sensitive collections like 'clubSettings' and 'availabilities'.

---
*PR created automatically by Jules for task [9082085047106347977](https://jules.google.com/task/9082085047106347977) started by @omichalo*