### PR TITLE
feat(security): Epic A — CSRF validateOrigin et rate limiting API

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -120,6 +120,46 @@ Ce projet utilise les secrets suivants (stockés dans Firebase Secret Manager en
 
 **Note** : Cette liste est fournie à titre informatif. Les valeurs réelles ne doivent jamais être exposées.
 
+## API : CSRF (`validateOrigin`) et rate limiting
+
+Les mutations exposées au navigateur sur la même origine passent par **`validateOrigin`** (`src/lib/auth/csrf-utils.ts`), qui vérifie `Origin` / `Referer` / `Host` par rapport à `APP_URL` ou `NEXT_PUBLIC_APP_URL`. En développement, `localhost` est autorisé.
+
+### Politique par type de route
+
+| Type | CSRF (`validateOrigin`) | Rate limiting |
+|------|-------------------------|---------------|
+| Formulaires / fetch same-origin avec cookie de session | **Oui** sur POST/PATCH/DELETE concernés | Identifiants stables (IP ou `uid`) via `checkRateLimit` / `enforceRateLimit` |
+| Webhooks Discord (`discord/interactions`) | **N/A** — signature Ed25519 | N/A (Discord applique ses propres limites) |
+| Webhooks / secrets serveur (`discord/link-license`, etc.) | **N/A** — secret partagé ou équivalent | Optionnel selon la route |
+| Envoi d’emails anonymes (`auth/send-password-reset`, `auth/send-verification`) | **N/A** — pas de session cookie | **Oui** — limite par email (voir routes) |
+| Lecture OpenAPI (`openapi`) | **N/A** — GET public | N/A |
+| Health (`health`) | **N/A** | N/A |
+
+### Inventaire des mutations (référence maintenance)
+
+**Session & auth navigateur**
+
+- `POST /api/session` — CSRF oui ; rate limit **par IP** (`session:post:<ip>`).
+- `POST /api/session/firebase-token` — CSRF oui ; rate limit **par uid** (`session:firebase-token:<uid>`).
+
+**Discord (proxy HTTP avec cookie)**
+
+- `POST /api/discord/send-message` — CSRF oui ; rate limit par uid.
+- `POST /api/discord/update-custom-message` — CSRF oui ; rate limit par uid.
+- `POST /api/discord/availability-polls/create` — CSRF oui ; rate limit par uid (sondages).
+- `POST /api/discord/availability-polls/[pollId]/close` — CSRF oui ; rate limit par uid.
+
+**Admin**
+
+- `POST /api/admin/discord-availability-config` — CSRF oui ; rate limit par uid (admin).
+- `POST /api/admin/sync-teams` — CSRF déjà présent ; rate limit par uid (sync).
+- `POST /api/admin/sync-players` — idem.
+- `POST /api/admin/sync-team-matches` — idem.
+
+Les autres routes admin / coach déjà couvertes par l’audit (ex. `brulage/validate`, `coach/request`, `teams/.../location`) conservent leur `validateOrigin` existant.
+
+**Limitation** : le rate limiting en mémoire n’est pas distribué ; pour plusieurs instances, prévoir Redis ou équivalent.
+
 ## Audit de sécurité automatisé
 
 Le projet utilise des outils automatisés pour détecter les secrets commités par erreur :

--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -1,0 +1,251 @@
+# Plan d’action — Audit Next.js / API / React (suivi)
+
+Ce document consolide les constats des audits **phase 1** (qualité globale Next.js, sécurité, perf, tests) et **phase 2** (matrice des routes API + qualité des composants React). Il sert de **backlog traçable** : cocher les cases au fil des PR / merges.
+
+**Dernière mise à jour :** 2026-05-09  
+**Statuts :** `[ ]` à faire · `[~]` en cours · `[x]` terminé
+
+---
+
+## Comment utiliser ce plan
+
+1. Traiter de préférence par **ordre de priorité** (P0 → P3), sauf dépendance indiquée.
+2. Une **étape = une PR** idéalement (ou un groupe cohérent), pour faciliter la review.
+3. Après chaque lot : `npm run check` (et smoke optionnel `npm run smoke:web` pour les changements sensibles).
+4. Référencer ce fichier dans les PR concernées (`Voir docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md`).
+
+---
+
+## Légende des priorités
+
+| Niveau | Signification |
+|--------|----------------|
+| **P0** | Sécurité ou incohérence critique avec les règles projet / risque élevé |
+| **P1** | Fiabilité, cohérence, conformité forte ; à faire rapidement après P0 |
+| **P2** | Qualité maintenabilité, perf, DX ; planifiable par sprints |
+| **P3** | Amélioration continue, dette technique non bloquante |
+
+---
+
+## Synthèse des epics
+
+| Epic | Description | Priorité max |
+|------|-------------|--------------|
+| A | Sécurité API : CSRF (`validateOrigin`), compléments rate limiting | ~~P0~~ **traité (2026-05-09)** |
+| B | En-têtes `Cache-Control` sur réponses sensibles | P0 / P1 |
+| C | `export const runtime = "nodejs"` sur routes concernées | P1 |
+| D | Cohérence des rôles (`resolveRole`, `hasAnyRole`, `USER_ROLES`) | P1 |
+| E | Toolchain : ESLint vs build, config Next (`next.config.ts`) | P2 |
+| F | Stratégie rendu : réduction du `force-dynamic` global si pertinent | P2 |
+| G | Qualité React : découpage, couche API client, patterns | P2 |
+| H | Accessibilité (a11y) ciblée | P3 |
+| I | Tests automatisés (API, hooks critiques, composants clés) | P2 |
+| J | Dette packages & observabilité (logs, dépendances) | P2 / P3 |
+
+---
+
+## Epic A — Sécurité API (CSRF & rate limiting)
+
+**Objectif :** Aligner les mutations exposées au navigateur avec la politique documentée (`validateOrigin` sur POST/PATCH/DELETE/PUT côté cookie), et renforcer les surfaces sensibles.
+
+### A.1 Inventaire et décision par route (prérequis)
+
+- [x] **A.1.1** Lister toutes les routes `app/api/**/route.ts` avec méthodes mutantes (POST, PUT, PATCH, DELETE).
+- [x] **A.1.2** Pour chaque route, classer : (1) appel navigateur same-origin attendu, (2) webhook / signature externe, (3) flux anonyme contrôlé (ex. email), (4) autre.
+- [x] **A.1.3** Produire une petite table « route → décision CSRF » dans `docs/SECURITY.md` (ou annexe) pour figer les exceptions **N/A**.
+
+### A.2 Implémenter ou documenter `validateOrigin`
+
+**Routes identifiées comme mutations « cookie » sans `validateOrigin` à traiter (audit phase 2) :**
+
+- [x] **A.2.1** `session` — `POST` (création session) — `validateOrigin` ajouté ; pas d’exception documentée (même politique que les autres mutations navigateur).
+- [x] **A.2.2** `discord/send-message` — `POST`
+- [x] **A.2.3** `discord/update-custom-message` — `POST`
+- [x] **A.2.4** `discord/availability-polls/create` — `POST`
+- [x] **A.2.5** `discord/availability-polls/[pollId]/close` — `POST`
+- [x] **A.2.6** `admin/discord-availability-config` — `POST` (GET à traiter en epic B pour cache)
+- [x] **A.2.7** Revérifier toute route ajoutée depuis l’audit — grep `export async function POST` sans `validateOrigin` après corrections.
+
+**Critères d’acceptation :** Aucune mutation same-origin par cookie ne reste sans garde **sans** entrée documentée dans la doc sécurité ; en dev, `APP_URL` / `NEXT_PUBLIC_APP_URL` cohérents pour ne pas casser les flux.
+
+### A.3 Rate limiting
+
+- [x] **A.3.1** Lister les endpoints à risque brute-force ou abus (auth, session, sync, Discord proxy, etc.).
+- [x] **A.3.2** Uniformiser l’usage de `checkRateLimit` (ou stratégie équivalente) sur les routes retenues ; clés de limite stables (ex. par IP + uid selon le cas).  
+  _Helpers :_ `src/lib/auth/rate-limit-http.ts`, `src/lib/auth/request-ip.ts` ; `session/firebase-token` aligné sur `enforceRateLimit`.
+- [x] **A.3.3** Vérifier la cohérence avec `docs/SECURITY.md` et les réponses HTTP `429`.
+
+---
+
+## Epic B — En-têtes `Cache-Control` (données sensibles)
+
+**Objectif :** `no-store` (et dérivés) sur les réponses JSON sensibles, conformément aux règles projet.
+
+### B.1 Helper réutilisable (optionnel mais recommandé)
+
+- [ ] **B.1.1** Introduire une fonction utilitaire du type `applyNoStoreHeaders(res: NextResponse)` dans `lib/auth/` ou `lib/http/` pour éviter la duplication.
+- [ ] **B.1.2** Utiliser ce helper dans les route handlers et dans `withAuth` si pertinent (évaluer double emballage).
+
+### B.2 Routes à corriger ou vérifier (audit)
+
+- [ ] **B.2.1** `admin/discord-availability-config` — `GET` et `POST` : ajouter en-têtes si absent.
+- [ ] **B.2.2** `brulage/validate` — `POST` : ajouter en-têtes sur la réponse JSON.
+- [ ] **B.2.3** `coach/request` — `POST`
+- [ ] **B.2.4** `discord/*` (create, close, send-message, update-custom-message, members, channels, etc.) : passer en revue **chaque** réponse JSON.
+- [ ] **B.2.5** Routes sans `Cache-Control` explicite **et** sans passage par `withAuth` : compléter (ex. certains `GET` admin).
+- [ ] **B.2.6** `openapi` — `GET` : décider si public OK sans `no-store` ou si restriction / désactivation en prod (documenter).
+
+**Critère d’acceptation :** Revue grep `NextResponse.json` sur `app/api` : soit headers no-store, soit `withAuth`, soit exception documentée (ex. health).
+
+---
+
+## Epic C — `runtime = "nodejs"` explicite
+
+**Objectif :** Toutes les routes utilisant Firebase Admin, Node crypto, Firestore, etc. déclarent `export const runtime = "nodejs";` (règles `.cursorrules`).
+
+### C.1 Routes signalées sans export explicite (audit phase 2)
+
+- [ ] **C.1.1** `admin/sync-status`
+- [ ] **C.1.2** `admin/users` (+ sous-routes si besoin)
+- [ ] **C.1.3** `admin/users/coach-request`
+- [ ] **C.1.4** `admin/users/set-role`
+- [ ] **C.1.5** `brulage/validate`
+- [ ] **C.1.6** `coach/request`
+- [ ] **C.1.7** `discord/link-license`
+- [ ] **C.1.8** `discord/members`
+- [ ] **C.1.9** `discord/send-message`
+- [ ] **C.1.10** `discord/update-custom-message`
+- [ ] **C.1.11** `fftt/players`
+- [ ] **C.1.12** `openapi` (si reste sur Node — sinon documenter)
+- [ ] **C.1.13** `teams/[teamId]/discord-channel`
+- [ ] **C.1.14** `teams/[teamId]/location`
+- [ ] **C.1.15** `teams/matches`
+
+- [ ] **C.2** Script ou checklist CI : optionnel — grep pour `firebase-admin` / `getFirestore` dans `route.ts` sans `runtime` (à discuter).
+
+---
+
+## Epic D — Cohérence des rôles (serveur & client)
+
+**Objectif :** Éviter les comparaisons magiques `"admin"`, `"coach"` ; utiliser `resolveRole`, `hasAnyRole`, `USER_ROLES`.
+
+- [ ] **D.1** Passer en revue **toutes** les routes API qui lisent `decoded.role` ou équivalent.
+- [ ] **D.2** Corriger les fichiers identifiés (ex. `discord/send-message`, `discord/update-custom-message`, autres grep `role !==` / `===`).
+- [ ] **D.3** Côté client : `useAuth` (`isAdmin`, `isCoach`, etc.) — aligner sur les constantes / types partagés si possible.
+- [ ] **D.4** Vérifier alignement **AuthGuard** (`allowedRoles`) vs routes API pour les pages modifiées (règle projet).
+
+---
+
+## Epic E — Toolchain & configuration Next
+
+### E.1 ESLint et build
+
+- [ ] **E.1.1** Décider : `eslint.ignoreDuringBuilds: false` dans `next.config.ts` **ou** politique explicite « le build CI utilise `npm run check` » — documenter dans `docs/QUALITY_GATES.md`.
+- [ ] **E.1.2** Si passage à `false`, corriger toutes les erreurs ESLint bloquantes puis valider `npm run check`.
+
+### E.2 `next.config.ts`
+
+- [ ] **E.2.1** **Fallbacks Firebase** : retirer ou isoler les valeurs par défaut ; utiliser variables d’environnement obligatoires en CI / App Hosting ; documenter pour dev local.
+- [ ] **E.2.2** **`productionBrowserSourceMaps`** : décision produit / sécurité — garder, désactiver, ou activer seulement sur branches / sentry ; documenter.
+- [ ] **E.2.3** Commentaire sur `generateBuildId` / `standalone` : vérifier qu’ils restent justifiés avec la stratégie de déploiement actuelle.
+
+---
+
+## Epic F — Rendu & performance (App Router)
+
+**Objectif :** Ne pas sur-optimiser prématurément ; récupérer du cache Next là où c’est safe.
+
+- [ ] **F.1** Cartographier les segments qui **peuvent** être statiques ou partiellement mis en cache (pages publiques, assets).
+- [ ] **F.2** Envisager de retirer `export const dynamic = "force-dynamic"` du **layout racine** si possible, et le pousser sur les segments qui posent problème (MUI/Firebase).
+- [ ] **F.3** Mesurer (Lighthouse / Web Vitals) avant/après sur 1–2 pages représentatives.
+
+---
+
+## Epic G — Qualité des composants React
+
+### G.1 Découpage des « god components »
+
+**Fichiers volumineux repérés (ordre de grandeur 800–1600+ lignes) :**  
+`AdvancedSettings`, `DiscordPollManager`, `NotificationCenter`, `SystemMaintenance`, `ThemeManager`, `ReportsManager`, `UserManagement`, `DataExportImport`, `AuditLogs`, `AppSettings`, `NotificationManager`, `GlobalStats`, `BackupRestore`, etc.
+
+Pour chaque fichier (traiter par ordre métier / douleur) :
+
+- [ ] **G.1.1** `AdvancedSettings` — extraire sous-composants + hooks
+- [ ] **G.1.2** `DiscordPollManager` — idem
+- [ ] **G.1.3** `NotificationCenter` / `NotificationManager` — mutualiser logique commune si duplication
+- [ ] **G.1.4** `ThemeManager`
+- [ ] **G.1.5** `ReportsManager`
+- [ ] **G.1.6** `UserManagement`
+- [ ] **G.1.7** `DataExportImport`
+- [ ] **G.1.8** `AuditLogs`
+- [ ] **G.1.9** `AppSettings`
+- [ ] **G.1.10** `SystemMaintenance`
+- [ ] **G.1.11** Autres fichiers > ~500 lignes restants (grep `wc -l`)
+
+**Critère :** Fichier principal < ~400 lignes **ou** justification inline (composant purement présentationnel sans logique).
+
+### G.2 Couche API client & hooks
+
+- [ ] **G.2.1** Créer des modules `lib/api/*.ts` ou hooks `useXxx` pour centraliser `fetch` vers `/api/...`, erreurs typées, et `credentials: "include"` si nécessaire.
+- [ ] **G.2.2** Migrer progressivement les plus gros consommateurs (admin, discord, compositions).
+
+### G.3 Patterns React
+
+- [ ] **G.3.1** Politique `React.FC` : soit migration vers fonctions `(props: Props) => JSX`, soit statu quo documenté.
+- [ ] **G.3.2** `React.memo` : l’utiliser seulement après profilage ou sur listes lourdes identifiées.
+
+---
+
+## Epic H — Accessibilité (a11y)
+
+- [ ] **H.1** Audit rapide des dialogs MUI (focus, escape, titres `aria-labelledby`).
+- [ ] **H.2** Accordion / onglets custom (compositions, équipes) — roles et clavier.
+- [ ] **H.3** Formulaires : labels explicites, messages d’erreur annoncés (où pertinent).
+
+---
+
+## Epic I — Tests
+
+- [ ] **I.1** Tests d’intégration route handlers critiques : `session`, `admin/users`, `brulage/validate`, `discord` proxy (mocks).
+- [ ] **I.2** Tests `middleware.ts` (redirects, rôles) si faisable avec `@edge-runtime` ou tests unitaires des fonctions extraites.
+- [ ] **I.3** Tests RTL pour 2–3 flux UI critiques (login masqué par middleware — choisir composants isolables).
+- [ ] **I.4** Vérifier que `coverageThreshold` Jest reste tenable ou ajuster avec justification dans `jest.config.js`.
+
+---
+
+## Epic J — Dette & observabilité
+
+### J.1 Dépendances
+
+- [ ] **J.1.1** Plan de migration **`react-beautiful-dnd`** vers une lib maintenue (ex. `@hello-pangea/dnd` ou Pragmatic drag-and-drop) — spike + estimation.
+
+### J.2 Logs
+
+- [ ] **J.2.1** Passer les `console.log` / `console.error` des `route.ts` en logs conditionnels (`NODE_ENV`, `DEBUG`) conformément aux règles projet.
+- [ ] **J.2.2** Éviter données sensibles dans les logs (emails, tokens).
+
+---
+
+## Epic K — Documentation & gouvernance
+
+- [ ] **K.1** Mettre à jour `docs/SECURITY.md` avec : CSRF, exceptions, rate limits, cache.
+- [ ] **K.2** Si pertinent, ajouter une section dans `.cursorrules` ou `docs/QUALITY_GATES.md` pointant vers ce plan **ou** vers la doc sécurité consolidée.
+- [ ] **K.3** Clôturer ce document : quand toutes les cases P0–P2 sont cochées, archiver ou créer `AUDIT_NEXTJS_REACT_ACTION_PLAN_ARCHIVE.md` avec date de fin.
+
+---
+
+## Vérification finale (gate de clôture audit)
+
+- [ ] **V.1** `npm run check` vert sur `main` (ou branche release).
+- [ ] **V.2** `npm run smoke:web` OK si disponible.
+- [ ] **V.3** Revue manuelle : tableau des routes API à jour (optionnel : export OpenAPI régénéré / vérifié).
+- [ ] **V.4** Revue sécurité rapide (CSRF + cache + rôles) par un second dev.
+
+---
+
+## Historique des mises à jour (changelog du plan)
+
+| Date | Auteur | Changement |
+|------|--------|------------|
+| 2026-05-09 | — | Création initiale à partir des audits phase 1 et 2 |
+| 2026-05-09 | — | Epic A complété : CSRF sur routes listées, rate limiting session / Discord / admin sync / discord config, doc `SECURITY.md`, helpers HTTP |

--- a/src/app/api/admin/discord-availability-config/route.ts
+++ b/src/app/api/admin/discord-availability-config/route.ts
@@ -9,6 +9,11 @@ import {
   initializeFirebaseAdmin,
 } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_ADMIN_DISCORD_CONFIG_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 const COLLECTION_NAME = "discordAvailabilityConfig";
 const DOCUMENT_ID = "default";
@@ -93,6 +98,13 @@ export async function GET() {
  */
 export async function POST(req: Request) {
   try {
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin" },
+        { status: 403 }
+      );
+    }
+
     // Vérifier l'authentification
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
@@ -120,6 +132,13 @@ export async function POST(req: Request) {
         { status: 403 }
       );
     }
+
+    const configRl = enforceRateLimit(
+      `admin:discord-availability-config:${decoded.uid}`,
+      RATE_LIMIT_ADMIN_DISCORD_CONFIG_PER_UID.max,
+      RATE_LIMIT_ADMIN_DISCORD_CONFIG_PER_UID.windowMs
+    );
+    if (configRl) return configRl;
 
     const body = await req.json();
     const { parisChannelId, equipesChannelId, parisMention, equipesMention } =

--- a/src/app/api/admin/sync-players/route.ts
+++ b/src/app/api/admin/sync-players/route.ts
@@ -6,6 +6,10 @@ import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/fir
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_ADMIN_SYNC_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 export const runtime = "nodejs";
 
@@ -46,6 +50,13 @@ export async function POST(req: NextRequest) {
         { status: 403 }
       );
     }
+
+    const syncRl = enforceRateLimit(
+      `admin:sync-players:${decoded.uid}`,
+      RATE_LIMIT_ADMIN_SYNC_PER_UID.max,
+      RATE_LIMIT_ADMIN_SYNC_PER_UID.windowMs
+    );
+    if (syncRl) return syncRl;
 
     console.log("🔄 [app/api/admin/sync-players] Déclenchement de la synchronisation des joueurs directe");
 

--- a/src/app/api/admin/sync-team-matches/route.ts
+++ b/src/app/api/admin/sync-team-matches/route.ts
@@ -10,6 +10,10 @@ import { Timestamp } from "firebase-admin/firestore";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_ADMIN_SYNC_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 export const runtime = "nodejs";
 
@@ -50,6 +54,13 @@ export async function POST(req: NextRequest) {
         { status: 403 }
       );
     }
+
+    const syncRl = enforceRateLimit(
+      `admin:sync-team-matches:${decoded.uid}`,
+      RATE_LIMIT_ADMIN_SYNC_PER_UID.max,
+      RATE_LIMIT_ADMIN_SYNC_PER_UID.windowMs
+    );
+    if (syncRl) return syncRl;
 
     console.log("🔄 [app/api/admin/sync-team-matches] Déclenchement de la synchronisation des matchs par équipe");
 

--- a/src/app/api/admin/sync-teams/route.ts
+++ b/src/app/api/admin/sync-teams/route.ts
@@ -9,6 +9,10 @@ import {
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_ADMIN_SYNC_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 export const runtime = "nodejs";
 
@@ -49,6 +53,13 @@ export async function POST(req: NextRequest) {
         { status: 403 }
       );
     }
+
+    const syncRl = enforceRateLimit(
+      `admin:sync-teams:${decoded.uid}`,
+      RATE_LIMIT_ADMIN_SYNC_PER_UID.max,
+      RATE_LIMIT_ADMIN_SYNC_PER_UID.windowMs
+    );
+    if (syncRl) return syncRl;
 
     console.log("🔄 [app/api/admin/sync-teams] Déclenchement de la synchronisation des équipes directe");
 

--- a/src/app/api/discord/availability-polls/[pollId]/close/route.ts
+++ b/src/app/api/discord/availability-polls/[pollId]/close/route.ts
@@ -7,6 +7,11 @@ import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import { initializeFirebaseAdmin } from "@/lib/firebase-admin";
 import { DiscordPollServiceAdmin } from "@/lib/services/discord-poll-service-admin";
 import { ChampionshipType } from "@/types/championship";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 
@@ -18,6 +23,13 @@ export async function POST(
   context: { params: Promise<{ pollId: string }> }
 ) {
   try {
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin" },
+        { status: 403 }
+      );
+    }
+
     const params = await context.params;
 
     // Vérifier l'authentification
@@ -47,6 +59,13 @@ export async function POST(
         { status: 403 }
       );
     }
+
+    const pollRl = enforceRateLimit(
+      `discord:poll-close:${decoded.uid}`,
+      RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID.max,
+      RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID.windowMs
+    );
+    if (pollRl) return pollRl;
 
     if (!DISCORD_TOKEN) {
       return NextResponse.json(

--- a/src/app/api/discord/availability-polls/create/route.ts
+++ b/src/app/api/discord/availability-polls/create/route.ts
@@ -8,6 +8,11 @@ import { initializeFirebaseAdmin } from "@/lib/firebase-admin";
 import { DiscordPollServiceAdmin } from "@/lib/services/discord-poll-service-admin";
 import { buildAvailabilityPollMessage } from "@/lib/discord/poll-builder";
 import { ChampionshipType } from "@/types/championship";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 
@@ -16,6 +21,13 @@ const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
  */
 export async function POST(req: Request) {
   try {
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin" },
+        { status: 403 }
+      );
+    }
+
     // Vérifier l'authentification
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
@@ -43,6 +55,13 @@ export async function POST(req: Request) {
         { status: 403 }
       );
     }
+
+    const pollRl = enforceRateLimit(
+      `discord:poll-create:${decoded.uid}`,
+      RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID.max,
+      RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID.windowMs
+    );
+    if (pollRl) return pollRl;
 
     if (!DISCORD_TOKEN) {
       return NextResponse.json(

--- a/src/app/api/discord/send-message/route.ts
+++ b/src/app/api/discord/send-message/route.ts
@@ -2,11 +2,23 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_DISCORD_PROXY_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 const db = getFirestore();
 
 export async function POST(req: Request) {
   try {
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin" },
+        { status: 403 }
+      );
+    }
+
     // Configuration du bot Discord (vérifier à l'intérieur de la fonction)
     const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
     const DISCORD_SERVER_ID = process.env.DISCORD_SERVER_ID;
@@ -38,6 +50,14 @@ export async function POST(req: Request) {
     }
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+
+    const discordRl = enforceRateLimit(
+      `discord:send-message:${decoded.uid}`,
+      RATE_LIMIT_DISCORD_PROXY_PER_UID.max,
+      RATE_LIMIT_DISCORD_PROXY_PER_UID.windowMs
+    );
+    if (discordRl) return discordRl;
+
     const role = decoded.role || "player";
 
     // Seuls les admins et coaches peuvent envoyer des messages Discord

--- a/src/app/api/discord/update-custom-message/route.ts
+++ b/src/app/api/discord/update-custom-message/route.ts
@@ -2,11 +2,23 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_DISCORD_PROXY_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 const db = getFirestore();
 
 export async function POST(req: Request) {
   try {
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid origin" },
+        { status: 403 }
+      );
+    }
+
     // Vérifier l'authentification
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
@@ -19,6 +31,14 @@ export async function POST(req: Request) {
     }
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+
+    const discordRl = enforceRateLimit(
+      `discord:update-custom:${decoded.uid}`,
+      RATE_LIMIT_DISCORD_PROXY_PER_UID.max,
+      RATE_LIMIT_DISCORD_PROXY_PER_UID.windowMs
+    );
+    if (discordRl) return discordRl;
+
     const role = decoded.role || "player";
     
     // Seuls les admins et coaches peuvent modifier les messages

--- a/src/app/api/session/firebase-token/route.ts
+++ b/src/app/api/session/firebase-token/route.ts
@@ -3,31 +3,12 @@ import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { adminAuth } from "@/lib/firebase-admin";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_FIREBASE_CUSTOM_TOKEN_PER_UID,
+} from "@/lib/auth/rate-limit-http";
 
 export const runtime = "nodejs";
-
-// Rate limiting simple en mémoire (pour éviter les abus)
-// En production, utilisez un service dédié comme Redis
-const tokenRequests = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
-const RATE_LIMIT_MAX_REQUESTS = 10; // Max 10 requêtes par minute
-
-function checkRateLimit(uid: string): boolean {
-  const now = Date.now();
-  const userLimit = tokenRequests.get(uid);
-
-  if (!userLimit || now > userLimit.resetAt) {
-    tokenRequests.set(uid, { count: 1, resetAt: now + RATE_LIMIT_WINDOW });
-    return true;
-  }
-
-  if (userLimit.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return false;
-  }
-
-  userLimit.count++;
-  return true;
-}
 
 export async function POST(req: NextRequest) {
   // Valider l'origine de la requête pour prévenir les attaques CSRF
@@ -47,15 +28,14 @@ export async function POST(req: NextRequest) {
 
   try {
     const decoded = await adminAuth.verifySessionCookie(cookie, true);
-    
-    // Rate limiting par utilisateur
-    if (!checkRateLimit(decoded.uid)) {
-      return NextResponse.json(
-        { error: "Too many requests" },
-        { status: 429 }
-      );
-    }
-    
+
+    const limited = enforceRateLimit(
+      `session:firebase-token:${decoded.uid}`,
+      RATE_LIMIT_FIREBASE_CUSTOM_TOKEN_PER_UID.max,
+      RATE_LIMIT_FIREBASE_CUSTOM_TOKEN_PER_UID.windowMs
+    );
+    if (limited) return limited;
+
     // Créer un custom token pour cet utilisateur
     const customToken = await adminAuth.createCustomToken(decoded.uid, {
       role: decoded.role,
@@ -68,4 +48,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid session" }, { status: 401 });
   }
 }
-

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,11 +1,32 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { getClientIp } from "@/lib/auth/request-ip";
+import {
+  enforceRateLimit,
+  RATE_LIMIT_SESSION_POST_PER_IP,
+} from "@/lib/auth/rate-limit-http";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
   try {
+    if (!validateOrigin(req)) {
+      return NextResponse.json(
+        { error: "Invalid origin", message: "Requête non autorisée" },
+        { status: 403 }
+      );
+    }
+
+    const ip = getClientIp(req);
+    const rateLimited = enforceRateLimit(
+      `session:post:${ip}`,
+      RATE_LIMIT_SESSION_POST_PER_IP.max,
+      RATE_LIMIT_SESSION_POST_PER_IP.windowMs
+    );
+    if (rateLimited) return rateLimited;
+
     const body = await req.json().catch(() => ({}));
     const { idToken } = body;
 

--- a/src/lib/auth/rate-limit-http.ts
+++ b/src/lib/auth/rate-limit-http.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { checkRateLimit } from "@/lib/auth/rate-limit";
+
+/** Limites par défaut pour l’Epic A (mutations coûteuses / auth). */
+export const RATE_LIMIT_SESSION_POST_PER_IP = {
+  max: 40,
+  windowMs: 15 * 60 * 1000,
+} as const;
+
+export const RATE_LIMIT_DISCORD_PROXY_PER_UID = {
+  max: 45,
+  windowMs: 60 * 1000,
+} as const;
+
+export const RATE_LIMIT_DISCORD_POLL_MUTATION_PER_UID = {
+  max: 25,
+  windowMs: 60 * 1000,
+} as const;
+
+export const RATE_LIMIT_ADMIN_SYNC_PER_UID = {
+  max: 10,
+  windowMs: 60 * 1000,
+} as const;
+
+export const RATE_LIMIT_ADMIN_DISCORD_CONFIG_PER_UID = {
+  max: 30,
+  windowMs: 60 * 1000,
+} as const;
+
+/** Custom token Firebase pour le client (rafraîchissements fréquents). */
+export const RATE_LIMIT_FIREBASE_CUSTOM_TOKEN_PER_UID = {
+  max: 10,
+  windowMs: 60 * 1000,
+} as const;
+
+export function tooManyRequestsResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      error: "Too many requests",
+      message: "Trop de requêtes. Réessayez plus tard.",
+    },
+    { status: 429 }
+  );
+}
+
+/**
+ * Retourne une réponse 429 si la limite est dépassée, sinon `null`.
+ */
+export function enforceRateLimit(
+  identifier: string,
+  maxRequests: number,
+  windowMs: number
+): NextResponse | null {
+  const result = checkRateLimit(identifier, maxRequests, windowMs);
+  if (!result.allowed) {
+    return tooManyRequestsResponse();
+  }
+  return null;
+}

--- a/src/lib/auth/request-ip.ts
+++ b/src/lib/auth/request-ip.ts
@@ -1,0 +1,14 @@
+/**
+ * Adresse IP client pour le rate limiting derrière proxy / CDN.
+ * Ne pas utiliser comme identité de sécurité forte (spoofable sans configuration proxy).
+ */
+export function getClientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = req.headers.get("x-real-ip");
+  if (realIp) return realIp.trim();
+  return "unknown";
+}


### PR DESCRIPTION
## Résumé
Mise en œuvre de l’**Epic A** (audit) : protection CSRF via `validateOrigin` sur les mutations listées, rate limiting cohérent (helpers `request-ip` + `rate-limit-http`), alignement de `/api/session/firebase-token` sur `checkRateLimit` centralisé.

## Détails
- `POST /api/session`, routes Discord (send, update-custom, polls create/close), `POST /api/admin/discord-availability-config`
- Limites : session (IP), Discord & sondages & admin sync (uid)
- Documentation : `docs/SECURITY.md`, `docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md` (Epic A coché)

## Vérifications
- [x] `npm run check`

Made with [Cursor](https://cursor.com)