### PR TITLE
🛡️ Sentinel: Secure player and team match API endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - API Route Authentication Gap
+**Vulnerability:** Publicly accessible API endpoints (`/api/fftt/players`, `/api/teams/matches`) exposing PII and internal club data.
+**Learning:** Developers assumed the Next.js `middleware.ts` protected all routes, but the matcher explicitly excluded the `/api` prefix, leaving all API routes open by default unless manually secured.
+**Prevention:** Always implement manual session verification (`adminAuth.verifySessionCookie`) and role checks in every API route. Use anti-caching headers for sensitive data.

--- a/src/app/api/fftt/players/route.ts
+++ b/src/app/api/fftt/players/route.ts
@@ -1,9 +1,50 @@
 import { NextResponse } from "next/server";
-import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { cookies } from "next/headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import type { Player } from "@/types";
 
 export async function GET(req: Request) {
   try {
+    // Initialiser Firebase Admin pour accéder à Auth et Firestore
+    await initializeFirebaseAdmin();
+
+    // Vérification d'authentification
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
+
+    try {
+      const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+      if (!decoded.email_verified) {
+        return NextResponse.json(
+          { error: "Email non vérifié" },
+          { status: 403 }
+        );
+      }
+
+      // Vérifier que l'utilisateur est admin ou coach pour accéder aux données des joueurs (PII)
+      const role = resolveRole(decoded.role as string | undefined);
+      if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+        return NextResponse.json(
+          { error: "Accès refusé" },
+          { status: 403 }
+        );
+      }
+    } catch (error) {
+      console.error("[app/api/fftt/players] Session Verification Error:", error);
+      return NextResponse.json(
+        { error: "Session invalide ou expirée" },
+        { status: 401 }
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const clubCode = searchParams.get("clubCode");
 
@@ -14,7 +55,6 @@ export async function GET(req: Request) {
       );
     }
 
-    await initializeFirebaseAdmin();
     const firestore = getFirestoreAdmin();
 
     const playersSnapshot = await firestore.collection("players").get();
@@ -46,7 +86,7 @@ export async function GET(req: Request) {
 
     console.log(`📊 [app/api/fftt/players] ${players.length} joueurs récupérés depuis Firestore`);
 
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         players,
         total: players.length,
@@ -54,6 +94,13 @@ export async function GET(req: Request) {
       },
       { status: 200 }
     );
+
+    // Protection contre le cache pour les données sensibles
+    response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    response.headers.set("Pragma", "no-cache");
+    response.headers.set("Expires", "0");
+
+    return response;
   } catch (error) {
     console.error("[app/api/fftt/players] Firestore Error:", error);
     return NextResponse.json(

--- a/src/app/api/teams/matches/route.ts
+++ b/src/app/api/teams/matches/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { cookies } from "next/headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import {
   getTeams,
   getTeamMatches,
@@ -14,7 +15,38 @@ interface TeamMatchSerialized extends Omit<TeamMatch, "date" | "createdAt" | "up
 
 export async function GET(req: Request) {
   try {
+    // Initialiser Firebase Admin
     await initializeFirebaseAdmin();
+
+    // Vérification d'authentification
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
+
+    try {
+      const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+      if (!decoded.email_verified) {
+        return NextResponse.json(
+          { error: "Email non vérifié" },
+          { status: 403 }
+        );
+      }
+      // Pour cet endpoint qui expose l'ensemble des matchs du club,
+      // on autorise tous les utilisateurs connectés avec un email vérifié (rôle PLAYER minimum).
+    } catch (error) {
+      console.error("[app/api/teams/matches] Session Verification Error:", error);
+      return NextResponse.json(
+        { error: "Session invalide ou expirée" },
+        { status: 401 }
+      );
+    }
+
     const firestore = getFirestoreAdmin();
 
     const teams = await getTeams(firestore);
@@ -56,7 +88,7 @@ export async function GET(req: Request) {
       })
     );
 
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         teams: teamMatches,
         totalTeams: teamMatches.length,
@@ -64,6 +96,13 @@ export async function GET(req: Request) {
       },
       { status: 200 }
     );
+
+    // Protection contre le cache pour les données privées du club
+    response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    response.headers.set("Pragma", "no-cache");
+    response.headers.set("Expires", "0");
+
+    return response;
   } catch (error) {
     console.error("[app/api/teams/matches] Firestore Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
This PR addresses a critical security gap where several API endpoints were publicly accessible, exposing player PII (names, points, etc.) and internal club match data.

### Changes:
- **Authentication**: Implemented session verification using `adminAuth.verifySessionCookie` for `/api/fftt/players` and `/api/teams/matches`.
- **Authorization**: 
    - `/api/fftt/players`: Restricted to `ADMIN` and `COACH` roles.
    - `/api/teams/matches`: Restricted to authenticated users with verified emails.
- **Cache Protection**: Added `Cache-Control: no-store` and other anti-caching headers to prevent sensitive data from being stored in intermediate caches.
- **Robustness**: Ensured `initializeFirebaseAdmin()` is called at the beginning of the handlers to avoid "app not initialized" errors.

### Verification:
- Ran `npm run lint` - Passed.
- Ran `npm test` - Passed.
- Manual inspection of code logic and initialization order.
- Security learning documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10009183283891503786](https://jules.google.com/task/10009183283891503786) started by @omichalo*