### PR TITLE
🛡️ Sentinel: Harden Firestore Security Rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Broken Access Control in Availabilities
+**Vulnerability:** Any authenticated user could create, update, or delete any availability document in the `availabilities` collection, leading to potential data loss or tampering of other players' data.
+**Learning:** Broad `allow write: if isAuthenticated();` rules are dangerous in collections that store multi-user data. Granular field-level validation using `request.resource.data.diff(resource.data).affectedKeys()` is necessary to enforce the principle of least privilege.
+**Prevention:** Always use `affectedKeys()` and `diff()` to restrict updates to user-specific fields, and fetch user-related identifiers (like `playerId`) from a trusted source (e.g., the user's document) within the rule.

--- a/firestore.rules
+++ b/firestore.rules
@@ -111,10 +111,20 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Écriture :
+    // - Les admins/coaches peuvent tout faire
+    // - Les joueurs peuvent uniquement mettre à jour leur PROPRE disponibilité dans la map 'players'
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow create: if isCoach();
+      allow update: if isCoach() || (
+        isAuthenticated() &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['players', 'updatedAt']) &&
+        request.resource.data.players.diff(resource.data.players).affectedKeys().hasOnly([
+          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.playerId
+        ])
+      );
+      allow delete: if isCoach();
     }
     
     // ============================================
@@ -130,17 +140,14 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture strictement réservées aux admins
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================


### PR DESCRIPTION
I have identified and fixed a high-priority security issue in the Firestore security rules.

### 🚨 Severity: HIGH

### 💡 Vulnerability:
1.  **Broken Access Control**: Any authenticated user could previously create, update, or delete any document in the `availabilities` collection. This allowed any player to tamper with or delete the availability data of any other player.
2.  **Sensitive Data Exposure**: The `clubSettings` collection, which can contain sensitive information like Discord webhooks and FFTT credentials, was readable by any authenticated user.

### 🔧 Fix:
- **`availabilities`**: 
    - Restricted `create` and `delete` to users with `admin` or `coach` roles.
    - Implemented granular `update` rules that allow regular users to only modify their own entry within the `players` map. It verifies the user's `playerId` by fetching it from their user document.
    - Prevented modification of other fields like `updatedAt` (though `updatedAt` is allowed to be updated) and other metadata.
- **`clubSettings` & `club_settings`**:
    - Restricted both `read` and `write` access to users with the `admin` role.

### ✅ Verification:
- Verified `firestore.rules` logic.
- Ran `npm run check:dev` (lint & type-check) - Passed.
- Ran `npm test` - Passed.
- Confirmed `clubSettings` is currently unused in the frontend via grep, minimizing regression risk.

---
*PR created automatically by Jules for task [16487316553040808283](https://jules.google.com/task/16487316553040808283) started by @omichalo*