### PR TITLE
fix(compositions): allow coach Discord notifications

### DIFF
--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { adminAuth, adminDb } from "@/lib/firebase-admin";
+import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+
+    if (!sessionCookie) {
+      return NextResponse.json(
+        { success: false, error: "Authentification requise" },
+        { status: 401 }
+      );
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    if (!decoded.email_verified) {
+      return NextResponse.json(
+        { success: false, error: "Email non vérifié" },
+        { status: 403 }
+      );
+    }
+
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return NextResponse.json(
+        { success: false, error: "Accès refusé" },
+        { status: 403 }
+      );
+    }
+
+    const locationsRef = adminDb.collection("locations");
+    const snapshot = await locationsRef.orderBy("name", "asc").get();
+
+    const locations = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      name: doc.data().name as string,
+      createdAt:
+        doc.data().createdAt?.toDate?.()?.toISOString() ??
+        new Date().toISOString(),
+      updatedAt:
+        doc.data().updatedAt?.toDate?.()?.toISOString() ??
+        new Date().toISOString(),
+    }));
+
+    return NextResponse.json({ success: true, locations }, { status: 200 });
+  } catch (error) {
+    console.error("[app/api/locations] GET error", error);
+    return NextResponse.json(
+      { success: false, error: "Erreur lors de la récupération des lieux" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/compositions/_containers/CompositionsPageContainer.tsx
+++ b/src/app/compositions/_containers/CompositionsPageContainer.tsx
@@ -556,7 +556,7 @@ export function CompositionsPageContainer() {
   useEffect(() => {
     const loadLocations = async () => {
       try {
-        const response = await fetch("/api/admin/locations", {
+        const response = await fetch("/api/locations", {
           method: "GET",
           credentials: "include",
           headers: {


### PR DESCRIPTION
## Summary
- unblock coaches on the compositions page by switching location loading from the admin-only endpoint to a coach/admin readable endpoint
- add a dedicated `GET /api/locations` route secured for authenticated `admin` and `coach` users
- keep write operations for locations unchanged under `/api/admin/locations` (admin-only)

## Test plan
- [x] `npm run check:dev`
- [x] `npm run check`
- [ ] login as coach and verify Discord send button is enabled when team channel + location are configured
- [ ] login as player and verify `/api/locations` returns 403

Made with [Cursor](https://cursor.com)