### PR TITLE
🛡️ Sentinel: [HIGH] Harden Firestore rules and add CSRF protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-05-15 - Firestore Rules Hardening and CSRF Protection
+**Vulnerability:** Insecure Firestore rules for 'availabilities' collection (IDOR) and missing CSRF protection on coach request endpoint.
+**Learning:** Middleware protection in Next.js might exclude /api routes, leading to a "Middleware Fallacy" where developers assume all routes are protected. Similarly, Firestore rules must explicitly mirror authentication requirements like email verification to ensure defense in depth.
+**Prevention:** Always implement explicit ownership checks in Firestore rules (e.g., using a getPlayerId helper) and validate request origins in all state-changing API routes.

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,9 +5,9 @@ service cloud.firestore {
     // Fonctions helper
     // ============================================
     
-    // Vérifie si l'utilisateur est authentifié
+    // Vérifie si l'utilisateur est authentifié et son email vérifié
     function isAuthenticated() {
-      return request.auth != null;
+      return request.auth != null && request.auth.token.email_verified == true;
     }
     
     // Récupère le rôle de l'utilisateur depuis les custom claims
@@ -26,15 +26,25 @@ service cloud.firestore {
     function isCoach() {
       return isAdmin() || authRole() == "coach";
     }
+
+    // Récupère l'ID du joueur associé à l'utilisateur
+    function getPlayerId() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.get("playerId", null);
+    }
     
     // ============================================
     // Collection: users
     // ============================================
-    // Les utilisateurs peuvent créer/mettre à jour leur propre profil
-    // Seuls les admins peuvent lire/supprimer les profils d'autres utilisateurs
     match /users/{userId} {
-      // Création et mise à jour : uniquement son propre profil
-      allow create, update: if isAuthenticated() && request.auth.uid == userId;
+      // Permettre la création de son propre profil avec des valeurs par défaut sécurisées
+      allow create: if isAuthenticated() && request.auth.uid == userId &&
+        request.resource.data.role == "player" &&
+        request.resource.data.get("coachRequestStatus", "none") == "none";
+
+      // Empêcher la modification des champs sensibles par l'utilisateur
+      allow update: if isAuthenticated() && request.auth.uid == userId &&
+        !request.resource.data.diff(resource.data).affectedKeys()
+          .hasAny(["role", "playerId", "coachRequestHandledBy", "coachRequestHandledAt"]);
       
       // Lecture : son propre profil ou admin
       allow read: if isAuthenticated() && (isAdmin() || request.auth.uid == userId);
@@ -110,11 +120,23 @@ service cloud.firestore {
     // ============================================
     // Collection: availabilities
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+
+      // Seuls les admins/coachs peuvent tout modifier.
+      // Les joueurs ne peuvent modifier que leur propre entrée dans la map 'players'.
+      allow create: if isCoach() || (
+        isAuthenticated() &&
+        request.resource.data.players.keys().hasOnly([getPlayerId()])
+      );
+
+      allow update: if isCoach() || (
+        isAuthenticated() &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(["players", "updatedAt"]) &&
+        request.resource.data.players.diff(resource.data.players).affectedKeys().hasOnly([getPlayerId()])
+      );
+
+      allow delete: if isCoach();
     }
     
     // ============================================

--- a/src/app/api/coach/request/route.ts
+++ b/src/app/api/coach/request/route.ts
@@ -3,9 +3,18 @@ import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, COACH_REQUEST_STATUS, resolveRole } from "@/lib/auth/roles";
 import { FieldValue } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
 
 export async function POST(req: Request) {
   try {
+    // Valider l'origine de la requête pour prévenir les attaques CSRF
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin", message: "Requête non autorisée" },
+        { status: 403 }
+      );
+    }
+
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Broken Access Control (IDOR) in availabilities collection, privilege escalation risk in user profiles, and missing CSRF protection on the coach request API.
🎯 Impact: Unauthorized users could modify any player's availability, and users could potentially elevate their own roles. Lack of CSRF protection allowed for unauthorized state-changing requests.
🔧 Fix:
- Updated `firestore.rules` to enforce email verification and restrict 'availabilities' writes to the record owner (matching `playerId`).
- Hardened 'users' rules to prevent role/playerId modification by users.
- Implemented `validateOrigin` CSRF protection in `src/app/api/coach/request/route.ts`.
- Documented findings in `.jules/sentinel.md`.
✅ Verification: Ran `npm test` and `npm run type-check`. Verified Firestore logic and API implementation.

---
*PR created automatically by Jules for task [3870931336777641566](https://jules.google.com/task/3870931336777641566) started by @omichalo*