### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix privilege escalation and IDOR in Firestore rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel 🛡️ - Security Journal
+
+## 2025-05-15 - Firestore Privilege Escalation and IDOR on Maps
+**Vulnerability:** Permissive Firestore rules allowed any authenticated user to change their own role in the `/users` collection and modify any player's availability in the `/availabilities` collection (IDOR). Additionally, sensitive club credentials in `/clubSettings` were readable by all users.
+**Learning:** In applications using a mix of Custom Claims and Firestore documents for user state, rules must explicitly block modification of sensitive fields using `request.resource.data.diff(resource.data).affectedKeys()`. For documents containing maps (like `/availabilities`), the rule must verify that only the key corresponding to the user's UID is being modified.
+**Prevention:** Always use `hasOnly` or `hasAny` on `affectedKeys()` to restrict which fields a user can update. Ensure that Custom Claims are prioritized as the source of truth in session verification APIs.

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,8 +33,15 @@ service cloud.firestore {
     // Les utilisateurs peuvent créer/mettre à jour leur propre profil
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil avec rôle par défaut
+      allow create: if isAuthenticated() && request.auth.uid == userId
+                    && request.resource.data.role == "player"
+                    && request.resource.data.coachRequestStatus == "none";
+
+      // Mise à jour : uniquement son propre profil, sans changer le rôle ou le statut de demande coach
+      allow update: if isAuthenticated() && request.auth.uid == userId
+                    && !request.resource.data.diff(resource.data).affectedKeys()
+                        .hasAny(["role", "coachRequestStatus", "coachRequestHandledBy", "coachRequestHandledAt"]);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -111,10 +118,19 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture : Coaches/Admins peuvent tout faire.
+    // Les joueurs peuvent créer un document s'ils n'incluent que leur propre ID dans players,
+    // ou mettre à jour un document existant en ne modifiant que leur propre entrée.
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow create: if isAuthenticated()
+                    && (isCoach() || (request.resource.data.players.keys().hasOnly([request.auth.uid])));
+      allow update: if isCoach()
+                    || (isAuthenticated()
+                        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(["players", "updatedAt"])
+                        && request.resource.data.players.diff(resource.data.players).affectedKeys().hasOnly([request.auth.uid])
+                       );
+      allow delete: if isCoach();
     }
     
     // ============================================
@@ -130,17 +146,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture strictement réservées aux admins (contient des secrets FFTT/Discord)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -93,10 +93,11 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      // Prioriser les données du token (claims) qui sont la source de vérité pour l'authentification
+      role: (decoded.role as string | undefined) || (userData?.role as string | undefined) || "player",
       coachRequestStatus:
+        (decoded.coachRequestStatus as string | undefined) ||
         (userData?.coachRequestStatus as string | undefined) ||
-        decoded.coachRequestStatus ||
         "none",
       coachRequestMessage: (userData?.coachRequestMessage as string | undefined) || null,
       coachRequestUpdatedAt,


### PR DESCRIPTION
🛡️ Sentinel: Security hardening for Firestore and session verification.

🚨 Severity: CRITICAL/HIGH
💡 Vulnerability:
1. Privilege Escalation: Users could change their own roles in Firestore.
2. IDOR: Users could modify availability data for any other player.
3. Information Disclosure: Sensitive FFTT and Discord credentials were readable by any authenticated user.
4. Session Weakness: The verify API trusted Firestore data more than Custom Claims for roles.

🎯 Impact: Malicious users could become admins, disrupt availability tracking for the entire club, or steal API credentials.

🔧 Fix:
- Enhanced `firestore.rules` with strict `affectedKeys()` checks.
- Restricted `clubSettings` read access.
- Updated `src/app/api/session/verify/route.ts` to prioritize Custom Claims.

✅ Verification:
- All tests passed (`npm test`).
- Code review confirmed the fix is correct and follows best practices.

---
*PR created automatically by Jules for task [9580192625273292254](https://jules.google.com/task/9580192625273292254) started by @omichalo*