### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing authentication on PII-exposing API route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-16 - [CRITICAL] Missing authentication on PII-exposing API route
+**Vulnerability:** The `/api/fftt/players` endpoint was publicly accessible and returned sensitive player data including email addresses and phone numbers.
+**Learning:** API routes in Next.js (App Router) are not automatically protected by middleware if they are explicitly excluded in the matcher (as in this project). Each API route must implement its own authentication and authorization checks.
+**Prevention:** Always implement session verification (`adminAuth.verifySessionCookie`) and role-based access control (`hasAnyRole`) in API routes that expose sensitive data. Add anti-caching headers to prevent PII leakage via caches.

--- a/src/app/api/fftt/players/route.ts
+++ b/src/app/api/fftt/players/route.ts
@@ -1,9 +1,34 @@
 import { NextResponse } from "next/server";
-import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { cookies } from "next/headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import type { Player } from "@/types";
 
 export async function GET(req: Request) {
   try {
+    // Session verification
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+
+    if (!sessionCookie) {
+      return NextResponse.json({ error: "Authentification requise" }, { status: 401 });
+    }
+
+    try {
+      const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+      if (!decoded.email_verified) {
+        return NextResponse.json({ error: "Email non vérifié" }, { status: 403 });
+      }
+
+      // Check for ADMIN or COACH role (required for PII access)
+      const role = resolveRole(decoded.role as string | undefined);
+      if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+        return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+      }
+    } catch {
+      return NextResponse.json({ error: "Session invalide" }, { status: 401 });
+    }
+
     const { searchParams } = new URL(req.url);
     const clubCode = searchParams.get("clubCode");
 
@@ -46,7 +71,7 @@ export async function GET(req: Request) {
 
     console.log(`📊 [app/api/fftt/players] ${players.length} joueurs récupérés depuis Firestore`);
 
-    return NextResponse.json(
+    const res = NextResponse.json(
       {
         players,
         total: players.length,
@@ -54,6 +79,11 @@ export async function GET(req: Request) {
       },
       { status: 200 }
     );
+    // Anti-caching headers for sensitive data
+    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    res.headers.set("Pragma", "no-cache");
+    res.headers.set("Expires", "0");
+    return res;
   } catch (error) {
     console.error("[app/api/fftt/players] Firestore Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix missing authentication on PII-exposing API route

I identified that the `/api/fftt/players` endpoint was publicly accessible and exposed sensitive player information (PII) like email addresses and phone numbers. This was a critical security vulnerability.

I have implemented:
1.  **Authentication:** Session verification using Firebase Admin SDK.
2.  **Authorization:** Role-based access control (RBAC), restricting access to `ADMIN` and `COACH` roles only.
3.  **Data Protection:** Added anti-caching headers (`no-store`, `no-cache`, etc.) to prevent sensitive data from being cached.
4.  **Documentation:** Recorded the vulnerability and prevention strategy in the `.jules/sentinel.md` security journal.

The change is under 50 lines (excluding the new journal file) and significantly improves the application's security posture.

Verification:
- Confirmed that `/api/fftt/players` returns `401 Unauthorized` when accessed without a session cookie.
- Verified that existing tests pass (`npm test`).
- Manually tested with `curl`.

---
*PR created automatically by Jules for task [6279869614422479535](https://jules.google.com/task/6279869614422479535) started by @omichalo*