### PR TITLE
feat(security): Epic B — en-têtes no-store sur les réponses API

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -160,6 +160,14 @@ Les autres routes admin / coach déjà couvertes par l’audit (ex. `brulage/val
 
 **Limitation** : le rate limiting en mémoire n’est pas distribué ; pour plusieurs instances, prévoir Redis ou équivalent.
 
+## API : en-têtes anti-cache (`Cache-Control`)
+
+Les réponses JSON des route handlers passent par **`jsonNoStore`** ou **`applyNoStoreHeaders`** (`src/lib/http/cache-headers.ts`) : `Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`, `Pragma: no-cache`, `Expires: 0` (aligné sur les règles projet).
+
+- Le wrapper **`withAuth`** (`src/lib/auth/api-utils.ts`) applique `applyNoStoreHeaders` sur la réponse du handler et renvoie les erreurs d’authentification via **`jsonNoStore`**.
+- **`POST` / `DELETE` `/api/session`** : construction d’une `NextResponse` avec cookies, puis **`applyNoStoreHeaders`** (seul cas courant de `NextResponse.json` direct hors helper).
+- **`GET` `/api/openapi`** et **`GET` `/api/health`** : `jsonNoStore` pour une politique homogène (le contenu reste public, sans cache intermédiaire sur le JSON).
+
 ## Audit de sécurité automatisé
 
 Le projet utilise des outils automatisés pour détecter les secrets commités par erreur :

--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -2,7 +2,7 @@
 
 Ce document consolide les constats des audits **phase 1** (qualité globale Next.js, sécurité, perf, tests) et **phase 2** (matrice des routes API + qualité des composants React). Il sert de **backlog traçable** : cocher les cases au fil des PR / merges.
 
-**Dernière mise à jour :** 2026-05-09  
+**Dernière mise à jour :** 2026-05-09 (Epic B)  
 **Statuts :** `[ ]` à faire · `[~]` en cours · `[x]` terminé
 
 ---
@@ -32,7 +32,7 @@ Ce document consolide les constats des audits **phase 1** (qualité globale Next
 | Epic | Description | Priorité max |
 |------|-------------|--------------|
 | A | Sécurité API : CSRF (`validateOrigin`), compléments rate limiting | ~~P0~~ **traité (2026-05-09)** |
-| B | En-têtes `Cache-Control` sur réponses sensibles | P0 / P1 |
+| B | En-têtes `Cache-Control` sur réponses sensibles | ~~P0 / P1~~ **traité (2026-05-09)** |
 | C | `export const runtime = "nodejs"` sur routes concernées | P1 |
 | D | Cohérence des rôles (`resolveRole`, `hasAnyRole`, `USER_ROLES`) | P1 |
 | E | Toolchain : ESLint vs build, config Next (`next.config.ts`) | P2 |
@@ -83,19 +83,19 @@ Ce document consolide les constats des audits **phase 1** (qualité globale Next
 
 ### B.1 Helper réutilisable (optionnel mais recommandé)
 
-- [ ] **B.1.1** Introduire une fonction utilitaire du type `applyNoStoreHeaders(res: NextResponse)` dans `lib/auth/` ou `lib/http/` pour éviter la duplication.
-- [ ] **B.1.2** Utiliser ce helper dans les route handlers et dans `withAuth` si pertinent (évaluer double emballage).
+- [x] **B.1.1** `src/lib/http/cache-headers.ts` : `applyNoStoreHeaders`, `jsonNoStore`.
+- [x] **B.1.2** `withAuth` utilise `applyNoStoreHeaders` / `jsonNoStore` ; routes API migrées vers `jsonNoStore` (remplace `NextResponse.json`).
 
 ### B.2 Routes à corriger ou vérifier (audit)
 
-- [ ] **B.2.1** `admin/discord-availability-config` — `GET` et `POST` : ajouter en-têtes si absent.
-- [ ] **B.2.2** `brulage/validate` — `POST` : ajouter en-têtes sur la réponse JSON.
-- [ ] **B.2.3** `coach/request` — `POST`
-- [ ] **B.2.4** `discord/*` (create, close, send-message, update-custom-message, members, channels, etc.) : passer en revue **chaque** réponse JSON.
-- [ ] **B.2.5** Routes sans `Cache-Control` explicite **et** sans passage par `withAuth` : compléter (ex. certains `GET` admin).
-- [ ] **B.2.6** `openapi` — `GET` : décider si public OK sans `no-store` ou si restriction / désactivation en prod (documenter).
+- [x] **B.2.1** `admin/discord-availability-config` — `GET` / `POST` via `jsonNoStore`.
+- [x] **B.2.2** `brulage/validate` — `jsonNoStore`.
+- [x] **B.2.3** `coach/request` — `jsonNoStore`.
+- [x] **B.2.4** Toutes les routes `discord/**/route.ts` passées en revue — `jsonNoStore`.
+- [x] **B.2.5** Passage systématique sur `src/app/api/**/route.ts` (sauf `session` : cookies + `applyNoStoreHeaders`).
+- [x] **B.2.6** `openapi` — `jsonNoStore` ; politique documentée dans `docs/SECURITY.md` (homogénéité, contenu toujours public).
 
-**Critère d’acceptation :** Revue grep `NextResponse.json` sur `app/api` : soit headers no-store, soit `withAuth`, soit exception documentée (ex. health).
+**Critère d’acceptation :** Plus de `NextResponse.json` nu dans `app/api` sauf `session/route.ts` (cookies) ; ou passage par `withAuth`.
 
 ---
 
@@ -249,3 +249,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 |------|--------|------------|
 | 2026-05-09 | — | Création initiale à partir des audits phase 1 et 2 |
 | 2026-05-09 | — | Epic A complété : CSRF sur routes listées, rate limiting session / Discord / admin sync / discord config, doc `SECURITY.md`, helpers HTTP |
+| 2026-05-09 | — | Epic B complété : `lib/http/cache-headers`, `withAuth` + toutes les routes `app/api` en `jsonNoStore` / `applyNoStoreHeaders`, doc `SECURITY.md` |

--- a/src/app/api/admin/discord-availability-config/route.ts
+++ b/src/app/api/admin/discord-availability-config/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -28,7 +28,7 @@ export async function GET() {
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -36,7 +36,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -45,7 +45,7 @@ export async function GET() {
     // Vérifier que l'utilisateur est admin
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé - Admin uniquement" },
         { status: 403 }
       );
@@ -57,7 +57,7 @@ export async function GET() {
     const docSnap = await docRef.get();
 
     if (!docSnap.exists) {
-      return NextResponse.json({
+      return jsonNoStore({
         success: true,
         config: {
           parisChannelId: null,
@@ -69,7 +69,7 @@ export async function GET() {
     }
 
     const data = docSnap.data();
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       config: {
         parisChannelId: data?.parisChannelId || null,
@@ -83,7 +83,7 @@ export async function GET() {
       "[Discord Availability Config] Erreur lors de la récupération:",
       error
     );
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la récupération de la configuration",
@@ -99,7 +99,7 @@ export async function GET() {
 export async function POST(req: Request) {
   try {
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -110,7 +110,7 @@ export async function POST(req: Request) {
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -118,7 +118,7 @@ export async function POST(req: Request) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -127,7 +127,7 @@ export async function POST(req: Request) {
     // Vérifier que l'utilisateur est admin
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé - Admin uniquement" },
         { status: 403 }
       );
@@ -150,7 +150,7 @@ export async function POST(req: Request) {
       parisChannelId !== undefined &&
       typeof parisChannelId !== "string"
     ) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "parisChannelId doit être une chaîne ou null",
@@ -164,7 +164,7 @@ export async function POST(req: Request) {
       equipesChannelId !== undefined &&
       typeof equipesChannelId !== "string"
     ) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "equipesChannelId doit être une chaîne ou null",
@@ -178,7 +178,7 @@ export async function POST(req: Request) {
       parisMention !== undefined &&
       typeof parisMention !== "string"
     ) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "parisMention doit être une chaîne ou null" },
         { status: 400 }
       );
@@ -189,7 +189,7 @@ export async function POST(req: Request) {
       equipesMention !== undefined &&
       typeof equipesMention !== "string"
     ) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "equipesMention doit être une chaîne ou null",
@@ -213,7 +213,7 @@ export async function POST(req: Request) {
 
     await docRef.set(dataToSave, { merge: true });
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       config: {
         parisChannelId: parisChannelId || null,
@@ -227,7 +227,7 @@ export async function POST(req: Request) {
       "[Discord Availability Config] Erreur lors de la sauvegarde:",
       error
     );
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la sauvegarde de la configuration",

--- a/src/app/api/admin/locations/route.ts
+++ b/src/app/api/admin/locations/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { adminDb, adminAuth } from "@/lib/firebase-admin";
@@ -15,7 +15,7 @@ export async function GET() {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Authentification requise" },
         { status: 401 }
       );
@@ -23,7 +23,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -32,7 +32,7 @@ export async function GET() {
     // Vérifier que l'utilisateur est admin
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -48,10 +48,10 @@ export async function GET() {
       updatedAt: doc.data().updatedAt?.toDate?.()?.toISOString() || new Date().toISOString(),
     }));
 
-    return NextResponse.json({ success: true, locations });
+    return jsonNoStore({ success: true, locations });
   } catch (error) {
     console.error("[locations] GET error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des lieux" },
       { status: 500 }
     );
@@ -62,7 +62,7 @@ export async function POST(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Invalid origin",
@@ -77,7 +77,7 @@ export async function POST(req: NextRequest) {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Authentification requise" },
         { status: 401 }
       );
@@ -85,7 +85,7 @@ export async function POST(req: NextRequest) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -94,7 +94,7 @@ export async function POST(req: NextRequest) {
     // Vérifier que l'utilisateur est admin
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
     const { name } = await req.json();
 
     if (!name || typeof name !== "string" || name.trim() === "") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Le nom du lieu est requis" },
         { status: 400 }
       );
@@ -118,7 +118,7 @@ export async function POST(req: NextRequest) {
       .get();
     
     if (!existingSnapshot.empty) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Ce lieu existe déjà" },
         { status: 400 }
       );
@@ -130,7 +130,7 @@ export async function POST(req: NextRequest) {
       updatedAt: Timestamp.fromDate(now),
     });
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       location: {
         id: docRef.id,
@@ -141,7 +141,7 @@ export async function POST(req: NextRequest) {
     });
   } catch (error) {
     console.error("[locations] POST error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de l'ajout du lieu" },
       { status: 500 }
     );
@@ -152,7 +152,7 @@ export async function DELETE(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Invalid origin",
@@ -167,7 +167,7 @@ export async function DELETE(req: NextRequest) {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Authentification requise" },
         { status: 401 }
       );
@@ -175,7 +175,7 @@ export async function DELETE(req: NextRequest) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -184,7 +184,7 @@ export async function DELETE(req: NextRequest) {
     // Vérifier que l'utilisateur est admin
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -194,7 +194,7 @@ export async function DELETE(req: NextRequest) {
     const id = searchParams.get("id");
 
     if (!id) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "L'ID du lieu est requis" },
         { status: 400 }
       );
@@ -203,10 +203,10 @@ export async function DELETE(req: NextRequest) {
     const locationRef = adminDb.collection("locations").doc(id);
     await locationRef.delete();
 
-    return NextResponse.json({ success: true });
+    return jsonNoStore({ success: true });
   } catch (error) {
     console.error("[locations] DELETE error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la suppression du lieu" },
       { status: 500 }
     );

--- a/src/app/api/admin/sync-players/route.ts
+++ b/src/app/api/admin/sync-players/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { syncPlayers } from "@/lib/shared/sync-utils";
@@ -17,7 +17,7 @@ export async function POST(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Invalid origin",
           message: "Requête non autorisée",
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Token d'authentification requis",
           message: "Cette API nécessite une authentification valide",
@@ -42,7 +42,7 @@ export async function POST(req: NextRequest) {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Accès refusé",
           message: "Cette opération est réservée aux administrateurs",
@@ -75,14 +75,10 @@ export async function POST(req: NextRequest) {
       success: result.success,
     });
 
-    const res = NextResponse.json(result, { status: 200 });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore(result, { status: 200 });
   } catch (error) {
     console.error("❌ [app/api/admin/sync-players] Erreur lors de la synchronisation des joueurs:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la synchronisation des joueurs",

--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -8,7 +8,7 @@ export async function GET() {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Session cookie requis" },
         { status: 401 }
       );
@@ -18,7 +18,7 @@ export async function GET() {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Accès refusé",
@@ -48,7 +48,7 @@ export async function GET() {
       `✅ Statut récupéré: ${playersCount} joueurs, ${teamsCount} équipes, ${teamMatchesCount} matchs par équipe`
     );
 
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: true,
         data: {
@@ -73,7 +73,7 @@ export async function GET() {
     );
   } catch (error) {
     console.error("❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",

--- a/src/app/api/admin/sync-team-matches/route.ts
+++ b/src/app/api/admin/sync-team-matches/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import {
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Invalid origin",
           message: "Requête non autorisée",
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Token d'authentification requis",
           message: "Cette API nécessite une authentification valide",
@@ -46,7 +46,7 @@ export async function POST(req: NextRequest) {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Accès refusé",
           message: "Cette opération est réservée aux administrateurs",
@@ -75,7 +75,7 @@ export async function POST(req: NextRequest) {
     const syncResult = await teamMatchesSyncService.syncMatchesForAllTeams(db);
 
     if (!syncResult.success || !syncResult.processedMatches) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Erreur lors de la synchronisation",
@@ -121,7 +121,7 @@ export async function POST(req: NextRequest) {
       success: true,
     });
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       {
         success: true,
         message: `Synchronisation des matchs réussie: ${saveResult.saved} matchs sauvegardés dans les sous-collections`,
@@ -133,13 +133,9 @@ export async function POST(req: NextRequest) {
       },
       { status: 200 }
     );
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
   } catch (error) {
     console.error("❌ [app/api/admin/sync-team-matches] Erreur lors de la synchronisation des matchs:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la synchronisation des matchs",

--- a/src/app/api/admin/sync-teams/route.ts
+++ b/src/app/api/admin/sync-teams/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import {
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Invalid origin",
           message: "Requête non autorisée",
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Token d'authentification requis",
           message: "Cette API nécessite une authentification valide",
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Accès refusé",
           message: "Cette opération est réservée aux administrateurs",
@@ -72,7 +72,7 @@ export async function POST(req: NextRequest) {
     const syncResult = await teamSyncService.syncTeamsAndMatches();
 
     if (!syncResult.success || !syncResult.processedTeams) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Erreur lors de la synchronisation",
@@ -109,7 +109,7 @@ export async function POST(req: NextRequest) {
       success: true,
     });
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       {
         success: true,
         message: `Synchronisation des équipes réussie: ${saveResult.saved} équipes sauvegardées`,
@@ -121,13 +121,9 @@ export async function POST(req: NextRequest) {
       },
       { status: 200 }
     );
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
   } catch (error) {
     console.error("❌ [app/api/admin/sync-teams] Erreur lors de la synchronisation des équipes:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la synchronisation des équipes",

--- a/src/app/api/admin/users/coach-request/route.ts
+++ b/src/app/api/admin/users/coach-request/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import {
@@ -28,7 +28,7 @@ export async function PATCH(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Invalid origin",
@@ -41,7 +41,7 @@ export async function PATCH(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Session cookie requis" },
         { status: 401 }
       );
@@ -51,7 +51,7 @@ export async function PATCH(req: NextRequest) {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -65,7 +65,7 @@ export async function PATCH(req: NextRequest) {
     }: CoachRequestUpdatePayload = await req.json();
 
     if (!userId || (action !== "approve" && action !== "reject")) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Paramètres invalides" },
         { status: 400 }
       );
@@ -143,17 +143,10 @@ export async function PATCH(req: NextRequest) {
       });
     }
 
-    const res = NextResponse.json({ success: true }, { status: 200 });
-    res.headers.set(
-      "Cache-Control",
-      "no-store, no-cache, must-revalidate, proxy-revalidate"
-    );
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore({ success: true }, { status: 200 });
   } catch (error) {
     console.error("[app/api/admin/users/coach-request] error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Impossible de mettre à jour la demande",

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { DocumentData, QueryDocumentSnapshot, Query } from "firebase-admin/firestore";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
@@ -10,7 +10,7 @@ export async function GET() {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Session cookie requis" },
         { status: 401 }
       );
@@ -19,7 +19,7 @@ export async function GET() {
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -160,14 +160,10 @@ export async function GET() {
       };
     });
 
-    const res = NextResponse.json({ success: true, users }, { status: 200 });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore({ success: true, users }, { status: 200 });
   } catch (error) {
     console.error("[app/api/admin/users] error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Impossible de récupérer la liste des utilisateurs",

--- a/src/app/api/admin/users/set-role/route.ts
+++ b/src/app/api/admin/users/set-role/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
@@ -52,7 +52,7 @@ export async function POST(req: NextRequest) {
   try {
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Invalid origin",
@@ -65,7 +65,7 @@ export async function POST(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Session cookie requis" },
         { status: 401 }
       );
@@ -75,7 +75,7 @@ export async function POST(req: NextRequest) {
     const requesterRole = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(requesterRole, ADMIN_ONLY_ROLES)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Accès refusé",
@@ -91,7 +91,7 @@ export async function POST(req: NextRequest) {
       body ?? {};
 
     if (!userId || typeof userId !== "string") {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Paramètre 'userId' invalide",
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
     const resolvedRole = resolveRole(role ?? null);
 
     if (!MANAGED_ROLES.includes(resolvedRole)) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: "Rôle invalide",
@@ -164,7 +164,7 @@ export async function POST(req: NextRequest) {
       success: true,
     });
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       {
         success: true,
         data: {
@@ -175,10 +175,6 @@ export async function POST(req: NextRequest) {
       },
       { status: 200 }
     );
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
   } catch (error) {
     console.error("[app/api/admin/users/set-role] error", error);
     
@@ -198,7 +194,7 @@ export async function POST(req: NextRequest) {
       // Ignorer les erreurs de logging d'audit
     }
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la mise à jour du rôle",
@@ -206,8 +202,6 @@ export async function POST(req: NextRequest) {
       },
       { status: 500 }
     );
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    return res;
   }
 }
 

--- a/src/app/api/auth/send-password-reset/route.ts
+++ b/src/app/api/auth/send-password-reset/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { sendMail } from "@/lib/mailer";
 import { readFile } from "fs/promises";
@@ -22,13 +22,13 @@ export async function POST(req: Request) {
   try {
     const { email } = await req.json();
     if (!email || typeof email !== "string") {
-      return NextResponse.json({ error: "Email requis" }, { status: 400 });
+      return jsonNoStore({ error: "Email requis" }, { status: 400 });
     }
 
     // Validation du format email
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Format d'email invalide" },
         { status: 400 }
       );
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
     // Rate limiting par email (3 requêtes par 15 minutes)
     const rateLimitResult = checkRateLimit(`email:${email}`, 3, 15 * 60 * 1000);
     if (!rateLimitResult.allowed) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Trop de requêtes",
           message: `Veuillez patienter avant de renvoyer un email. Prochaine tentative possible dans ${Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000 / 60)} minutes.`,
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
       ) {
         // Ne pas révéler si l'utilisateur existe ou non (sécurité)
         // Retourner toujours 200 pour éviter l'énumération d'emails
-        return NextResponse.json({ ok: true });
+        return jsonNoStore({ ok: true });
       }
       
       if (
@@ -120,7 +120,7 @@ export async function POST(req: Request) {
         errorMessage.includes("invalid-email") ||
         errorMessage.includes("INVALID_EMAIL")
       ) {
-        return NextResponse.json(
+        return jsonNoStore(
           { error: "Email invalide", message: "L'adresse email n'est pas valide" },
           { status: 400 }
         );
@@ -128,7 +128,7 @@ export async function POST(req: Request) {
 
       // Autres erreurs Firebase
       console.error("[send-password-reset] Erreur Firebase:", error);
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Erreur lors de la génération du lien", message: getFirebaseErrorMessage(error) },
         { status: 500 }
       );
@@ -173,7 +173,7 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       console.error("[send-password-reset] Erreur lors de l'envoi de l'email:", error);
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Erreur lors de l'envoi de l'email", message: "Impossible d'envoyer l'email de réinitialisation" },
         { status: 500 }
       );
@@ -181,11 +181,7 @@ export async function POST(req: Request) {
 
     // Ne pas révéler si l'utilisateur existe ou non (sécurité)
     // Toujours retourner 200 pour éviter l'énumération d'emails
-    const res = NextResponse.json({ ok: true });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore({ ok: true });
   } catch (error) {
     // Logger l'erreur complète côté serveur pour le débogage
     console.error("[send-password-reset] error", error);
@@ -226,11 +222,9 @@ export async function POST(req: Request) {
       statusCode = 429;
     }
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       { error: errorMessage },
       { status: statusCode }
     );
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    return res;
   }
 }

--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { sendMail } from "@/lib/mailer";
 import { readFile } from "fs/promises";
@@ -21,13 +21,13 @@ export async function POST(req: Request) {
   try {
     const { email } = await req.json();
     if (!email || typeof email !== "string") {
-      return NextResponse.json({ error: "Email requis" }, { status: 400 });
+      return jsonNoStore({ error: "Email requis" }, { status: 400 });
     }
 
     // Validation du format email
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Format d'email invalide" },
         { status: 400 }
       );
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
     // Rate limiting par email (3 requêtes par 15 minutes)
     const rateLimitResult = checkRateLimit(`email:${email}`, 3, 15 * 60 * 1000);
     if (!rateLimitResult.allowed) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Trop de requêtes",
           message: `Veuillez patienter avant de renvoyer un email. Prochaine tentative possible dans ${Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000 / 60)} minutes.`,
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
         errorMessage.includes("USER_NOT_FOUND") ||
         errorMessage.includes("no user record")
       ) {
-        return NextResponse.json(
+        return jsonNoStore(
           { error: "Utilisateur non trouvé", message: "Aucun compte n'est associé à cet email" },
           { status: 404 }
         );
@@ -120,7 +120,7 @@ export async function POST(req: Request) {
         errorMessage.includes("invalid-email") ||
         errorMessage.includes("INVALID_EMAIL")
       ) {
-        return NextResponse.json(
+        return jsonNoStore(
           { error: "Email invalide", message: "L'adresse email n'est pas valide" },
           { status: 400 }
         );
@@ -128,7 +128,7 @@ export async function POST(req: Request) {
 
       // Autres erreurs Firebase
       console.error("[send-verification] Erreur Firebase:", error);
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Erreur lors de la génération du lien", message: getFirebaseErrorMessage(error) },
         { status: 500 }
       );
@@ -174,18 +174,13 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       console.error("[send-verification] Erreur lors de l'envoi de l'email:", error);
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Erreur lors de l'envoi de l'email", message: "Impossible d'envoyer l'email de vérification" },
         { status: 500 }
       );
     }
 
-    const res = NextResponse.json({ ok: true });
-    // Ajouter Cache-Control pour éviter la mise en cache
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore({ ok: true });
   } catch (error) {
     // Logger l'erreur complète côté serveur pour le débogage
     console.error("[send-verification] error", error);
@@ -204,11 +199,9 @@ export async function POST(req: Request) {
       statusCode = 429;
     }
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       { error: errorMessage },
       { status: statusCode }
     );
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    return res;
   }
 }

--- a/src/app/api/brulage/validate/route.ts
+++ b/src/app/api/brulage/validate/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
   try {
     // CSRF Protection
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -20,13 +20,13 @@ export async function POST(req: Request) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json({ error: "Session cookie requis" }, { status: 401 });
+      return jsonNoStore({ error: "Session cookie requis" }, { status: 401 });
     }
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Accès refusé", message: "Cette ressource est réservée aux administrateurs et coachs" },
         { status: 403 }
       );
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
 
     const { composition, teamNumber, journee, phase } = await req.json();
     if (!composition || !teamNumber || !journee || !phase) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Missing required parameters: composition, teamNumber, journee, phase" },
         { status: 400 }
       );
@@ -52,10 +52,10 @@ export async function POST(req: Request) {
       phase
     );
 
-    return NextResponse.json(validation, { status: 200 });
+    return jsonNoStore(validation, { status: 200 });
   } catch (error) {
     console.error("[app/api/brulage/validate] Error:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         error: "Failed to validate composition",
         details: error instanceof Error ? error.message : "Unknown error",

--- a/src/app/api/coach/request/route.ts
+++ b/src/app/api/coach/request/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, COACH_REQUEST_STATUS, resolveRole } from "@/lib/auth/roles";
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
   try {
     // CSRF Protection
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Authentification requise" },
         { status: 401 }
       );
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
       !hasAnyRole(role, [USER_ROLES.PLAYER]) &&
       !hasAnyRole(role, [USER_ROLES.COACH, USER_ROLES.ADMIN])
     ) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -72,10 +72,10 @@ export async function POST(req: Request) {
       success: true,
     });
 
-    return NextResponse.json({ success: true }, { status: 200 });
+    return jsonNoStore({ success: true }, { status: 200 });
   } catch (error) {
     console.error("[app/api/coach/request] error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Impossible d'enregistrer la demande",

--- a/src/app/api/discord/availability-polls/[pollId]/close/route.ts
+++ b/src/app/api/discord/availability-polls/[pollId]/close/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -24,7 +24,7 @@ export async function POST(
 ) {
   try {
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -37,7 +37,7 @@ export async function POST(
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -45,7 +45,7 @@ export async function POST(
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -54,7 +54,7 @@ export async function POST(
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé - Admin ou Coach requis" },
         { status: 403 }
       );
@@ -68,7 +68,7 @@ export async function POST(
     if (pollRl) return pollRl;
 
     if (!DISCORD_TOKEN) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
         { status: 500 }
       );
@@ -80,7 +80,7 @@ export async function POST(
     // Récupérer le sondage
     const parts = params.pollId.split("_");
     if (parts.length < 3) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Format de pollId invalide" },
         { status: 400 }
       );
@@ -99,14 +99,14 @@ export async function POST(
     );
 
     if (!poll) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Sondage introuvable" },
         { status: 404 }
       );
     }
 
     if (!poll.isActive) {
-      return NextResponse.json({
+      return jsonNoStore({
         success: true,
         message: "Le sondage est déjà fermé",
         poll,
@@ -231,13 +231,13 @@ export async function POST(
     // Fermer le sondage dans Firestore
     await pollService.closePoll(journee, phase, championshipType, idEpreuve);
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       message: "Sondage fermé avec succès",
     });
   } catch (error) {
     console.error("[Discord Poll Close] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la fermeture du sondage" },
       { status: 500 }
     );

--- a/src/app/api/discord/availability-polls/create/route.ts
+++ b/src/app/api/discord/availability-polls/create/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -22,7 +22,7 @@ const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 export async function POST(req: Request) {
   try {
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -33,7 +33,7 @@ export async function POST(req: Request) {
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé - Admin ou Coach requis" },
         { status: 403 }
       );
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     if (pollRl) return pollRl;
 
     if (!DISCORD_TOKEN) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
         { status: 500 }
       );
@@ -85,21 +85,21 @@ export async function POST(req: Request) {
 
     // Validation
     if (typeof journee !== "number" || journee < 1) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "journee doit être un nombre positif" },
         { status: 400 }
       );
     }
 
     if (phase !== "aller" && phase !== "retour") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "phase doit être 'aller' ou 'retour'" },
         { status: 400 }
       );
     }
 
     if (championshipType !== "masculin" && championshipType !== "feminin") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "championshipType doit être 'masculin' ou 'feminin'" },
         { status: 400 }
       );
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
     // Récupérer la configuration des channels Discord
     const configDoc = await db.collection("discordAvailabilityConfig").doc("default").get();
     if (!configDoc.exists) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration Discord non trouvée. Configurez les channels dans l'administration." },
         { status: 400 }
       );
@@ -139,7 +139,7 @@ export async function POST(req: Request) {
       : config?.parisChannelId || null;
 
     if (!targetChannelId) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: isTeamChampionship
@@ -166,7 +166,7 @@ export async function POST(req: Request) {
     );
 
     if (existingPoll && existingPoll.isActive) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error: `Un sondage actif existe déjà pour cette combinaison (Journée ${journee}, Phase ${phase}, ${pollChampionshipTypeForCheck === "masculin" ? "Masculin" : "Féminin"}). Veuillez fermer le sondage existant avant d'en créer un nouveau.`,
@@ -218,7 +218,7 @@ export async function POST(req: Request) {
             : messageTemplate,
         embedDescriptionLength: embedDescription.length,
       });
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error:
@@ -244,7 +244,7 @@ export async function POST(req: Request) {
     if (!discordResponse.ok) {
       const errorText = await discordResponse.text();
       console.error("[Discord Poll] Erreur lors de l'envoi:", errorText);
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Erreur lors de l'envoi du message Discord" },
         { status: 500 }
       );
@@ -266,7 +266,7 @@ export async function POST(req: Request) {
       createdBy: decoded.uid,
     });
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       poll: {
         id: pollId,
@@ -281,7 +281,7 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     console.error("[Discord Poll Create] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la création du sondage" },
       { status: 500 }
     );

--- a/src/app/api/discord/availability-polls/route.ts
+++ b/src/app/api/discord/availability-polls/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -18,7 +18,7 @@ export async function GET(req: Request) {
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -26,7 +26,7 @@ export async function GET(req: Request) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -35,7 +35,7 @@ export async function GET(req: Request) {
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé - Admin ou Coach requis" },
         { status: 403 }
       );
@@ -59,7 +59,7 @@ export async function GET(req: Request) {
         idEpreuve ? parseInt(idEpreuve, 10) : undefined
       );
 
-      return NextResponse.json({
+      return jsonNoStore({
         success: true,
         poll: poll || null,
       });
@@ -92,13 +92,13 @@ export async function GET(req: Request) {
       };
     });
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       polls,
     });
   } catch (error) {
     console.error("[Discord Polls GET] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des sondages" },
       { status: 500 }
     );

--- a/src/app/api/discord/channels/route.ts
+++ b/src/app/api/discord/channels/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -15,7 +15,7 @@ export async function GET() {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -23,7 +23,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -32,14 +32,14 @@ export async function GET() {
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
     }
 
     if (!DISCORD_TOKEN || !DISCORD_SERVER_ID) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
         { status: 500 }
       );
@@ -59,7 +59,7 @@ export async function GET() {
     if (!response.ok) {
       const errorText = await response.text();
       console.error("[Discord Channels] Erreur lors de la récupération des canaux:", errorText);
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: `Erreur lors de la récupération des canaux Discord: ${errorText}` },
         { status: response.status }
       );
@@ -152,14 +152,14 @@ export async function GET() {
       .map(({ id, name }) => ({ id, name }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    return NextResponse.json({ 
+    return jsonNoStore({ 
       success: true, 
       channels: flatChannels, // Format plat pour compatibilité
       hierarchy: channelsByCategory, // Structure hiérarchique
     });
   } catch (error) {
     console.error("[Discord] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des canaux" },
       { status: 500 }
     );

--- a/src/app/api/discord/check-message-sent/route.ts
+++ b/src/app/api/discord/check-message-sent/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
@@ -15,7 +15,7 @@ export async function GET(req: Request) {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -23,7 +23,7 @@ export async function GET(req: Request) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -32,7 +32,7 @@ export async function GET(req: Request) {
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -45,7 +45,7 @@ export async function GET(req: Request) {
     const phase = searchParams.get("phase");
 
     if (!journee || !phase) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "journee et phase sont requis" },
         { status: 400 }
       );
@@ -60,14 +60,14 @@ export async function GET(req: Request) {
       // Ancien format : un seul teamId (rétrocompatibilité)
       teamIds = [teamId];
     } else {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "teamIds ou teamId est requis" },
         { status: 400 }
       );
     }
 
     if (teamIds.length === 0) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Au moins un teamId est requis" },
         { status: 400 }
       );
@@ -76,7 +76,7 @@ export async function GET(req: Request) {
     // Limiter le nombre de teamIds pour éviter l'énumération et les abus
     const MAX_TEAM_IDS = 50;
     if (teamIds.length > MAX_TEAM_IDS) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: `Maximum ${MAX_TEAM_IDS} teamIds autorisés` },
         { status: 400 }
       );
@@ -87,7 +87,7 @@ export async function GET(req: Request) {
     const validTeamIdPattern = /^[a-zA-Z0-9_-]+$/;
     const invalidTeamIds = teamIds.filter(id => !validTeamIdPattern.test(id));
     if (invalidTeamIds.length > 0) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Format de teamId invalide" },
         { status: 400 }
       );
@@ -141,7 +141,7 @@ export async function GET(req: Request) {
     // Si un seul teamId était demandé (ancien format), retourner le format simple pour compatibilité
     if (teamIds.length === 1 && teamId) {
       const result = results[teamIds[0]];
-      return NextResponse.json({
+      return jsonNoStore({
         success: true,
         sent: result.sent,
         sentAt: result.sentAt,
@@ -150,10 +150,10 @@ export async function GET(req: Request) {
     }
 
     // Nouveau format : retourner tous les résultats
-    return NextResponse.json({ success: true, results });
+    return jsonNoStore({ success: true, results });
   } catch (error) {
     console.error("[Discord] Erreur lors de la vérification:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la vérification" },
       { status: 500 }
     );

--- a/src/app/api/discord/interactions/route.ts
+++ b/src/app/api/discord/interactions/route.ts
@@ -1,7 +1,7 @@
 // Forcer le runtime Node.js pour utiliser les modules crypto natifs
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import {
   getFirestoreAdmin,
   initializeFirebaseAdmin,
@@ -46,7 +46,7 @@ export async function POST(req: Request) {
     // Vérifier que DISCORD_PUBLIC_KEY est configuré (obligatoire en production)
     if (!DISCORD_PUBLIC_KEY) {
       console.error("[Discord Interactions] DISCORD_PUBLIC_KEY non configuré");
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Server misconfiguration" },
         { status: 500 }
       );
@@ -59,7 +59,7 @@ export async function POST(req: Request) {
 
     if (!signature || !timestamp) {
       console.error("[Discord Interactions] Headers de signature manquants");
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+      return jsonNoStore({ error: "Invalid signature" }, { status: 401 });
     }
 
     const isValid = verifyDiscordSignature(
@@ -70,7 +70,7 @@ export async function POST(req: Request) {
     );
     if (!isValid) {
       console.error("[Discord Interactions] Signature invalide");
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+      return jsonNoStore({ error: "Invalid signature" }, { status: 401 });
     }
 
     const data = JSON.parse(body) as DiscordInteraction;
@@ -78,7 +78,7 @@ export async function POST(req: Request) {
     // Gérer les interactions Discord (slash commands, etc.)
     if (data.type === InteractionType.PING) {
       // PING - répondre avec PONG (Discord exige une réponse en moins de 3 secondes)
-      return NextResponse.json({ type: InteractionType.PING });
+      return jsonNoStore({ type: InteractionType.PING });
     }
 
     // Gérer les commandes slash (type 2)
@@ -113,7 +113,7 @@ export async function POST(req: Request) {
       }
 
       // Commande inconnue
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
         data: {
           content: `❌ Commande inconnue : ${commandName || "N/A"}`,
@@ -153,7 +153,7 @@ export async function POST(req: Request) {
       });
 
       if (!customId || !customId.startsWith("availability_")) {
-        return NextResponse.json({
+        return jsonNoStore({
           type: 4,
           data: {
             content: "❌ Interaction non reconnue.",
@@ -167,7 +167,7 @@ export async function POST(req: Request) {
         // Select menu
         const parts = customId.split("_");
         if (parts.length < 3) {
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Format d'interaction invalide.",
@@ -206,7 +206,7 @@ export async function POST(req: Request) {
           pollId = parts.slice(1, -3).join("_");
           selectType = "women_sat";
         } else {
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Format de select menu invalide.",
@@ -238,7 +238,7 @@ export async function POST(req: Request) {
             return await handleWomenSelect(interactionWithMetadata, pollId, "sat");
           }
 
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Type de select menu non reconnu.",
@@ -247,7 +247,7 @@ export async function POST(req: Request) {
           });
         } catch (error) {
           console.error("[Discord Interactions] Erreur dans le handler select menu:", error);
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Erreur lors du traitement. Veuillez réessayer.",
@@ -265,7 +265,7 @@ export async function POST(req: Request) {
       // - availability_${pollId}_comment
       const parts = customId.split("_");
       if (parts.length < 3) {
-        return NextResponse.json({
+        return jsonNoStore({
           type: 4,
           data: {
             content: "❌ Format d'interaction invalide.",
@@ -286,7 +286,7 @@ export async function POST(req: Request) {
       });
 
       if (!pollId || !action) {
-        return NextResponse.json({
+        return jsonNoStore({
           type: 4,
           data: {
             content: "❌ Format d'interaction invalide (pollId ou action manquant).",
@@ -311,7 +311,7 @@ export async function POST(req: Request) {
           return await handleCommentButton(interactionWithMetadata, pollId);
         }
 
-        return NextResponse.json({
+        return jsonNoStore({
           type: 4,
           data: {
             content: "❌ Action non reconnue.",
@@ -320,7 +320,7 @@ export async function POST(req: Request) {
         });
       } catch (error) {
         console.error("[Discord Interactions] Erreur dans le handler:", error);
-        return NextResponse.json({
+        return jsonNoStore({
           type: 4,
           data: {
             content: "❌ Erreur lors du traitement. Veuillez réessayer.",
@@ -337,7 +337,7 @@ export async function POST(req: Request) {
       const customId = interaction.data?.custom_id;
 
       if (!customId) {
-        return NextResponse.json({
+        return jsonNoStore({
           type: 4,
           data: {
             content: "❌ Modal non reconnu.",
@@ -351,7 +351,7 @@ export async function POST(req: Request) {
       if (customId.startsWith("availability_") && customId.endsWith("_comment_modal")) {
         const parts = customId.split("_");
         if (parts.length < 4) {
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Format de modal invalide.",
@@ -368,7 +368,7 @@ export async function POST(req: Request) {
         const pollId = pollIdParts.join("_");
 
         if (!pollId) {
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Impossible d'extraire l'ID du sondage.",
@@ -384,7 +384,7 @@ export async function POST(req: Request) {
             "[Discord Interactions] Erreur dans handleModalSubmit:",
             error
           );
-          return NextResponse.json({
+          return jsonNoStore({
             type: 4,
             data: {
               content: "❌ Erreur lors du traitement. Veuillez réessayer.",
@@ -395,7 +395,7 @@ export async function POST(req: Request) {
       }
 
       // Modal non reconnu
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Modal non reconnu.",
@@ -405,7 +405,7 @@ export async function POST(req: Request) {
     }
 
     // Type d'interaction non géré
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Unknown interaction type" },
       { status: 400 }
     );
@@ -415,7 +415,7 @@ export async function POST(req: Request) {
       error instanceof Error ? error.message : "Unknown error";
     console.error("[Discord Interactions] Détails:", errorMessage);
 
-    return NextResponse.json(
+    return jsonNoStore(
       {
         error: "Erreur lors du traitement de l'interaction",
         details: errorMessage,
@@ -518,7 +518,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
       console.error(
         "[Discord Interactions] Impossible de récupérer l'ID utilisateur"
       );
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
         data: {
           content: "❌ Erreur: Impossible de récupérer votre ID Discord.",
@@ -539,7 +539,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
         : undefined;
 
     if (!licenseNumber || typeof licenseNumber !== "string") {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Erreur: Numéro de licence requis.",
@@ -551,7 +551,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
     // Valider que le numéro de licence ne contient que des chiffres
     const trimmedLicense = licenseNumber.trim();
     if (!/^\d+$/.test(trimmedLicense)) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content:
@@ -578,7 +578,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
         existingPlayerData?.nom || ""
       }`.trim();
 
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: `❌ Un utilisateur Discord ne peut être associé qu'à un seul joueur. Vous êtes déjà associé à la licence ${existingLicense}${
@@ -593,7 +593,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
     const playerDoc = await db.collection("players").doc(trimmedLicense).get();
 
     if (!playerDoc.exists) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: `❌ Aucun joueur trouvé avec la licence ${trimmedLicense}. Vérifiez que le numéro de licence est correct.`,
@@ -611,7 +611,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
         playerData?.nom || ""
       }`.trim();
 
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: `ℹ️ Vous êtes déjà associé à la licence ${trimmedLicense}${
@@ -638,7 +638,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
       `[Discord Interactions] Utilisateur ${userId} associé à la licence ${trimmedLicense}`
     );
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `✅ Votre compte Discord a été associé à la licence ${trimmedLicense}${
@@ -656,7 +656,7 @@ async function handleLinkLicenseCommand(data: DiscordInteraction) {
       error instanceof Error ? error.message : "Unknown error";
     console.error("[Discord Interactions] Détails de l'erreur:", errorMessage);
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `❌ Erreur lors de l'association de la licence. Veuillez réessayer plus tard.`,
@@ -678,7 +678,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
       console.error(
         "[Discord Interactions] Impossible de récupérer l'ID utilisateur"
       );
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Erreur: Impossible de récupérer votre ID Discord.",
@@ -699,7 +699,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
         : undefined;
 
     if (!licenseNumber || typeof licenseNumber !== "string") {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Erreur: Numéro de licence requis.",
@@ -711,7 +711,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
     // Valider que le numéro de licence ne contient que des chiffres
     const trimmedLicense = licenseNumber.trim();
     if (!/^\d+$/.test(trimmedLicense)) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content:
@@ -732,7 +732,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
       .get();
 
     if (existingPlayerQuery.empty) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content:
@@ -751,7 +751,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
         oldPlayerData?.nom || ""
       }`.trim();
 
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: `✅ Vous êtes déjà associé à la licence ${trimmedLicense}${
@@ -769,7 +769,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
       .get();
 
     if (!newPlayerDoc.exists) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: `❌ Aucun joueur trouvé avec la licence ${trimmedLicense}. Vérifiez que le numéro de licence est correct.`,
@@ -799,7 +799,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
         newPlayerData?.nom || ""
       }`.trim();
 
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: `✅ Vous êtes déjà associé à la licence ${trimmedLicense}${
@@ -828,7 +828,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
       `[Discord Interactions] Utilisateur ${userId} a modifié son association de la licence ${oldLicense} vers ${trimmedLicense}`
     );
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `✅ Votre association a été modifiée de la licence ${oldLicense}${
@@ -848,7 +848,7 @@ async function handleUpdateLicenseCommand(data: DiscordInteraction) {
       error instanceof Error ? error.message : "Unknown error";
     console.error("[Discord Interactions] Détails de l'erreur:", errorMessage);
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `❌ Erreur lors de la modification de l'association. Veuillez réessayer plus tard.`,
@@ -870,7 +870,7 @@ async function handleUnlinkLicenseCommand(data: DiscordInteraction) {
       console.error(
         "[Discord Interactions] Impossible de récupérer l'ID utilisateur"
       );
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Erreur: Impossible de récupérer votre ID Discord.",
@@ -890,7 +890,7 @@ async function handleUnlinkLicenseCommand(data: DiscordInteraction) {
       .get();
 
     if (existingPlayerQuery.empty) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Vous n'êtes actuellement associé à aucune licence.",
@@ -921,7 +921,7 @@ async function handleUnlinkLicenseCommand(data: DiscordInteraction) {
       `[Discord Interactions] Utilisateur ${userId} a supprimé son association avec la licence ${license}`
     );
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `✅ Votre association avec la licence ${license}${
@@ -939,7 +939,7 @@ async function handleUnlinkLicenseCommand(data: DiscordInteraction) {
       error instanceof Error ? error.message : "Unknown error";
     console.error("[Discord Interactions] Détails de l'erreur:", errorMessage);
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `❌ Erreur lors de la suppression de l'association. Veuillez réessayer plus tard.`,
@@ -961,7 +961,7 @@ async function handleGetLicenseCommand(data: DiscordInteraction) {
       console.error(
         "[Discord Interactions] Impossible de récupérer l'ID utilisateur"
       );
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content: "❌ Erreur: Impossible de récupérer votre ID Discord.",
@@ -981,7 +981,7 @@ async function handleGetLicenseCommand(data: DiscordInteraction) {
       .get();
 
     if (existingPlayerQuery.empty) {
-      return NextResponse.json({
+      return jsonNoStore({
         type: 4,
         data: {
           content:
@@ -997,7 +997,7 @@ async function handleGetLicenseCommand(data: DiscordInteraction) {
       playerData?.nom || ""
     }`.trim();
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `📋 Vous êtes associé à la licence **${license}**${
@@ -1015,7 +1015,7 @@ async function handleGetLicenseCommand(data: DiscordInteraction) {
       error instanceof Error ? error.message : "Unknown error";
     console.error("[Discord Interactions] Détails de l'erreur:", errorMessage);
 
-    return NextResponse.json({
+    return jsonNoStore({
       type: 4,
       data: {
         content: `❌ Erreur lors de la récupération de votre licence. Veuillez réessayer plus tard.`,

--- a/src/app/api/discord/link-license/route.ts
+++ b/src/app/api/discord/link-license/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { getFirestoreAdmin, initializeFirebaseAdmin } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
 
@@ -18,7 +18,7 @@ export async function POST(req: Request) {
     // Vérifier la configuration
     if (!DISCORD_LICENSE_CHANNEL_ID) {
       console.error("[Discord Link License] DISCORD_LICENSE_CHANNEL_ID non configuré");
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration manquante: DISCORD_LICENSE_CHANNEL_ID" },
         { status: 500 }
       );
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
     // Authentification via secret partagé (obligatoire)
     if (!DISCORD_WEBHOOK_SECRET) {
       console.error("[Discord Link License] DISCORD_WEBHOOK_SECRET non configuré");
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration manquante: DISCORD_WEBHOOK_SECRET" },
         { status: 500 }
       );
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
 
     const authHeader = req.headers.get("authorization");
     if (!authHeader || authHeader !== `Bearer ${DISCORD_WEBHOOK_SECRET}`) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non autorisé" },
         { status: 401 }
       );
@@ -47,12 +47,12 @@ export async function POST(req: Request) {
     // Vérifier que le message vient du bon canal
     if (channelId !== DISCORD_LICENSE_CHANNEL_ID) {
       console.log(`[Discord Link License] Message ignoré (canal ${channelId} != ${DISCORD_LICENSE_CHANNEL_ID})`);
-      return NextResponse.json({ success: true, message: "Message ignoré (mauvais canal)" });
+      return jsonNoStore({ success: true, message: "Message ignoré (mauvais canal)" });
     }
 
     // Vérifier que le message n'est pas vide
     if (!content || typeof content !== "string") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Contenu du message requis" },
         { status: 400 }
       );
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     // Vérifier que le message ne contient que des chiffres
     if (!/^\d+$/.test(trimmedContent)) {
       console.log(`[Discord Link License] Message ignoré (contient autre chose que des chiffres): "${trimmedContent}"`);
-      return NextResponse.json({ success: true, message: "Message ignoré (doit contenir uniquement des chiffres)" });
+      return jsonNoStore({ success: true, message: "Message ignoré (doit contenir uniquement des chiffres)" });
     }
 
     const licenseNumber = trimmedContent;
@@ -91,7 +91,7 @@ export async function POST(req: Request) {
         `❌ Un utilisateur Discord ne peut être associé qu'à un seul joueur. Vous êtes déjà associé à la licence ${existingLicense}.`
       );
 
-      return NextResponse.json({
+      return jsonNoStore({
         success: false,
         error: "Utilisateur déjà associé à un joueur",
         existingLicense,
@@ -111,7 +111,7 @@ export async function POST(req: Request) {
         `❌ Aucun joueur trouvé avec la licence ${licenseNumber}. Vérifiez que le numéro de licence est correct.`
       );
 
-      return NextResponse.json({
+      return jsonNoStore({
         success: false,
         error: "Licence non trouvée",
         licenseNumber,
@@ -125,7 +125,7 @@ export async function POST(req: Request) {
     // Vérifier que l'ID Discord n'est pas déjà dans la liste
     if (existingDiscordMentions.includes(userId)) {
       console.log(`[Discord Link License] Utilisateur ${userId} déjà dans la liste des mentions pour la licence ${licenseNumber}`);
-      return NextResponse.json({
+      return jsonNoStore({
         success: true,
         message: "Utilisateur déjà associé à ce joueur",
         licenseNumber,
@@ -149,7 +149,7 @@ export async function POST(req: Request) {
       `✅ Votre compte Discord a été associé à la licence ${licenseNumber} (${playerData?.prenom || ""} ${playerData?.nom || ""}). Vous recevrez désormais les notifications pour ce joueur.`
     );
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       message: "Licence associée avec succès",
       licenseNumber,
@@ -157,7 +157,7 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     console.error("[Discord Link License] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de l'association de la licence",

--- a/src/app/api/discord/members/route.ts
+++ b/src/app/api/discord/members/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 
@@ -12,7 +12,7 @@ export async function GET() {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -21,7 +21,7 @@ export async function GET() {
     await adminAuth.verifySessionCookie(sessionCookie, true);
 
     if (!DISCORD_TOKEN || !DISCORD_SERVER_ID) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
         { status: 500 }
       );
@@ -66,7 +66,7 @@ export async function GET() {
           // Si l'erreur n'est pas du JSON, utiliser le message d'erreur tel quel
         }
         
-        return NextResponse.json(
+        return jsonNoStore(
           { success: false, error: errorMessage, details: errorText },
           { status: response.status }
         );
@@ -102,10 +102,10 @@ export async function GET() {
     // Trier par nom d'affichage
     members.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
-    return NextResponse.json({ success: true, members });
+    return jsonNoStore({ success: true, members });
   } catch (error) {
     console.error("[Discord] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des membres" },
       { status: 500 }
     );

--- a/src/app/api/discord/roles/route.ts
+++ b/src/app/api/discord/roles/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
@@ -23,7 +23,7 @@ export async function GET() {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -31,7 +31,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -40,14 +40,14 @@ export async function GET() {
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
     }
 
     if (!DISCORD_TOKEN || !DISCORD_SERVER_ID) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
         { status: 500 }
       );
@@ -67,7 +67,7 @@ export async function GET() {
     if (!response.ok) {
       const errorText = await response.text();
       console.error("[Discord Roles] Erreur lors de la récupération des rôles:", errorText);
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: `Erreur lors de la récupération des rôles Discord: ${errorText}` },
         { status: response.status }
       );
@@ -98,13 +98,13 @@ export async function GET() {
 
     console.log("[Discord Roles] Rôles retournés:", allRoles.length, allRoles.map(r => r.name));
 
-    return NextResponse.json({ 
+    return jsonNoStore({ 
       success: true, 
       roles: allRoles,
     });
   } catch (error) {
     console.error("[Discord Roles] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des rôles" },
       { status: 500 }
     );

--- a/src/app/api/discord/send-message/route.ts
+++ b/src/app/api/discord/send-message/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
@@ -13,7 +13,7 @@ const db = getFirestore();
 export async function POST(req: Request) {
   try {
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
         hasToken: !!DISCORD_TOKEN,
         hasServerId: !!DISCORD_SERVER_ID,
       });
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error:
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
 
     // Seuls les admins et coaches peuvent envoyer des messages Discord
     if (role !== "admin" && role !== "coach") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -72,14 +72,14 @@ export async function POST(req: Request) {
       await req.json();
 
     if (!content || typeof content !== "string") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Le contenu du message est requis" },
         { status: 400 }
       );
     }
 
     if (!teamId || journee === undefined || !phase) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "teamId, journee et phase sont requis" },
         { status: 400 }
       );
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
 
     // Le channelId doit être fourni (configuré au niveau de l'équipe)
     if (!channelId) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           success: false,
           error:
@@ -128,7 +128,7 @@ export async function POST(req: Request) {
     if (!response.ok) {
       const errorText = await response.text();
       console.error("[Discord] Erreur lors de l'envoi:", errorText);
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Erreur lors de l'envoi du message Discord" },
         { status: 500 }
       );
@@ -156,10 +156,10 @@ export async function POST(req: Request) {
       // Ne pas faire échouer l'envoi si l'enregistrement échoue
     }
 
-    return NextResponse.json({ success: true });
+    return jsonNoStore({ success: true });
   } catch (error) {
     console.error("[Discord] Erreur:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de l'envoi du message" },
       { status: 500 }
     );

--- a/src/app/api/discord/update-custom-message/route.ts
+++ b/src/app/api/discord/update-custom-message/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
@@ -13,7 +13,7 @@ const db = getFirestore();
 export async function POST(req: Request) {
   try {
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     const sessionCookie = cookieStore.get("__session")?.value;
     
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Non authentifié" },
         { status: 401 }
       );
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
     
     // Seuls les admins et coaches peuvent modifier les messages
     if (role !== "admin" && role !== "coach") {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -52,7 +52,7 @@ export async function POST(req: Request) {
     const { teamId, journee, phase, customMessage } = await req.json();
 
     if (!teamId || journee === undefined || !phase) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "teamId, journee et phase sont requis" },
         { status: 400 }
       );
@@ -71,10 +71,10 @@ export async function POST(req: Request) {
 
     await db.collection("discordMessages").doc(messageId).set(messageDoc, { merge: true });
 
-    return NextResponse.json({ success: true });
+    return jsonNoStore({ success: true });
   } catch (error) {
     console.error("[Discord] Erreur lors de la mise à jour:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la mise à jour" },
       { status: 500 }
     );

--- a/src/app/api/fftt/opponent-compositions/route.ts
+++ b/src/app/api/fftt/opponent-compositions/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import type { NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
@@ -207,7 +207,7 @@ export async function GET(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Authentification requise" },
         { status: 401 }
       );
@@ -217,7 +217,7 @@ export async function GET(req: NextRequest) {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Accès refusé" },
         { status: 403 }
       );
@@ -230,7 +230,7 @@ export async function GET(req: NextRequest) {
     const opponentName = req.nextUrl.searchParams.get("opponentName")?.trim();
 
     if (!teamId || !phase || !opponentName) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Paramètres teamId, phase et opponentName requis" },
         { status: 400 }
       );
@@ -265,7 +265,7 @@ export async function GET(req: NextRequest) {
     });
 
     if (!ourEquipe?.lienDivision) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Équipe ou division non trouvée" },
         { status: 404 }
       );
@@ -448,13 +448,13 @@ export async function GET(req: NextRequest) {
       });
     }
 
-    return NextResponse.json({ matches: results });
+    return jsonNoStore({ matches: results });
   } catch (error) {
     console.error(
       "Erreur API opponent-compositions:",
       error instanceof Error ? error.message : error
     );
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Erreur lors de la récupération des compositions adverses" },
       { status: 500 }
     );

--- a/src/app/api/fftt/players/route.ts
+++ b/src/app/api/fftt/players/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { getFirestoreAdmin } from "@/lib/firebase-admin";
 import { withAuth } from "@/lib/auth/api-utils";
 import { USER_ROLES } from "@/lib/auth/roles";
@@ -7,7 +7,7 @@ import type { Player } from "@/types";
 export const GET = withAuth(async (req: Request) => {
   try {
     const clubCode = new URL(req.url).searchParams.get("clubCode");
-    if (!clubCode) return NextResponse.json({ error: "Club code required" }, { status: 400 });
+    if (!clubCode) return jsonNoStore({ error: "Club code required" }, { status: 400 });
     const snap = await getFirestoreAdmin().collection("players").get();
     const players: Player[] = snap.docs.map(doc => {
       const data = doc.data();
@@ -17,8 +17,8 @@ export const GET = withAuth(async (req: Request) => {
       };
       return { id: doc.id, ...data, createdAt: toD(data.createdAt), updatedAt: toD(data.updatedAt) } as Player;
     }).sort((a, b) => b.points - a.points);
-    return NextResponse.json({ players, total: players.length, clubCode });
+    return jsonNoStore({ players, total: players.length, clubCode });
   } catch {
-    return NextResponse.json({ error: "Failed to fetch players" }, { status: 500 });
+    return jsonNoStore({ error: "Failed to fetch players" }, { status: 500 });
   }
 }, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/fftt/pool-ranking/route.ts
+++ b/src/app/api/fftt/pool-ranking/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import type { NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
@@ -50,7 +50,7 @@ export async function GET(req: NextRequest) {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Authentification requise" },
         { status: 401 }
       );
@@ -60,7 +60,7 @@ export async function GET(req: NextRequest) {
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Accès refusé" },
         { status: 403 }
       );
@@ -68,7 +68,7 @@ export async function GET(req: NextRequest) {
 
     const teamId = req.nextUrl.searchParams.get("teamId");
     if (!teamId || !teamId.trim()) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Paramètre teamId requis" },
         { status: 400 }
       );
@@ -102,7 +102,7 @@ export async function GET(req: NextRequest) {
     });
 
     if (!equipe || !equipe.lienDivision) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Équipe ou division non trouvée" },
         { status: 404 }
       );
@@ -150,7 +150,7 @@ export async function GET(req: NextRequest) {
     );
 
     if (!Array.isArray(raw)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Classement non disponible" },
         { status: 404 }
       );
@@ -191,20 +191,15 @@ export async function GET(req: NextRequest) {
       return out;
     });
 
-    const res = NextResponse.json(
+    return jsonNoStore(
       { ranking: entries, division: equipe.division },
       { status: 200 }
     );
-    res.headers.set(
-      "Cache-Control",
-      "no-store, no-cache, must-revalidate, max-age=0"
-    );
-    return res;
   } catch (error) {
     console.error("[api/fftt/pool-ranking]", error);
     const message =
       error instanceof Error ? error.message : "Erreur lors du chargement du classement";
-    return NextResponse.json(
+    return jsonNoStore(
       { error: message },
       { status: 500 }
     );

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,5 @@
 // app/api/health/route.ts
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 
 // Pas forcément obligatoire, mais tu peux forcer le runtime node :
 export const runtime = "nodejs";
@@ -8,7 +8,7 @@ export async function GET() {
   // Optionnel : un log minimal pour savoir que le ping passe
   console.log("[health] ping");
 
-  return NextResponse.json(
+  return jsonNoStore(
     { ok: true, timestamp: new Date().toISOString() },
     { status: 200 }
   );

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth, adminDb } from "@/lib/firebase-admin";
 import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
@@ -11,7 +11,7 @@ export async function GET() {
     const sessionCookie = cookieStore.get("__session")?.value;
 
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Authentification requise" },
         { status: 401 }
       );
@@ -19,7 +19,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Email non vérifié" },
         { status: 403 }
       );
@@ -27,7 +27,7 @@ export async function GET() {
 
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }
       );
@@ -47,10 +47,10 @@ export async function GET() {
         new Date().toISOString(),
     }));
 
-    return NextResponse.json({ success: true, locations }, { status: 200 });
+    return jsonNoStore({ success: true, locations }, { status: 200 });
   } catch (error) {
     console.error("[app/api/locations] GET error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des lieux" },
       { status: 500 }
     );

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { openApiSpec } from "@/lib/openapi";
 
 export async function GET() {
-  return NextResponse.json(openApiSpec, { status: 200 });
+  return jsonNoStore(openApiSpec, { status: 200 });
 }
 
 

--- a/src/app/api/session/firebase-token/route.ts
+++ b/src/app/api/session/firebase-token/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { adminAuth } from "@/lib/firebase-admin";
@@ -13,7 +13,7 @@ export const runtime = "nodejs";
 export async function POST(req: NextRequest) {
   // Valider l'origine de la requête pour prévenir les attaques CSRF
   if (!validateOrigin(req)) {
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Invalid origin" },
       { status: 403 }
     );
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
   const cookie = cookieStore.get("__session")?.value;
 
   if (!cookie) {
-    return NextResponse.json({ error: "No session" }, { status: 401 });
+    return jsonNoStore({ error: "No session" }, { status: 401 });
   }
 
   try {
@@ -42,9 +42,9 @@ export async function POST(req: NextRequest) {
       coachRequestStatus: decoded.coachRequestStatus,
     });
 
-    return NextResponse.json({ customToken });
+    return jsonNoStore({ customToken });
   } catch (error) {
     console.error("[session/firebase-token] Error:", error);
-    return NextResponse.json({ error: "Invalid session" }, { status: 401 });
+    return jsonNoStore({ error: "Invalid session" }, { status: 401 });
   }
 }

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -7,13 +7,14 @@ import {
   enforceRateLimit,
   RATE_LIMIT_SESSION_POST_PER_IP,
 } from "@/lib/auth/rate-limit-http";
+import { applyNoStoreHeaders, jsonNoStore } from "@/lib/http/cache-headers";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
   try {
     if (!validateOrigin(req)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Invalid origin", message: "Requête non autorisée" },
         { status: 403 }
       );
@@ -31,7 +32,7 @@ export async function POST(req: Request) {
     const { idToken } = body;
 
     if (!idToken || typeof idToken !== "string") {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Missing token", message: "Le token d'authentification est requis" },
         { status: 400 }
       );
@@ -46,7 +47,7 @@ export async function POST(req: Request) {
       
       // Token expiré
       if (errorMessage.includes("expired") || errorMessage.includes("Expired")) {
-        return NextResponse.json(
+        return jsonNoStore(
           { error: "Token expired", message: "Le token d'authentification a expiré" },
           { status: 401 }
         );
@@ -58,7 +59,7 @@ export async function POST(req: Request) {
         errorMessage.includes("Invalid") ||
         errorMessage.includes("malformed")
       ) {
-        return NextResponse.json(
+        return jsonNoStore(
           { error: "Invalid token", message: "Le token d'authentification est invalide" },
           { status: 401 }
         );
@@ -66,14 +67,14 @@ export async function POST(req: Request) {
 
       // Autres erreurs de vérification
       console.error("[session] Erreur lors de la vérification du token:", error);
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Token verification failed", message: "Échec de la vérification du token" },
         { status: 401 }
       );
     }
 
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Email non vérifié", message: "L'email associé au compte n'est pas vérifié" },
         { status: 403 }
       );
@@ -88,7 +89,7 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       console.error("[session] Erreur lors de la création du cookie de session:", error);
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Session creation failed", message: "Impossible de créer la session" },
         { status: 500 }
       );
@@ -106,14 +107,10 @@ export async function POST(req: Request) {
       path: "/",
       maxAge: Math.floor((14 * 24 * 60 * 60 * 1000) / 1000),
     });
-    // Ajouter Cache-Control pour éviter la mise en cache
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return applyNoStoreHeaders(res);
   } catch (error) {
     console.error("[session] Erreur inattendue lors de la création de session:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         error: "Internal server error",
         message: "Une erreur inattendue s'est produite lors de la création de la session",
@@ -164,10 +161,7 @@ export async function DELETE() {
       path: "/",
       maxAge: 0,
     });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return applyNoStoreHeaders(res);
   } catch (error) {
     console.error("[session] Erreur lors de la déconnexion:", error);
     // Même en cas d'erreur, on supprime le cookie côté client avec les mêmes paramètres
@@ -182,10 +176,7 @@ export async function DELETE() {
       path: "/",
       maxAge: 0,
     });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return applyNoStoreHeaders(res);
   }
 }
 

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
 
@@ -32,23 +32,19 @@ export async function GET() {
   const cookie = cookieStore.get("__session")?.value;
 
   if (!cookie) {
-    return NextResponse.json({ user: null }, { status: 200 });
+    return jsonNoStore({ user: null }, { status: 200 });
   }
 
   try {
     const decoded = await adminAuth.verifySessionCookie(cookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json({ user: null }, { status: 200 });
+      return jsonNoStore({ user: null }, { status: 200 });
     }
 
     // Vérifier le cache d'abord
     const cachedUser = getCachedUser(decoded.uid);
     if (cachedUser) {
-      const res = NextResponse.json({ user: cachedUser });
-      res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-      res.headers.set("Pragma", "no-cache");
-      res.headers.set("Expires", "0");
-      return res;
+      return jsonNoStore({ user: cachedUser });
     }
 
     // Essayer de récupérer les informations utilisateur depuis Firestore
@@ -107,17 +103,9 @@ export async function GET() {
       setCachedUser(decoded.uid, user);
     }
 
-    const res = NextResponse.json({ user });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore({ user });
   } catch (error) {
     console.error("[session/verify] Error:", error);
-    const res = NextResponse.json({ user: null }, { status: 200 });
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-    res.headers.set("Pragma", "no-cache");
-    res.headers.set("Expires", "0");
-    return res;
+    return jsonNoStore({ user: null }, { status: 200 });
   }
 }

--- a/src/app/api/teams/[teamId]/discord-channel/route.ts
+++ b/src/app/api/teams/[teamId]/discord-channel/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import {
@@ -17,7 +17,7 @@ export async function PATCH(
   try {
     // CSRF Protection
     if (!validateOrigin(request)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -26,7 +26,7 @@ export async function PATCH(
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Token d'authentification requis",
           message: "Cette API nécessite une authentification valide",
@@ -39,7 +39,7 @@ export async function PATCH(
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Accès refusé",
           message:
@@ -53,7 +53,7 @@ export async function PATCH(
     const { discordChannelId } = await request.json();
 
     if (discordChannelId !== null && discordChannelId !== undefined && typeof discordChannelId !== "string") {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Le canal Discord doit être une chaîne de caractères ou null",
         },
@@ -68,7 +68,7 @@ export async function PATCH(
     const teamDoc = await teamRef.get();
 
     if (!teamDoc.exists) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Équipe introuvable",
         },
@@ -97,7 +97,7 @@ export async function PATCH(
       success: true,
     });
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       data: {
         teamId,
@@ -106,7 +106,7 @@ export async function PATCH(
     });
   } catch (error) {
     console.error("[app/api/teams/[teamId]/discord-channel] PATCH error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la mise à jour du canal Discord",

--- a/src/app/api/teams/[teamId]/location/route.ts
+++ b/src/app/api/teams/[teamId]/location/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import {
@@ -17,7 +17,7 @@ export async function PATCH(
   try {
     // CSRF Protection
     if (!validateOrigin(request)) {
-      return NextResponse.json(
+      return jsonNoStore(
         { success: false, error: "Invalid origin" },
         { status: 403 }
       );
@@ -26,7 +26,7 @@ export async function PATCH(
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("__session")?.value;
     if (!sessionCookie) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Token d'authentification requis",
           message: "Cette API nécessite une authentification valide",
@@ -39,7 +39,7 @@ export async function PATCH(
     const role = resolveRole(decoded.role as string | undefined);
 
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Accès refusé",
           message:
@@ -53,7 +53,7 @@ export async function PATCH(
     const { location } = await request.json();
 
     if (location !== null && location !== undefined && typeof location !== "string") {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Le lieu doit être une chaîne de caractères ou null",
         },
@@ -68,7 +68,7 @@ export async function PATCH(
     const teamDoc = await teamRef.get();
 
     if (!teamDoc.exists) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Équipe introuvable",
         },
@@ -81,7 +81,7 @@ export async function PATCH(
       const locationRef = db.collection("locations").doc(location.trim());
       const locationDoc = await locationRef.get();
       if (!locationDoc.exists) {
-        return NextResponse.json(
+        return jsonNoStore(
           {
             error: "Lieu introuvable",
           },
@@ -111,7 +111,7 @@ export async function PATCH(
       success: true,
     });
 
-    return NextResponse.json({
+    return jsonNoStore({
       success: true,
       data: {
         teamId,
@@ -120,7 +120,7 @@ export async function PATCH(
     });
   } catch (error) {
     console.error("[app/api/teams/[teamId]/location] PATCH error", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la mise à jour du lieu",

--- a/src/app/api/teams/[teamId]/matches/route.ts
+++ b/src/app/api/teams/[teamId]/matches/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { getTeamMatches } from "@/lib/server/team-matches";
@@ -15,7 +15,7 @@ export async function GET(
   const sessionCookie = cookieStore.get("__session")?.value;
   
   if (!sessionCookie) {
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Authentification requise" },
       { status: 401 }
     );
@@ -24,13 +24,13 @@ export async function GET(
   try {
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Email non vérifié" },
         { status: 403 }
       );
     }
   } catch {
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Session invalide" },
       { status: 401 }
     );
@@ -40,7 +40,7 @@ export async function GET(
   const { teamId } = await params;
 
   if (!teamId || typeof teamId !== "string") {
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Team ID parameter is required" },
       { status: 400 }
     );
@@ -55,7 +55,7 @@ export async function GET(
       `📊 [app/api/teams/${teamId}/matches] ${matches.length} matchs récupérés pour l'équipe ${teamId}`
     );
 
-    return NextResponse.json(
+    return jsonNoStore(
       {
         teamId,
         matches,
@@ -65,7 +65,7 @@ export async function GET(
     );
   } catch (error) {
     console.error("[app/api/teams/[teamId]/matches] Firestore Error:", error);
-    return NextResponse.json(
+    return jsonNoStore(
       {
         error: "Failed to fetch team matches",
         details: error instanceof Error ? error.message : "Unknown error",

--- a/src/app/api/teams/matches/route.ts
+++ b/src/app/api/teams/matches/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { getFirestoreAdmin } from "@/lib/firebase-admin";
 import { withAuth } from "@/lib/auth/api-utils";
 import { USER_ROLES } from "@/lib/auth/roles";
@@ -15,8 +15,8 @@ export const GET = withAuth(async (req: Request) => {
       const fmt = (d: unknown) => (d instanceof Date ? d : new Date()).toISOString();
       return { team, matches: ms.map(m => ({ ...m, date: fmt(m.date), createdAt: fmt(m.createdAt), updatedAt: fmt(m.updatedAt) })), total: ms.length };
     }));
-    return NextResponse.json({ teams: teamMatches, totalTeams: teamMatches.length, totalMatches: teamMatches.reduce((acc, e) => acc + e.total, 0) });
+    return jsonNoStore({ teams: teamMatches, totalTeams: teamMatches.length, totalMatches: teamMatches.reduce((acc, e) => acc + e.total, 0) });
   } catch {
-    return NextResponse.json({ error: "Failed to fetch matches" }, { status: 500 });
+    return jsonNoStore({ error: "Failed to fetch matches" }, { status: 500 });
   }
 }, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/teams/route.ts
+++ b/src/app/api/teams/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { getTeams, TeamSummary } from "@/lib/server/team-matches";
@@ -12,7 +12,7 @@ export async function GET() {
   const sessionCookie = cookieStore.get("__session")?.value;
   
   if (!sessionCookie) {
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Authentification requise" },
       { status: 401 }
     );
@@ -21,7 +21,7 @@ export async function GET() {
   try {
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     if (!decoded.email_verified) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Email non vérifié" },
         { status: 403 }
       );
@@ -30,13 +30,13 @@ export async function GET() {
     // Vérifier que l'utilisateur est admin ou coach
     const role = resolveRole(decoded.role as string | undefined);
     if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return NextResponse.json(
+      return jsonNoStore(
         { error: "Accès refusé" },
         { status: 403 }
       );
     }
   } catch {
-    return NextResponse.json(
+    return jsonNoStore(
       { error: "Session invalide" },
       { status: 401 }
     );
@@ -49,7 +49,7 @@ export async function GET() {
 
     console.log(`📊 [app/api/teams] ${teams.length} équipes récupérées depuis Firestore`);
 
-    return NextResponse.json(
+    return jsonNoStore(
       {
         teams,
         total: teams.length,
@@ -65,7 +65,7 @@ export async function GET() {
       errorMessage.includes("credentials") ||
       errorMessage.includes("Could not load the default credentials")
     ) {
-      return NextResponse.json(
+      return jsonNoStore(
         {
           error: "Firebase Admin credentials not configured",
           details:
@@ -76,7 +76,7 @@ export async function GET() {
       );
     }
 
-    return NextResponse.json(
+    return jsonNoStore(
       {
         error: "Failed to fetch teams data",
         details: errorMessage,

--- a/src/lib/auth/api-utils.ts
+++ b/src/lib/auth/api-utils.ts
@@ -2,20 +2,20 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase-admin";
 import { resolveRole, hasAnyRole, UserRole } from "@/lib/auth/roles";
+import { applyNoStoreHeaders, jsonNoStore } from "@/lib/http/cache-headers";
 
 export const withAuth = (handler: (req: Request, context: unknown) => Promise<NextResponse>, allowedRoles?: UserRole[]) =>
   async (req: Request, context: unknown) => {
     try {
       const session = (await cookies()).get("__session")?.value;
-      if (!session) return NextResponse.json({ error: "Authentification requise" }, { status: 401 });
+      if (!session) return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
       const decoded = await adminAuth.verifySessionCookie(session, true);
-      if (!decoded.email_verified) return NextResponse.json({ error: "Email non vérifié" }, { status: 403 });
+      if (!decoded.email_verified) return jsonNoStore({ error: "Email non vérifié" }, { status: 403 });
       const role = resolveRole(decoded.role as string);
-      if (allowedRoles && !hasAnyRole(role, allowedRoles)) return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+      if (allowedRoles && !hasAnyRole(role, allowedRoles)) return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
       const res = await handler(req, { ... (context as object), decoded, role });
-      res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-      return res;
+      return applyNoStoreHeaders(res);
     } catch {
-      return NextResponse.json({ error: "Session invalide" }, { status: 401 });
+      return jsonNoStore({ error: "Session invalide" }, { status: 401 });
     }
   };

--- a/src/lib/auth/rate-limit-http.ts
+++ b/src/lib/auth/rate-limit-http.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/auth/rate-limit";
+import { jsonNoStore } from "@/lib/http/cache-headers";
 
 /** Limites par défaut pour l’Epic A (mutations coûteuses / auth). */
 export const RATE_LIMIT_SESSION_POST_PER_IP = {
@@ -34,7 +35,7 @@ export const RATE_LIMIT_FIREBASE_CUSTOM_TOKEN_PER_UID = {
 } as const;
 
 export function tooManyRequestsResponse(): NextResponse {
-  return NextResponse.json(
+  return jsonNoStore(
     {
       error: "Too many requests",
       message: "Trop de requêtes. Réessayez plus tard.",

--- a/src/lib/http/cache-headers.ts
+++ b/src/lib/http/cache-headers.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+/**
+ * En-têtes anti-cache pour réponses HTTP sensibles (sessions, données utilisateur).
+ * Aligné sur les règles projet (.cursorrules).
+ */
+export function applyNoStoreHeaders(res: NextResponse): NextResponse {
+  res.headers.set(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, proxy-revalidate"
+  );
+  res.headers.set("Pragma", "no-cache");
+  res.headers.set("Expires", "0");
+  return res;
+}
+
+/** Réponse JSON avec en-têtes no-store (routes API sensibles). */
+export function jsonNoStore(body: unknown, init?: ResponseInit): NextResponse {
+  return applyNoStoreHeaders(NextResponse.json(body, init));
+}


### PR DESCRIPTION
## Epic B (audit)
- `src/lib/http/cache-headers.ts` : `applyNoStoreHeaders`, `jsonNoStore`
- `withAuth` : erreurs 401/403 en `jsonNoStore`, succès via `applyNoStoreHeaders`
- Toutes les routes `src/app/api/**/route.ts` : `jsonNoStore` (remplace `NextResponse.json`), sauf `session/route.ts` (cookies + `applyNoStoreHeaders`)
- `rate-limit-http` : réponses 429 via `jsonNoStore`
- Docs : `docs/SECURITY.md`, plan d’audit coché

## Vérifications
- [x] `npm run check`

Made with [Cursor](https://cursor.com)