### PR TITLE
🛡️ Sentinel: [HIGH] Fix privilege escalation and secure session verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-14 - Privilege Escalation via Firestore and Session Logic
+**Vulnerability:** Users could potentially escalate their privileges by modifying the `role` or `coachRequestStatus` fields in their Firestore user document, or by self-approving coach requests. Additionally, the session verification API prioritized Firestore data over signed custom claims.
+**Learning:** Security depends on both robust database rules and authoritative source selection in the backend. Relying on mutable database fields for authorization when signed claims are available creates an escalation vector.
+**Prevention:** Enforce strict field-level write permissions in Firestore using `affectedKeys()`. Always prioritize signed, immutable custom claims over database fields for role-based access control in session verification.

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,6 +26,12 @@ service cloud.firestore {
     function isCoach() {
       return isAdmin() || authRole() == "coach";
     }
+
+    // Vérifie si l'utilisateur change son statut de demande de coach vers 'pending'
+    function isMovingToPending() {
+      return request.resource.data.coachRequestStatus == "pending" &&
+             (resource == null || resource.data.get('coachRequestStatus', 'none') == "none" || resource.data.coachRequestStatus == "rejected");
+    }
     
     // ============================================
     // Collection: users
@@ -33,8 +39,16 @@ service cloud.firestore {
     // Les utilisateurs peuvent créer/mettre à jour leur propre profil
     // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, avec rôle player par défaut
+      allow create: if isAuthenticated() && request.auth.uid == userId &&
+                      request.resource.data.role == "player" &&
+                      request.resource.data.coachRequestStatus == "none";
+
+      // Mise à jour : uniquement son propre profil, interdire la modification des champs sensibles
+      allow update: if isAuthenticated() && request.auth.uid == userId &&
+                      !(request.resource.data.diff(resource.data).affectedKeys()
+                        .hasAny(['role', 'playerId', 'coachRequestHandledBy', 'coachRequestHandledAt'])) &&
+                      (request.resource.data.coachRequestStatus == resource.data.coachRequestStatus || isMovingToPending());
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);

--- a/src/app/api/coach/request/route.ts
+++ b/src/app/api/coach/request/route.ts
@@ -3,9 +3,22 @@ import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, COACH_REQUEST_STATUS, resolveRole } from "@/lib/auth/roles";
 import { FieldValue } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
 
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Invalid origin",
+          message: "Requête non autorisée",
+        },
+        { status: 403 }
+      );
+    }
+
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -93,10 +93,11 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      // Prioriser les claims du token (custom claims) sur les données Firestore pour la sécurité
+      role: (decoded.role as string | undefined) || (userData?.role as string | undefined) || "player",
       coachRequestStatus:
+        (decoded.coachRequestStatus as string | undefined) ||
         (userData?.coachRequestStatus as string | undefined) ||
-        decoded.coachRequestStatus ||
         "none",
       coachRequestMessage: (userData?.coachRequestMessage as string | undefined) || null,
       coachRequestUpdatedAt,


### PR DESCRIPTION
This PR addresses a privilege escalation vulnerability where users could potentially modify their roles or status by updating their Firestore documents directly. 

Key changes:
1. **Firestore Rules Hardening**: Modified `firestore.rules` to block updates to `role`, `playerId`, and administrative fields by users. It also ensures that only legitimate transitions to `pending` status are allowed for coach requests.
2. **Authoritative Role Resolution**: Updated `/api/session/verify` to prioritize roles and statuses from the verified session token's custom claims, providing a more secure defense-in-depth approach.
3. **CSRF Protection**: Added origin validation to the coach request endpoint.
4. **Security Journaling**: Recorded the vulnerability pattern and prevention strategies in the project's security journal.

All tests passed.

---
*PR created automatically by Jules for task [14362443952935112508](https://jules.google.com/task/14362443952935112508) started by @omichalo*