### PR TITLE
🛡️ Sentinel: [HIGH] Restrict access to club settings and add CSRF protection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -130,17 +130,15 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture strictement réservées aux admins
+    // Contient des secrets (mots de passe FFTT, webhooks Discord)
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================

--- a/src/app/api/coach/request/route.ts
+++ b/src/app/api/coach/request/route.ts
@@ -3,9 +3,22 @@ import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, COACH_REQUEST_STATUS, resolveRole } from "@/lib/auth/roles";
 import { FieldValue } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
 
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Invalid origin",
+          message: "Requête non autorisée",
+        },
+        { status: 403 }
+      );
+    }
+
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Security Enhancements

🚨 Severity: HIGH
💡 Vulnerability: 
1. Unauthorized exposure of sensitive configuration: The `clubSettings` collection, which contains FFTT passwords and Discord webhook URLs, was readable by any authenticated user.
2. Missing CSRF protection: The `/api/coach/request` endpoint was vulnerable to cross-site request forgery as it lacked origin validation.

🎯 Impact:
- Attackers with any authenticated account could have extracted administrative credentials and webhook secrets.
- Malicious websites could have triggered unauthorized coach requests on behalf of users.

🔧 Fix:
- Updated `firestore.rules` to strictly limit `clubSettings` (and alias `club_settings`) to the `admin` role.
- Integrated `validateOrigin` from the project's CSRF utility into the coach request API handler.

✅ Verification:
- Verified rules update via manual inspection of `firestore.rules`.
- Verified API route logic and imports via `npm run check:dev` (lint + type-check).
- Confirmed no regressions by running the full test suite (`npm test`).

---
*PR created automatically by Jules for task [17271952371893004190](https://jules.google.com/task/17271952371893004190) started by @omichalo*