### PR TITLE
🛡️ Sentinel: [HIGH] Harden Firestore rules for users and club settings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Prevent Privilege Escalation via Firestore Rules
+**Vulnerability:** Authenticated users could escalate their privileges by setting or updating the `role` field in their Firestore `users` document.
+**Learning:** Although administrative logic often checks Firebase Custom Claims, the application's session verification API may trust the Firestore document's `role` field if it exists, leading to a bypass if the document is user-editable.
+**Prevention:** Use `request.resource.data.diff(resource.data).affectedKeys()` in Firestore rules to block unauthorized modifications to sensitive fields like `role` and `coachRequestStatus`. Enforce a default role and status on document creation.

--- a/firestore.rules
+++ b/firestore.rules
@@ -32,9 +32,18 @@ service cloud.firestore {
     // ============================================
     // Les utilisateurs peuvent créer/mettre à jour leur propre profil
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
+    // Sécurité: Empêche l'escalade de privilèges en bloquant la modification du rôle par l'utilisateur
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, avec rôle par défaut 'player'
+      allow create: if isAuthenticated() && request.auth.uid == userId
+        && request.resource.data.role == "player"
+        && (request.resource.data.coachRequestStatus == "none" || !("coachRequestStatus" in request.resource.data));
+
+      // Mise à jour : uniquement son propre profil, sans modifier les champs sensibles (role, status coach, etc.)
+      allow update: if isAuthenticated() && request.auth.uid == userId
+        && !request.resource.data.diff(resource.data).affectedKeys().hasAny([
+          "role", "coachRequestStatus", "coachRequestHandledBy", "coachRequestHandledAt", "coachRequestUpdatedAt"
+        ]);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -130,17 +139,15 @@ service cloud.firestore {
     // ============================================
     // Collection: clubSettings (ou club_settings)
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture uniquement pour les admins
+    // Lecture et écriture uniquement pour les admins
+    // Sécurité: Protège les identifiants FFTT et autres configurations sensibles
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
-      allow write: if isAdmin();
+      allow read, write: if isAdmin();
     }
     
     // ============================================

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jest-environment-jsdom",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
-  moduleNameMapping: {
+  moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   collectCoverageFrom: [


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Privilege Escalation in user profiles and potential sensitive data leakage in club settings.
🎯 Impact: Authenticated users could potentially escalate their privileges by modifying the 'role' field in their Firestore document, and non-admin users could read sensitive club credentials.
🔧 Fix: Implemented field-level security in Firestore rules using `affectedKeys()` to block unauthorized modifications to 'role' and 'coachRequestStatus'. Restricted 'clubSettings' read access to admins only.
✅ Verification: Verified rules by manual inspection and ran the full test suite (`npm test`) and production build (`npm run build`) successfully. Corrected a Jest configuration error to ensure reliable testing.

---
*PR created automatically by Jules for task [11465900314602194092](https://jules.google.com/task/11465900314602194092) started by @omichalo*