### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix privilege escalation in Firestore rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Privilege Escalation via Unrestricted Firestore User Profile Updates
+**Vulnerability:** The `users` collection allowed any authenticated user to create or update their own profile document without field-level restrictions. This permitted a malicious user to set their own `role` to `admin` or `coach` via the client-side SDK.
+**Learning:** Relying on `request.auth.uid == userId` is insufficient for profile documents that contain authorization data (roles, permissions). Authorization fields must be explicitly protected from client-side modifications.
+**Prevention:** Always use `affectedKeys().hasAny([...])` in Firestore rules to block client-side updates to sensitive fields like `role`, `permissions`, or `status`. Use `request.resource.data.get('role', 'player') == 'player'` on creation to enforce default low-privilege roles.

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,11 +30,27 @@ service cloud.firestore {
     // ============================================
     // Collection: users
     // ============================================
-    // Les utilisateurs peuvent créer/mettre à jour leur propre profil
-    // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
+    // Les utilisateurs peuvent créer/mettre à jour leur propre profil.
+    // Les règles empêchent l'escalade de privilèges en restreignant les champs modifiables.
+    // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs via le client.
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Création : uniquement son propre profil, le rôle doit être 'player'
+      allow create: if isAuthenticated() && request.auth.uid == userId
+                    && request.resource.data.get('role', 'player') == 'player'
+                    && request.resource.data.get('coachRequestStatus', 'none') == 'none';
+
+      // Mise à jour : uniquement son propre profil, empêche la modification des champs sensibles
+      allow update: if isAuthenticated() && request.auth.uid == userId
+                    && !request.resource.data.diff(resource.data).affectedKeys()
+                        .hasAny(['role', 'playerId', 'coachRequestHandledBy', 'coachRequestHandledAt'])
+                    && (
+                      // Soit le statut de demande coach ne change pas
+                      !request.resource.data.diff(resource.data).affectedKeys().hasAny(['coachRequestStatus'])
+                      // Soit il passe à 'pending' depuis 'none' ou 'rejected'
+                      || (request.resource.data.coachRequestStatus == 'pending'
+                          && (resource.data.get('coachRequestStatus', 'none') == 'none'
+                              || resource.data.get('coachRequestStatus', 'none') == 'rejected'))
+                    );
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Privilege escalation via unrestricted Firestore updates in the 'users' collection.
🎯 Impact: Any authenticated user could grant themselves 'admin' or 'coach' roles by directly updating their own document in Firestore via the client SDK.
🔧 Fix: Implemented strict field-level security using 'affectedKeys()' to block unauthorized field modifications and enforced default roles on document creation.
✅ Verification: Rules were manually verified for correctness. Full test suite passed (30/30 tests).

---
*PR created automatically by Jules for task [16800457658862564313](https://jules.google.com/task/16800457658862564313) started by @omichalo*