### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CSRF secret leak and harden token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-20 - Insecure CSRF token implementation exposing secrets
+**Vulnerability:** The initial CSRF token implementation was a simple base64-encoded string concatenation of `uid:timestamp:secret`.
+**Learning:** This approach allowed anyone with a valid CSRF token to decode it and retrieve the `CSRF_SECRET` directly from the token payload.
+**Prevention:** Always use HMAC-SHA256 signing for tokens that incorporate secrets, and never include the secret itself in the payload. Use timing-safe comparison (`crypto.timingSafeEqual`) for validation to prevent timing attacks.

--- a/src/__tests__/csrf-utils.test.ts
+++ b/src/__tests__/csrf-utils.test.ts
@@ -1,0 +1,83 @@
+import { generateCSRFToken, validateCSRFToken } from "@/lib/auth/csrf-utils";
+import { cookies } from "next/headers";
+
+// Mock next/headers
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+describe("CSRF Utilities", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, CSRF_SECRET: "test_csrf_secret_for_unit_tests" };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("should generate a signed token that does not contain the secret", async () => {
+    const uid = "user123";
+    const token = await generateCSRFToken(uid);
+
+    expect(token).toContain(".");
+    const [payloadB64] = token.split(".");
+    const payload = Buffer.from(payloadB64, "base64").toString("utf-8");
+
+    expect(payload).toContain(uid);
+    expect(token).not.toContain("test_csrf_secret_for_unit_tests");
+  });
+
+  it("should validate a correct token", async () => {
+    const uid = "user123";
+    const token = await generateCSRFToken(uid);
+
+    (cookies as jest.Mock).mockReturnValue(Promise.resolve({
+      get: (name: string) => name === "__csrf" ? { value: token } : undefined
+    }));
+
+    const isValid = await validateCSRFToken(token, uid);
+    expect(isValid).toBe(true);
+  });
+
+  it("should fail validation if the token is tampered with", async () => {
+    const uid = "user123";
+    const token = await generateCSRFToken(uid);
+    const tamperedToken = token.substring(0, token.length - 1) + (token.endsWith("A") ? "B" : "A");
+
+    (cookies as jest.Mock).mockReturnValue(Promise.resolve({
+      get: (name: string) => name === "__csrf" ? { value: tamperedToken } : undefined
+    }));
+
+    const isValid = await validateCSRFToken(tamperedToken, uid);
+    expect(isValid).toBe(false);
+  });
+
+  it("should fail validation if the UID does not match", async () => {
+    const uid = "user123";
+    const token = await generateCSRFToken(uid);
+
+    (cookies as jest.Mock).mockReturnValue(Promise.resolve({
+      get: (name: string) => name === "__csrf" ? { value: token } : undefined
+    }));
+
+    const isValid = await validateCSRFToken(token, "wrongUser");
+    expect(isValid).toBe(false);
+  });
+
+  it("should fail validation if the secret changes", async () => {
+    const uid = "user123";
+    const token = await generateCSRFToken(uid);
+
+    process.env.CSRF_SECRET = "different_secret";
+
+    (cookies as jest.Mock).mockReturnValue(Promise.resolve({
+      get: (name: string) => name === "__csrf" ? { value: token } : undefined
+    }));
+
+    const isValid = await validateCSRFToken(token, uid);
+    expect(isValid).toBe(false);
+  });
+});

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
+import { generateCSRFToken } from "@/lib/auth/csrf-utils";
 
 export const runtime = "nodejs";
 
@@ -80,6 +81,20 @@ export async function POST(req: Request) {
       name: "__session",
       value: sessionCookie,
       httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? "strict" : "lax",
+      path: "/",
+      maxAge: Math.floor((14 * 24 * 60 * 60 * 1000) / 1000),
+    });
+
+    // Générer un token CSRF signé
+    const csrfToken = await generateCSRFToken(decoded.uid);
+    // Le cookie CSRF n'est PAS httpOnly pour permettre au client de le lire
+    // et de l'envoyer dans le header X-CSRF-Token (Double-Submit Cookie)
+    res.cookies.set({
+      name: "__csrf",
+      value: csrfToken,
+      httpOnly: false,
       secure: isProduction,
       sameSite: isProduction ? "strict" : "lax",
       path: "/",

--- a/src/lib/auth/csrf-utils.ts
+++ b/src/lib/auth/csrf-utils.ts
@@ -1,79 +1,67 @@
 import { cookies } from "next/headers";
+import crypto from "node:crypto";
 
 /**
- * Génère un token CSRF basé sur l'UID de l'utilisateur et un secret.
- * Le token est stocké dans un cookie HTTP-only pour éviter les attaques XSS.
+ * Génère un token CSRF sécurisé (HMAC-SHA256).
+ * Empêche la fuite du secret CSRF présent dans l'ancienne implémentation base64.
  */
 export async function generateCSRFToken(uid: string): Promise<string> {
-  // Le secret CSRF doit être défini via la variable d'environnement CSRF_SECRET
   const secret = process.env.CSRF_SECRET;
   
   if (!secret) {
-    throw new Error(
-      "CSRF_SECRET environment variable is required. " +
-      "Please configure it in your environment variables or Firebase App Hosting secrets."
-    );
+    throw new Error("CSRF_SECRET environment variable is required.");
   }
   
-  // Créer un token simple basé sur l'UID et un timestamp
-  // En production, utilisez une bibliothèque comme `crypto` pour un hash plus sécurisé
   const timestamp = Date.now();
-  const token = Buffer.from(`${uid}:${timestamp}:${secret}`).toString("base64");
+  const payload = `${uid}:${timestamp}`;
+  // Signature HMAC-SHA256 pour éviter que le secret ne soit décodable depuis le token
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(payload)
+    .digest("base64");
   
-  return token;
+  return `${Buffer.from(payload).toString("base64")}.${signature}`;
 }
 
 /**
- * Valide un token CSRF en le comparant avec celui stocké dans le cookie.
- * @param providedToken - Le token fourni par le client
- * @param uid - L'UID de l'utilisateur (optionnel, extrait du cookie si non fourni)
+ * Valide un token CSRF avec une comparaison timing-safe.
  */
 export async function validateCSRFToken(
   providedToken: string | null | undefined,
   uid?: string
 ): Promise<boolean> {
-  if (!providedToken) {
-    return false;
-  }
+  if (!providedToken) return false;
 
   try {
     const cookieStore = await cookies();
     const csrfCookie = cookieStore.get("__csrf")?.value;
+    if (!csrfCookie || providedToken !== csrfCookie) return false;
 
-    if (!csrfCookie) {
-      return false;
-    }
-
-    // Le secret CSRF doit être défini via la variable d'environnement CSRF_SECRET
     const secret = process.env.CSRF_SECRET;
-    
-    if (!secret) {
-      console.error(
-        "[CSRF] CSRF_SECRET environment variable is required for token validation. " +
-        "Please configure it in your environment variables or Firebase App Hosting secrets."
-      );
+    if (!secret) return false;
+
+    const [payloadB64, signature] = providedToken.split(".");
+    if (!payloadB64 || !signature) return false;
+
+    const payload = Buffer.from(payloadB64, "base64").toString("utf-8");
+    const [tokenUid] = payload.split(":");
+
+    if (uid && tokenUid !== uid) return false;
+
+    const expectedSignature = crypto
+      .createHmac("sha256", secret)
+      .update(payload)
+      .digest("base64");
+
+    const signatureBuffer = Buffer.from(signature);
+    const expectedSignatureBuffer = Buffer.from(expectedSignature);
+
+    // timingSafeEqual nécessite des buffers de même longueur
+    if (signatureBuffer.length !== expectedSignatureBuffer.length) {
       return false;
     }
 
-    // Décoder le token fourni pour extraire l'UID et le timestamp
-    try {
-      const decoded = Buffer.from(providedToken, "base64").toString("utf-8");
-      const [tokenUid, timestamp] = decoded.split(":");
-      
-      // Si un UID est fourni, vérifier qu'il correspond
-      if (uid && tokenUid !== uid) {
-        return false;
-      }
-
-      // Re-générer le token attendu avec le secret
-      const expectedToken = Buffer.from(`${tokenUid}:${timestamp}:${secret}`).toString("base64");
-      
-      // Comparer les tokens
-      return providedToken === expectedToken && providedToken === csrfCookie;
-    } catch {
-      // Si le décodage échoue, le token est invalide
-      return false;
-    }
+    return crypto.timingSafeEqual(signatureBuffer, expectedSignatureBuffer);
   } catch {
     return false;
   }


### PR DESCRIPTION
Hardened CSRF protection by replacing insecure base64 concatenation with HMAC-SHA256 signing and implementing timing-safe validation. Enabled CSRF token issuance in the session API and added regression tests. Added security journal entry for the fix.

---
*PR created automatically by Jules for task [4980623957140566386](https://jules.google.com/task/4980623957140566386) started by @omichalo*