### PR TITLE
fix(auth): Epic D — cohérence des rôles (USER_ROLES)

### DIFF
--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -2,7 +2,7 @@
 
 Ce document consolide les constats des audits **phase 1** (qualité globale Next.js, sécurité, perf, tests) et **phase 2** (matrice des routes API + qualité des composants React). Il sert de **backlog traçable** : cocher les cases au fil des PR / merges.
 
-**Dernière mise à jour :** 2026-05-09 (Epic C)  
+**Dernière mise à jour :** 2026-05-09 (Epic D)  
 **Statuts :** `[ ]` à faire · `[~]` en cours · `[x]` terminé
 
 ---
@@ -34,7 +34,7 @@ Ce document consolide les constats des audits **phase 1** (qualité globale Next
 | A | Sécurité API : CSRF (`validateOrigin`), compléments rate limiting | ~~P0~~ **traité (2026-05-09)** |
 | B | En-têtes `Cache-Control` sur réponses sensibles | ~~P0 / P1~~ **traité (2026-05-09)** |
 | C | `export const runtime = "nodejs"` sur routes concernées | ~~P1~~ **traité (2026-05-09)** |
-| D | Cohérence des rôles (`resolveRole`, `hasAnyRole`, `USER_ROLES`) | P1 |
+| D | Cohérence des rôles (`resolveRole`, `hasAnyRole`, `USER_ROLES`) | ~~P1~~ **traité (2026-05-09)** |
 | E | Toolchain : ESLint vs build, config Next (`next.config.ts`) | P2 |
 | F | Stratégie rendu : réduction du `force-dynamic` global si pertinent | P2 |
 | G | Qualité React : découpage, couche API client, patterns | P2 |
@@ -129,10 +129,10 @@ Ce document consolide les constats des audits **phase 1** (qualité globale Next
 
 **Objectif :** Éviter les comparaisons magiques `"admin"`, `"coach"` ; utiliser `resolveRole`, `hasAnyRole`, `USER_ROLES`.
 
-- [ ] **D.1** Passer en revue **toutes** les routes API qui lisent `decoded.role` ou équivalent.
-- [ ] **D.2** Corriger les fichiers identifiés (ex. `discord/send-message`, `discord/update-custom-message`, autres grep `role !==` / `===`).
-- [ ] **D.3** Côté client : `useAuth` (`isAdmin`, `isCoach`, etc.) — aligner sur les constantes / types partagés si possible.
-- [ ] **D.4** Vérifier alignement **AuthGuard** (`allowedRoles`) vs routes API pour les pages modifiées (règle projet).
+- [x] **D.1** Revue des routes API : les comparaisons magiques restantes étaient surtout Discord + fallback session.
+- [x] **D.2** `discord/send-message`, `discord/update-custom-message` : `resolveRole` + `hasAnyRole([ADMIN, COACH])`. `session/verify` : fallback rôle avec `USER_ROLES.PLAYER`.
+- [x] **D.3** `useAuth` : `isAdmin` / `isCoach` / `isPlayer` via `USER_ROLES`.
+- [x] **D.4** `AuthGuard` : carte `fallbackByRole` indexée par `USER_ROLES.*` (pas de changement des pages ; middleware/API déjà sur les mêmes littéraux).
 
 ---
 
@@ -251,3 +251,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 | 2026-05-09 | — | Epic A complété : CSRF sur routes listées, rate limiting session / Discord / admin sync / discord config, doc `SECURITY.md`, helpers HTTP |
 | 2026-05-09 | — | Epic B complété : `lib/http/cache-headers`, `withAuth` + toutes les routes `app/api` en `jsonNoStore` / `applyNoStoreHeaders`, doc `SECURITY.md` |
 | 2026-05-09 | — | Epic C complété : `export const runtime = "nodejs"` sur les 14 routes restantes ; tous les `app/api/**/route.ts` ont l’export |
+| 2026-05-09 | — | Epic D complété : rôles Discord API + session/verify + `useAuth` + `AuthGuard` alignés sur `USER_ROLES` / helpers |

--- a/src/app/api/discord/send-message/route.ts
+++ b/src/app/api/discord/send-message/route.ts
@@ -9,6 +9,7 @@ import {
   enforceRateLimit,
   RATE_LIMIT_DISCORD_PROXY_PER_UID,
 } from "@/lib/auth/rate-limit-http";
+import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
 
 const db = getFirestore();
 
@@ -60,10 +61,8 @@ export async function POST(req: Request) {
     );
     if (discordRl) return discordRl;
 
-    const role = decoded.role || "player";
-
-    // Seuls les admins et coaches peuvent envoyer des messages Discord
-    if (role !== "admin" && role !== "coach") {
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
       return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }

--- a/src/app/api/discord/update-custom-message/route.ts
+++ b/src/app/api/discord/update-custom-message/route.ts
@@ -9,6 +9,7 @@ import {
   enforceRateLimit,
   RATE_LIMIT_DISCORD_PROXY_PER_UID,
 } from "@/lib/auth/rate-limit-http";
+import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
 
 const db = getFirestore();
 
@@ -41,10 +42,8 @@ export async function POST(req: Request) {
     );
     if (discordRl) return discordRl;
 
-    const role = decoded.role || "player";
-    
-    // Seuls les admins et coaches peuvent modifier les messages
-    if (role !== "admin" && role !== "coach") {
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
       return jsonNoStore(
         { success: false, error: "Accès refusé" },
         { status: 403 }

--- a/src/app/api/session/verify/route.ts
+++ b/src/app/api/session/verify/route.ts
@@ -1,6 +1,7 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 export const runtime = "nodejs";
 
@@ -89,7 +90,7 @@ export async function GET() {
     const user = {
       uid: decoded.uid,
       email: decoded.email || (userData?.email as string | undefined),
-      role: (userData?.role as string | undefined) || decoded.role || "player",
+      role: (userData?.role as string | undefined) || decoded.role || USER_ROLES.PLAYER,
       coachRequestStatus:
         (userData?.coachRequestStatus as string | undefined) ||
         decoded.coachRequestStatus ||

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -5,6 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { Box, CircularProgress } from "@mui/material";
 import { useAuth } from "@/hooks/useAuth";
 import { validateInternalRedirect } from "@/lib/auth/redirect-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -50,9 +51,9 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({
       // Redirection intelligente vers une page autorisée selon le rôle
       const role = user.role;
       const fallbackByRole: Record<string, string> = {
-        player: "/joueur",
-        coach: "/",
-        admin: "/",
+        [USER_ROLES.PLAYER]: "/joueur",
+        [USER_ROLES.COACH]: "/",
+        [USER_ROLES.ADMIN]: "/",
       };
       const target = fallbackByRole[role] || (redirectWhenUnauthorized || "/");
       router.push(target);

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { User } from "@/types";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 // Stub minimal pour compatibilité avec l'ancien code
 // Le nouveau système utilise les cookies HTTP-only côté serveur
@@ -49,9 +50,10 @@ export const useAuth = () => {
     signOut,
     signIn: async () => ({ success: false, error: "Use /login page" }),
     signUp: async () => ({ success: false, error: "Use /signup page" }),
-    isAdmin: user?.role === "admin",
-    isCoach: user?.role === "coach" || user?.role === "admin",
-    isPlayer: user?.role === "player",
+    isAdmin: user?.role === USER_ROLES.ADMIN,
+    isCoach:
+      user?.role === USER_ROLES.COACH || user?.role === USER_ROLES.ADMIN,
+    isPlayer: user?.role === USER_ROLES.PLAYER,
     refreshUser,
     sendEmailVerification: async () => {},
   };


### PR DESCRIPTION
## Résumé
Évite les comparaisons `role !== \"admin\"` sur les routes Discord ; uniformise les garde-fous avec `resolveRole` + `hasAnyRole`. Client : `useAuth`, `AuthGuard`.

## Fichiers
- API : `discord/send-message`, `discord/update-custom-message`, `session/verify`
- Client : `useAuth.tsx`, `AuthGuard.tsx`
- Doc : plan d’audit Epic D coché

## Vérifications
- [x] `npm run check`

Made with [Cursor](https://cursor.com)