### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing authentication and authorization in players API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [CRITICAL] Missing Authentication and Authorization in Player API
+**Vulnerability:** The `/api/fftt/players` endpoint was entirely public, exposing PII of all club players from Firestore without any session verification or role checks.
+**Learning:** Middleware configurations (`middleware.ts`) that exclude `/api` routes can leave endpoints vulnerable if developers assume global protection. Each API route must explicitly handle its own security if not covered by a unified middleware/guard.
+**Prevention:** Implement a standard authentication and authorization check in all sensitive API routes. Use consistent patterns like `adminAuth.verifySessionCookie` and `hasAnyRole` to enforce access control.

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jest-environment-jsdom",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
-  moduleNameMapping: {
+  moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   collectCoverageFrom: [

--- a/src/__tests__/api-fftt-players.test.ts
+++ b/src/__tests__/api-fftt-players.test.ts
@@ -1,0 +1,122 @@
+import { GET } from "@/app/api/fftt/players/route";
+import { adminAuth } from "@/lib/firebase-admin";
+import { cookies } from "next/headers";
+
+// Mock next/headers
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+interface MockResponse {
+  status: number;
+  json: () => Promise<unknown>;
+  headers: {
+    get: (name: string) => string | null;
+    set: jest.Mock;
+  };
+}
+
+// Mock next/server
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      headers: {
+        get: jest.fn((name) => init?.headers?.[name] || null),
+        set: jest.fn(),
+      },
+    })),
+  },
+}));
+
+// Mock firebase-admin/auth via @/lib/firebase-admin
+jest.mock("@/lib/firebase-admin", () => ({
+  adminAuth: {
+    verifySessionCookie: jest.fn(),
+  },
+  initializeFirebaseAdmin: jest.fn().mockResolvedValue(undefined),
+  getFirestoreAdmin: jest.fn().mockReturnValue({
+    collection: jest.fn().mockReturnValue({
+      get: jest.fn().mockResolvedValue({
+        forEach: jest.fn(),
+      }),
+    }),
+  }),
+}));
+
+describe("GET /api/fftt/players", () => {
+  let mockCookies: { get: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCookies = {
+      get: jest.fn(),
+    };
+    (cookies as jest.Mock).mockResolvedValue(mockCookies);
+  });
+
+  it("should return 400 if clubCode is missing", async () => {
+    const req = { url: "http://localhost/api/fftt/players" } as unknown as Request;
+    const res = await GET(req) as unknown as MockResponse;
+    const data = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBe("Club code parameter is required");
+  });
+
+  it("should return 401 if session cookie is missing", async () => {
+    const req = { url: "http://localhost/api/fftt/players?clubCode=123" } as unknown as Request;
+    mockCookies.get.mockReturnValue(undefined);
+
+    const res = await GET(req) as unknown as MockResponse;
+    const data = await res.json() as { error: string };
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBe("Authentification requise");
+  });
+
+  it("should return 403 if user does not have required role", async () => {
+    const req = { url: "http://localhost/api/fftt/players?clubCode=123" } as unknown as Request;
+    mockCookies.get.mockReturnValue({ value: "valid-session" });
+    (adminAuth.verifySessionCookie as jest.Mock).mockResolvedValue({
+      uid: "user123",
+      role: "player",
+    });
+
+    const res = await GET(req) as unknown as MockResponse;
+    const data = await res.json() as { error: string };
+
+    expect(res.status).toBe(403);
+    expect(data.error).toBe("Accès refusé");
+  });
+
+  it("should return 200 if user is admin", async () => {
+    const req = { url: "http://localhost/api/fftt/players?clubCode=123" } as unknown as Request;
+    mockCookies.get.mockReturnValue({ value: "valid-session" });
+    (adminAuth.verifySessionCookie as jest.Mock).mockResolvedValue({
+      uid: "admin123",
+      role: "admin",
+    });
+
+    const res = await GET(req) as unknown as MockResponse;
+    expect(res.status).toBe(200);
+
+    // Check security headers
+    expect(res.headers.set).toHaveBeenCalledWith("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    expect(res.headers.set).toHaveBeenCalledWith("Pragma", "no-cache");
+    expect(res.headers.set).toHaveBeenCalledWith("Expires", "0");
+  });
+
+  it("should return 200 if user is coach", async () => {
+    const req = { url: "http://localhost/api/fftt/players?clubCode=123" } as unknown as Request;
+    mockCookies.get.mockReturnValue({ value: "valid-session" });
+    (adminAuth.verifySessionCookie as jest.Mock).mockResolvedValue({
+      uid: "coach123",
+      role: "coach",
+    });
+
+    const res = await GET(req) as unknown as MockResponse;
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/fftt/players/route.ts
+++ b/src/app/api/fftt/players/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
-import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { cookies } from "next/headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import type { Player } from "@/types";
 
 export async function GET(req: Request) {
@@ -14,9 +16,29 @@ export async function GET(req: Request) {
       );
     }
 
-    await initializeFirebaseAdmin();
-    const firestore = getFirestoreAdmin();
+    // 🛡️ Sentinel: Session verification to prevent unauthorized access to player data
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
 
+    await initializeFirebaseAdmin();
+
+    // 🛡️ Sentinel: Role-based access control (Admin/Coach only)
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return NextResponse.json(
+        { error: "Accès refusé" },
+        { status: 403 }
+      );
+    }
+
+    const firestore = getFirestoreAdmin();
     const playersSnapshot = await firestore.collection("players").get();
 
     const players: Player[] = [];
@@ -46,7 +68,7 @@ export async function GET(req: Request) {
 
     console.log(`📊 [app/api/fftt/players] ${players.length} joueurs récupérés depuis Firestore`);
 
-    return NextResponse.json(
+    const res = NextResponse.json(
       {
         players,
         total: players.length,
@@ -54,6 +76,13 @@ export async function GET(req: Request) {
       },
       { status: 200 }
     );
+
+    // 🛡️ Sentinel: Anti-caching headers for sensitive data
+    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    res.headers.set("Pragma", "no-cache");
+    res.headers.set("Expires", "0");
+
+    return res;
   } catch (error) {
     console.error("[app/api/fftt/players] Firestore Error:", error);
     return NextResponse.json(
@@ -65,5 +94,3 @@ export async function GET(req: Request) {
     );
   }
 }
-
-


### PR DESCRIPTION
I have identified and fixed a critical security vulnerability in the \`/api/fftt/players\` endpoint. Previously, this endpoint was publicly accessible, exposing player PII from Firestore.

### Changes:
1.  **Authentication & Authorization:** Implemented \`adminAuth.verifySessionCookie\` and \`hasAnyRole\` checks in \`src/app/api/fftt/players/route.ts\` to restrict access to \`ADMIN\` and \`COACH\` roles.
2.  **Anti-Caching Headers:** Added \`Cache-Control\`, \`Pragma\`, and \`Expires\` headers to prevent sensitive data from being cached by browsers or proxies.
3.  **Test Configuration Fix:** Corrected a typo in \`jest.config.js\` (\`moduleNameMapping\` -> \`moduleNameMapper\`) which was preventing Jest from resolving \`@/\` path aliases.
4.  **Security Testing:** Created a new test suite \`src/__tests__/api-fftt-players.test.ts\` that verifies:
    *   400 error for missing club code.
    *   401 error for missing session cookie.
    *   403 error for unauthorized roles (e.g., \`player\`).
    *   200 success for \`admin\` and \`coach\` roles with correct security headers.
5.  **Audit/Journal:** Added a security learning entry in \`.jules/sentinel.md\`.

The core logic changes are minimal and follow established patterns in the codebase. All tests pass and linting is clean.

---
*PR created automatically by Jules for task [5252185857467353080](https://jules.google.com/task/5252185857467353080) started by @omichalo*