### PR TITLE
fix(ci): déployer sur tout merge de PR vers main

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,9 +14,8 @@ jobs:
   deploy:
     name: Deploy to Firebase App Hosting
     runs-on: ubuntu-latest
-    # Ne déployer que si ce n'est pas un commit de merge automatique
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, 'Merge pull request')
-
+    # Déclenché par tout push sur main (merges de PR inclus). Si aucun fichier
+    # hors paths-ignore ne change, le workflow entier ne tourne pas (voir `on.push`).
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Retire le `if` qui sautait le job quand le message de merge contenait `Merge pull request`, pour aligner avec le flux PR → production.

Made with [Cursor](https://cursor.com)