### PR TITLE
🛡️ Sentinel: [HIGH] Harden CSRF protection and fix Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jest-environment-jsdom",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
-  moduleNameMapping: {
+  moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   collectCoverageFrom: [

--- a/src/__tests__/csrf-utils.test.ts
+++ b/src/__tests__/csrf-utils.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+import { generateCSRFToken, validateCSRFToken } from "@/lib/auth/csrf-utils";
+import { cookies, headers } from "next/headers";
+
+// Mock next/headers
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+  headers: jest.fn(),
+}));
+
+describe("CSRF Utils", () => {
+  const SECRET = "test_csrf_secret_for_unit_tests";
+  const UID = "test-uid-123";
+
+  beforeAll(() => {
+    process.env.CSRF_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    delete process.env.CSRF_SECRET;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("generateCSRFToken", () => {
+    it("should generate a base64 encoded token with uid, timestamp and HMAC", async () => {
+      const token = await generateCSRFToken(UID);
+      expect(token).toBeDefined();
+      expect(typeof token).toBe("string");
+
+      const decoded = Buffer.from(token, "base64").toString("utf-8");
+      const parts = decoded.split(":");
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toBe(UID);
+      expect(parseInt(parts[1])).toBeGreaterThan(0);
+      expect(parts[2]).toHaveLength(64); // SHA256 hex signature
+    });
+
+    it("should throw error if CSRF_SECRET is missing", async () => {
+      const originalSecret = process.env.CSRF_SECRET;
+      delete process.env.CSRF_SECRET;
+
+      await expect(generateCSRFToken(UID)).rejects.toThrow("CSRF_SECRET environment variable is required");
+
+      process.env.CSRF_SECRET = originalSecret;
+    });
+  });
+
+  describe("validateCSRFToken", () => {
+    it("should validate a valid token matching the cookie", async () => {
+      const token = await generateCSRFToken(UID);
+
+      (cookies as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue({ value: token }),
+      });
+
+      const isValid = await validateCSRFToken(token, UID);
+      expect(isValid).toBe(true);
+    });
+
+    it("should validate a valid token from headers matching the cookie", async () => {
+      const token = await generateCSRFToken(UID);
+
+      (headers as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue(token),
+      });
+      (cookies as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue({ value: token }),
+      });
+
+      const isValid = await validateCSRFToken(undefined, UID);
+      expect(isValid).toBe(true);
+    });
+
+    it("should fail if token does not match cookie", async () => {
+      const token = await generateCSRFToken(UID);
+      // Attendre un peu pour que le timestamp soit différent
+      await new Promise(resolve => setTimeout(resolve, 2));
+      const differentToken = await generateCSRFToken(UID);
+
+      (cookies as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue({ value: differentToken }),
+      });
+
+      const isValid = await validateCSRFToken(token, UID);
+      expect(isValid).toBe(false);
+    });
+
+    it("should fail if UID does not match", async () => {
+      const token = await generateCSRFToken(UID);
+
+      (cookies as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue({ value: token }),
+      });
+
+      const isValid = await validateCSRFToken(token, "wrong-uid");
+      expect(isValid).toBe(false);
+    });
+
+    it("should fail if signature is invalid", async () => {
+      const timestamp = Date.now().toString();
+      const invalidToken = Buffer.from(`${UID}:${timestamp}:invalid-signature`).toString("base64");
+
+      (cookies as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue({ value: invalidToken }),
+      });
+
+      const isValid = await validateCSRFToken(invalidToken, UID);
+      expect(isValid).toBe(false);
+    });
+
+    it("should fail if token is malformed", async () => {
+      const malformedToken = Buffer.from("not-a-valid-token").toString("base64");
+
+      (cookies as jest.Mock).mockResolvedValue({
+        get: jest.fn().mockReturnValue({ value: malformedToken }),
+      });
+
+      const isValid = await validateCSRFToken(malformedToken, UID);
+      expect(isValid).toBe(false);
+    });
+  });
+});

--- a/src/app/api/admin/discord-availability-config/route.ts
+++ b/src/app/api/admin/discord-availability-config/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { validateOrigin, validateCSRFToken } from "@/lib/auth/csrf-utils";
 import {
   getFirestoreAdmin,
   initializeFirebaseAdmin,
@@ -93,6 +94,22 @@ export async function GET() {
  */
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin", message: "Requête non autorisée" },
+        { status: 403 }
+      );
+    }
+
+    // Valider le token CSRF pour le pattern Double-Submit Cookie
+    if (!(await validateCSRFToken())) {
+      return NextResponse.json(
+        { success: false, error: "Invalid CSRF token", message: "Session expirée ou invalide" },
+        { status: 403 }
+      );
+    }
+
     // Vérifier l'authentification
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;

--- a/src/app/api/coach/request/route.ts
+++ b/src/app/api/coach/request/route.ts
@@ -2,10 +2,27 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, COACH_REQUEST_STATUS, resolveRole } from "@/lib/auth/roles";
+import { validateOrigin, validateCSRFToken } from "@/lib/auth/csrf-utils";
 import { FieldValue } from "firebase-admin/firestore";
 
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin", message: "Requête non autorisée" },
+        { status: 403 }
+      );
+    }
+
+    // Valider le token CSRF pour le pattern Double-Submit Cookie
+    if (!(await validateCSRFToken())) {
+      return NextResponse.json(
+        { success: false, error: "Invalid CSRF token", message: "Session expirée ou invalide" },
+        { status: 403 }
+      );
+    }
+
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {

--- a/src/app/api/discord/send-message/route.ts
+++ b/src/app/api/discord/send-message/route.ts
@@ -2,11 +2,28 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { validateOrigin, validateCSRFToken } from "@/lib/auth/csrf-utils";
 
 const db = getFirestore();
 
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin", message: "Requête non autorisée" },
+        { status: 403 }
+      );
+    }
+
+    // Valider le token CSRF pour le pattern Double-Submit Cookie
+    if (!(await validateCSRFToken())) {
+      return NextResponse.json(
+        { success: false, error: "Invalid CSRF token", message: "Session expirée ou invalide" },
+        { status: 403 }
+      );
+    }
+
     // Configuration du bot Discord (vérifier à l'intérieur de la fonction)
     const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
     const DISCORD_SERVER_ID = process.env.DISCORD_SERVER_ID;

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
+import { generateCSRFToken } from "@/lib/auth/csrf-utils";
 
 export const runtime = "nodejs";
 
@@ -76,6 +77,17 @@ export async function POST(req: Request) {
     const res = NextResponse.json({ ok: true });
     // Normaliser les paramètres du cookie : Secure et SameSite=Strict en production
     const isProduction = process.env.NODE_ENV === "production";
+
+    // Générer un token CSRF pour le Double-Submit Cookie pattern
+    let csrfToken;
+    try {
+      csrfToken = await generateCSRFToken(decoded.uid);
+    } catch (error) {
+      console.error("[session] Erreur lors de la génération du token CSRF:", error);
+      // On continue quand même sans CSRF pour ne pas bloquer l'auth,
+      // mais les futures requêtes POST échoueront à la validation CSRF.
+    }
+
     res.cookies.set({
       name: "__session",
       value: sessionCookie,
@@ -85,6 +97,19 @@ export async function POST(req: Request) {
       path: "/",
       maxAge: Math.floor((14 * 24 * 60 * 60 * 1000) / 1000),
     });
+
+    if (csrfToken) {
+      res.cookies.set({
+        name: "__csrf",
+        value: csrfToken,
+        httpOnly: false, // Doit être accessible par le JS client pour être renvoyé dans un header
+        secure: isProduction,
+        sameSite: "lax", // Nécessaire pour que le cookie soit envoyé lors de redirections POST
+        path: "/",
+        maxAge: Math.floor((14 * 24 * 60 * 60 * 1000) / 1000),
+      });
+    }
+
     // Ajouter Cache-Control pour éviter la mise en cache
     res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
     res.headers.set("Pragma", "no-cache");
@@ -131,7 +156,7 @@ export async function DELETE() {
       }
     }
 
-    // Supprimer le cookie côté client avec les mêmes paramètres que la création
+    // Supprimer les cookies côté client avec les mêmes paramètres que la création
     const isProduction = process.env.NODE_ENV === "production";
     const res = NextResponse.json({ ok: true });
     res.cookies.set({
@@ -143,13 +168,22 @@ export async function DELETE() {
       path: "/",
       maxAge: 0,
     });
+    res.cookies.set({
+      name: "__csrf",
+      value: "",
+      httpOnly: false,
+      secure: isProduction,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+    });
     res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
     res.headers.set("Pragma", "no-cache");
     res.headers.set("Expires", "0");
     return res;
   } catch (error) {
     console.error("[session] Erreur lors de la déconnexion:", error);
-    // Même en cas d'erreur, on supprime le cookie côté client avec les mêmes paramètres
+    // Même en cas d'erreur, on supprime les cookies côté client avec les mêmes paramètres
     const isProduction = process.env.NODE_ENV === "production";
     const res = NextResponse.json({ ok: true });
     res.cookies.set({
@@ -158,6 +192,15 @@ export async function DELETE() {
       httpOnly: true,
       secure: isProduction,
       sameSite: isProduction ? "strict" : "lax",
+      path: "/",
+      maxAge: 0,
+    });
+    res.cookies.set({
+      name: "__csrf",
+      value: "",
+      httpOnly: false,
+      secure: isProduction,
+      sameSite: "lax",
       path: "/",
       maxAge: 0,
     });

--- a/src/lib/auth/csrf-utils.ts
+++ b/src/lib/auth/csrf-utils.ts
@@ -1,11 +1,11 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 /**
- * Génère un token CSRF basé sur l'UID de l'utilisateur et un secret.
- * Le token est stocké dans un cookie HTTP-only pour éviter les attaques XSS.
+ * Génère un token CSRF signé par HMAC-SHA256 basé sur l'UID de l'utilisateur et un timestamp.
+ * Le token est destiné à être stocké dans un cookie non-HTTP-only pour le pattern Double-Submit Cookie.
  */
 export async function generateCSRFToken(uid: string): Promise<string> {
-  // Le secret CSRF doit être défini via la variable d'environnement CSRF_SECRET
   const secret = process.env.CSRF_SECRET;
   
   if (!secret) {
@@ -15,65 +15,73 @@ export async function generateCSRFToken(uid: string): Promise<string> {
     );
   }
   
-  // Créer un token simple basé sur l'UID et un timestamp
-  // En production, utilisez une bibliothèque comme `crypto` pour un hash plus sécurisé
-  const timestamp = Date.now();
-  const token = Buffer.from(`${uid}:${timestamp}:${secret}`).toString("base64");
+  const timestamp = Date.now().toString();
+  const data = `${uid}:${timestamp}`;
   
-  return token;
+  // Signer les données avec HMAC-SHA256 pour empêcher toute altération
+  const signature = createHmac("sha256", secret).update(data).digest("hex");
+
+  // Le token final contient les données et la signature
+  return Buffer.from(`${data}:${signature}`).toString("base64");
 }
 
 /**
- * Valide un token CSRF en le comparant avec celui stocké dans le cookie.
- * @param providedToken - Le token fourni par le client
- * @param uid - L'UID de l'utilisateur (optionnel, extrait du cookie si non fourni)
+ * Valide un token CSRF en vérifiant sa signature HMAC et sa correspondance avec le cookie.
+ * @param providedToken - Le token fourni par le client (ex: header X-CSRF-Token)
+ * @param uid - L'UID de l'utilisateur attendu (optionnel)
  */
 export async function validateCSRFToken(
-  providedToken: string | null | undefined,
+  providedToken?: string | null,
   uid?: string
 ): Promise<boolean> {
-  if (!providedToken) {
-    return false;
+  // Si le token n'est pas passé explicitement, essayer de le récupérer depuis les headers
+  let token = providedToken;
+  if (!token) {
+    const headersList = await headers();
+    token = headersList.get("x-csrf-token");
   }
+
+  if (!token) return false;
 
   try {
     const cookieStore = await cookies();
     const csrfCookie = cookieStore.get("__csrf")?.value;
 
-    if (!csrfCookie) {
+    // Le pattern Double-Submit Cookie nécessite que le token soit présent dans le header ET le cookie
+    if (!csrfCookie || token !== csrfCookie) {
       return false;
     }
 
-    // Le secret CSRF doit être défini via la variable d'environnement CSRF_SECRET
     const secret = process.env.CSRF_SECRET;
-    
     if (!secret) {
-      console.error(
-        "[CSRF] CSRF_SECRET environment variable is required for token validation. " +
-        "Please configure it in your environment variables or Firebase App Hosting secrets."
-      );
+      console.error("[CSRF] CSRF_SECRET missing");
       return false;
     }
 
-    // Décoder le token fourni pour extraire l'UID et le timestamp
-    try {
-      const decoded = Buffer.from(providedToken, "base64").toString("utf-8");
-      const [tokenUid, timestamp] = decoded.split(":");
-      
-      // Si un UID est fourni, vérifier qu'il correspond
-      if (uid && tokenUid !== uid) {
-        return false;
-      }
+    // Décoder et vérifier la structure : uid:timestamp:signature
+    const decoded = Buffer.from(token, "base64").toString("utf-8");
+    const parts = decoded.split(":");
+    if (parts.length !== 3) return false;
 
-      // Re-générer le token attendu avec le secret
-      const expectedToken = Buffer.from(`${tokenUid}:${timestamp}:${secret}`).toString("base64");
-      
-      // Comparer les tokens
-      return providedToken === expectedToken && providedToken === csrfCookie;
-    } catch {
-      // Si le décodage échoue, le token est invalide
+    const [tokenUid, timestamp, signature] = parts;
+
+    // Vérifier l'UID si fourni
+    if (uid && tokenUid !== uid) return false;
+
+    // Re-calculer la signature attendue
+    const expectedData = `${tokenUid}:${timestamp}`;
+    const expectedSignature = createHmac("sha256", secret).update(expectedData).digest("hex");
+
+    // Les buffers doivent avoir la même longueur pour timingSafeEqual
+    const signatureBuffer = Buffer.from(signature);
+    const expectedSignatureBuffer = Buffer.from(expectedSignature);
+
+    if (signatureBuffer.length !== expectedSignatureBuffer.length) {
       return false;
     }
+
+    // Comparaison sécurisée contre les attaques temporelles
+    return timingSafeEqual(signatureBuffer, expectedSignatureBuffer);
   } catch {
     return false;
   }


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
1. CSRF protection was using an insecure base64 concatenation of UID, timestamp, and secret, which could potentially leak the secret if tokens were exposed.
2. Several critical POST endpoints were missing CSRF validation.
3. Jest configuration had a typo `moduleNameMapping` instead of `moduleNameMapper`, preventing path aliases from working in tests.

🎯 Impact:
1. Potential exposure of `CSRF_SECRET`.
2. Vulnerability to Cross-Site Request Forgery (CSRF) on critical administrative and user actions.
3. Difficulty in writing and running tests using path aliases.

🔧 Fix:
1. Hardened `src/lib/auth/csrf-utils.ts` to use HMAC-SHA256 signing for tokens.
2. Implemented `timingSafeEqual` for secure token validation.
3. Added CSRF token generation and cookie setting in `src/app/api/session/route.ts`.
4. Added `validateOrigin` and `validateCSRFToken` to:
   - `src/app/api/admin/discord-availability-config/route.ts`
   - `src/app/api/coach/request/route.ts`
   - `src/app/api/discord/send-message/route.ts`
5. Fixed `jest.config.js` typo.
6. Added unit tests for CSRF utilities.

✅ Verification:
1. Ran `npm test src/__tests__/csrf-utils.test.ts` - All 8 tests passed.
2. Ran `npm run lint` - No errors.
3. Ran `npm run type-check` - No errors.
4. Verified that `validateOrigin` is correctly exported and used.

---
*PR created automatically by Jules for task [11282084739026859038](https://jules.google.com/task/11282084739026859038) started by @omichalo*