### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability and harden token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-02 - Secure CSRF Token Comparison
+**Vulnerability:** Timing attacks on CSRF token validation.
+**Learning:** Standard string comparison (`===`) in Node.js is not constant-time, allowing potential attackers to guess tokens by measuring the time taken for validation.
+**Prevention:** Always use `crypto.timingSafeEqual` for comparing sensitive tokens or hashes to ensure constant-time validation.

--- a/src/app/api/coach/request/route.ts
+++ b/src/app/api/coach/request/route.ts
@@ -3,9 +3,18 @@ import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, COACH_REQUEST_STATUS, resolveRole } from "@/lib/auth/roles";
 import { FieldValue } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
 
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Origine non autorisée" },
+        { status: 403 }
+      );
+    }
+
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {

--- a/src/lib/auth/csrf-utils.ts
+++ b/src/lib/auth/csrf-utils.ts
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { timingSafeEqual } from "node:crypto";
 
 /**
  * Génère un token CSRF basé sur l'UID de l'utilisateur et un secret.
@@ -68,8 +69,20 @@ export async function validateCSRFToken(
       // Re-générer le token attendu avec le secret
       const expectedToken = Buffer.from(`${tokenUid}:${timestamp}:${secret}`).toString("base64");
       
-      // Comparer les tokens
-      return providedToken === expectedToken && providedToken === csrfCookie;
+      // Comparer les tokens de manière sécurisée contre les attaques temporelles
+      const providedBuffer = Buffer.from(providedToken);
+      const expectedBuffer = Buffer.from(expectedToken);
+      const cookieBuffer = Buffer.from(csrfCookie);
+
+      const isExpectedMatch =
+        providedBuffer.length === expectedBuffer.length &&
+        timingSafeEqual(providedBuffer, expectedBuffer);
+
+      const isCookieMatch =
+        providedBuffer.length === cookieBuffer.length &&
+        timingSafeEqual(providedBuffer, cookieBuffer);
+
+      return isExpectedMatch && isCookieMatch;
     } catch {
       // Si le décodage échoue, le token est invalide
       return false;


### PR DESCRIPTION
This PR addresses two security concerns:
1. **CSRF Protection**: Added `validateOrigin` check to the `POST /api/coach/request` endpoint to ensure requests come from authorized domains.
2. **Timing Attack Prevention**: Hardened `validateCSRFToken` by using `timingSafeEqual` for constant-time comparison of CSRF tokens, preventing potential token enumeration via timing analysis.

A new entry has been added to `.jules/sentinel.md` documenting the timing attack learning.

---
*PR created automatically by Jules for task [2855703381334342212](https://jules.google.com/task/2855703381334342212) started by @omichalo*