### PR TITLE
fix(next): suppression du devtool webpack forcé en dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,12 +18,8 @@ const nextConfig: NextConfig = {
     return "build-" + Date.now();
   },
   productionBrowserSourceMaps: true,
-  webpack: (config, { dev }) => {
-    if (dev) {
-      config.devtool = "source-map";
-    }
-    return config;
-  },
+  // Ne pas définir webpack devtool en dev : Next.js impose la valeur adaptée au mode
+  // (voir https://nextjs.org/docs/messages/improper-devtool — source-map en dev dégrade fortement les perfs).
   // Forcer l'injection des variables d'environnement au build
   // Next.js injecte NEXT_PUBLIC_* dans le bundle client au moment du build
   env: {


### PR DESCRIPTION
## Contexte
Next.js affichait l’avertissement [improper-devtool](https://nextjs.org/docs/messages/improper-devtool) au démarrage de `next dev`, car `next.config.ts` forçait `config.devtool = "source-map"` en développement.

## Changement
- Suppression du hook `webpack` qui modifiait `devtool` en mode dev.
- Conservation de `productionBrowserSourceMaps: true` pour la prod.

## Vérifications
- `npm run check` (lint, type-check, build) OK en local.

Made with [Cursor](https://cursor.com)