### PR TITLE
fix(auth): handle missing Firebase users in email endpoints

### DIFF
--- a/src/app/api/auth/send-password-reset/route.ts
+++ b/src/app/api/auth/send-password-reset/route.ts
@@ -9,6 +9,15 @@ import { checkRateLimit } from "@/lib/auth/rate-limit";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+function getAuthErrorCode(error: unknown): string {
+  if (typeof error !== "object" || error === null) {
+    return "";
+  }
+
+  const maybeCode = (error as { code?: unknown }).code;
+  return typeof maybeCode === "string" ? maybeCode : "";
+}
+
 export async function POST(req: Request) {
   try {
     const { email } = await req.json();
@@ -92,15 +101,25 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      const authCode = getAuthErrorCode(error);
       
       // Erreurs Firebase spécifiques
-      if (errorMessage.includes("user-not-found") || errorMessage.includes("USER_NOT_FOUND")) {
+      if (
+        authCode === "auth/user-not-found" ||
+        errorMessage.includes("user-not-found") ||
+        errorMessage.includes("USER_NOT_FOUND") ||
+        errorMessage.includes("no user record")
+      ) {
         // Ne pas révéler si l'utilisateur existe ou non (sécurité)
         // Retourner toujours 200 pour éviter l'énumération d'emails
         return NextResponse.json({ ok: true });
       }
       
-      if (errorMessage.includes("invalid-email") || errorMessage.includes("INVALID_EMAIL")) {
+      if (
+        authCode === "auth/invalid-email" ||
+        errorMessage.includes("invalid-email") ||
+        errorMessage.includes("INVALID_EMAIL")
+      ) {
         return NextResponse.json(
           { error: "Email invalide", message: "L'adresse email n'est pas valide" },
           { status: 400 }

--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -8,6 +8,15 @@ import { checkRateLimit } from "@/lib/auth/rate-limit";
 
 export const runtime = "nodejs";
 
+function getAuthErrorCode(error: unknown): string {
+  if (typeof error !== "object" || error === null) {
+    return "";
+  }
+
+  const maybeCode = (error as { code?: unknown }).code;
+  return typeof maybeCode === "string" ? maybeCode : "";
+}
+
 export async function POST(req: Request) {
   try {
     const { email } = await req.json();
@@ -91,16 +100,26 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      const authCode = getAuthErrorCode(error);
       
       // Erreurs Firebase spécifiques
-      if (errorMessage.includes("user-not-found") || errorMessage.includes("USER_NOT_FOUND")) {
+      if (
+        authCode === "auth/user-not-found" ||
+        errorMessage.includes("user-not-found") ||
+        errorMessage.includes("USER_NOT_FOUND") ||
+        errorMessage.includes("no user record")
+      ) {
         return NextResponse.json(
           { error: "Utilisateur non trouvé", message: "Aucun compte n'est associé à cet email" },
           { status: 404 }
         );
       }
       
-      if (errorMessage.includes("invalid-email") || errorMessage.includes("INVALID_EMAIL")) {
+      if (
+        authCode === "auth/invalid-email" ||
+        errorMessage.includes("invalid-email") ||
+        errorMessage.includes("INVALID_EMAIL")
+      ) {
         return NextResponse.json(
           { error: "Email invalide", message: "L'adresse email n'est pas valide" },
           { status: 400 }


### PR DESCRIPTION
## Summary
- map Firebase Auth `user-not-found` and `invalid-email` errors explicitly in `/api/auth/send-verification`
- apply the same robust error code handling in `/api/auth/send-password-reset`
- avoid generic 500 responses when the email is not present in Firebase Auth

## Test plan
- [x] `npm run check:dev`
- [x] manual test: resend verification email with existing account (mail received)
- [x] manual test: resend verification email with unknown account (clear user-not-found response)


Made with [Cursor](https://cursor.com)