### PR TITLE
fix(ci): déployer sur tout push vers main (sans paths-ignore)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,18 +4,13 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - ".github/workflows/*.md"
-      - "docs/**"
-      - "README.md"
 
 jobs:
   deploy:
     name: Deploy to Firebase App Hosting
     runs-on: ubuntu-latest
-    # Déclenché par tout push sur main (merges de PR inclus). Si aucun fichier
-    # hors paths-ignore ne change, le workflow entier ne tourne pas (voir `on.push`).
+    # Tout push sur main déclenche un déploiement (merges de PR inclus,
+    # y compris changements uniquement docs / markdown).
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Contexte
Complète la correction précédente : tout merge sur `main` doit lancer le déploiement, **y compris** lorsque la PR ne modifie que de la documentation (`**.md`, `docs/**`).

## Changement
- Suppression du bloc `paths-ignore` sur `on.push` dans `deploy-production.yml`.

## Effet
Chaque push sur `main` exécute **Deploy to Production** (merges PR inclus).

Made with [Cursor](https://cursor.com)