### PR TITLE
🛡️ Sentinel: [HIGH] Fix unauthenticated players API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2026-03-27 - [HIGH] Unauthenticated access to player data
+**Vulnerability:** The `/api/fftt/players` endpoint was publicly accessible and did not require any authentication or authorization.
+**Learning:** Next.js middleware exclusions (like `/api`) can leave sensitive endpoints exposed if they don't implement their own checks.
+**Prevention:** Always implement authentication and authorization checks in API routes that handle sensitive data, especially when they are excluded from global middleware.

--- a/src/app/api/fftt/players/route.ts
+++ b/src/app/api/fftt/players/route.ts
@@ -1,9 +1,31 @@
 import { NextResponse } from "next/server";
-import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { cookies } from "next/headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import type { Player } from "@/types";
 
 export async function GET(req: Request) {
   try {
+    // Authentification et autorisation
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return NextResponse.json(
+        { error: "Accès refusé" },
+        { status: 403 }
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const clubCode = searchParams.get("clubCode");
 
@@ -46,7 +68,7 @@ export async function GET(req: Request) {
 
     console.log(`📊 [app/api/fftt/players] ${players.length} joueurs récupérés depuis Firestore`);
 
-    return NextResponse.json(
+    const res = NextResponse.json(
       {
         players,
         total: players.length,
@@ -54,6 +76,13 @@ export async function GET(req: Request) {
       },
       { status: 200 }
     );
+
+    // Sécurité: empêcher la mise en cache des données sensibles des joueurs
+    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    res.headers.set("Pragma", "no-cache");
+    res.headers.set("Expires", "0");
+
+    return res;
   } catch (error) {
     console.error("[app/api/fftt/players] Firestore Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
This PR secures the `/api/fftt/players` endpoint which was previously public. It now requires a valid session cookie and specific user roles (`ADMIN` or `COACH`).

### Changes:
- Added `adminAuth.verifySessionCookie` for authentication.
- Added `hasAnyRole` check for authorization.
- Added `Cache-Control`, `Pragma`, and `Expires` headers to prevent response caching.

### Verification:
- Manual test using `curl` confirms that unauthenticated requests now return a 401 Unauthorized status.
- Existing tests and linting passed successfully.

---
*PR created automatically by Jules for task [9905898482501990171](https://jules.google.com/task/9905898482501990171) started by @omichalo*