### PR TITLE
chore(next): Epic E — toolchain Next.js et config prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@
 # Configuration Firebase (publiques)
 # ============================================
 # Ces variables sont publiques par design (préfixe NEXT_PUBLIC_)
-# Elles sont sécurisées par des restrictions de domaine dans Firebase Console
-# Les valeurs par défaut sont définies dans next.config.ts et apphosting.yaml
+# Elles sont sécurisées par des restrictions de domaine dans Firebase Console.
+# Obligatoires au build et au runtime client : les définir ici (local) ou dans apphosting.yaml / CI.
 
 NEXT_PUBLIC_FIREBASE_API_KEY=your_firebase_api_key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -18,8 +18,13 @@ npm run check
 ```
 - Lint (ESLint)
 - Type-check (TypeScript)
-- Build (Next.js)
-- **Utilisation**: Avant chaque commit/push
+- Build (Next.js), avec **ESLint exécuté pendant `next build`** (`eslint.ignoreDuringBuilds: false` dans `next.config.ts`). Une divergence entre lint CLI et build est donc impossible si `npm run check` passe.
+
+### Variables `NEXT_PUBLIC_*` au build
+
+Sans valeurs dans l’environnement au moment du `next build`, le bundle client peut manquer la config Firebase. En local : remplir `.env.local` à partir de `.env.example`. En production : définir les variables dans Firebase App Hosting (`apphosting.yaml`) ou dans les secrets CI, comme pour tout déploiement Next.js.
+
+**Utilisation**: Avant chaque commit/push
 
 ### Smoke Tests
 
@@ -47,9 +52,9 @@ npm run emulators:smoke
 
 La CI GitHub Actions exécute automatiquement:
 
-1. **Lint**: Vérifie le code avec ESLint
+1. **Lint**: Vérifie le code avec ESLint (`eslint` en ligne de commande)
 2. **Type-check**: Vérifie les types TypeScript
-3. **Build**: Compile l'application Next.js
+3. **Build**: Compile l'application Next.js (**inclut ESLint** comme ci-dessus, doublon acceptable pour une détection précoce dans les logs de job)
 4. **TODO Check**: Vérifie qu'il n'y a pas de TODO dans le code
 5. **Security Audit**: Audit npm des dépendances
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -83,6 +83,8 @@ Le script `scripts/setup-functions-config.js` lit les variables d'environnement 
 
 Les variables préfixées par `NEXT_PUBLIC_` sont **publiques** et incluses dans le bundle JavaScript côté client. C'est normal pour la configuration Firebase (clés API, domaines, etc.) car elles sont sécurisées par des restrictions de domaine dans Firebase Console.
 
+Elles doivent être définies dans l’environnement au **build** (`.env.local`, CI, `apphosting.yaml`) : **`next.config.ts` ne duplique plus de valeurs par défaut** pour éviter la divergence entre environnements et les faux positifs « tout marche sans .env » en local.
+
 ## En cas d'exposition de secrets
 
 Si un secret a été commité par erreur :

--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -2,7 +2,7 @@
 
 Ce document consolide les constats des audits **phase 1** (qualité globale Next.js, sécurité, perf, tests) et **phase 2** (matrice des routes API + qualité des composants React). Il sert de **backlog traçable** : cocher les cases au fil des PR / merges.
 
-**Dernière mise à jour :** 2026-05-09 (Epic D)  
+**Dernière mise à jour :** 2026-05-09 (Epic E)  
 **Statuts :** `[ ]` à faire · `[~]` en cours · `[x]` terminé
 
 ---
@@ -35,7 +35,7 @@ Ce document consolide les constats des audits **phase 1** (qualité globale Next
 | B | En-têtes `Cache-Control` sur réponses sensibles | ~~P0 / P1~~ **traité (2026-05-09)** |
 | C | `export const runtime = "nodejs"` sur routes concernées | ~~P1~~ **traité (2026-05-09)** |
 | D | Cohérence des rôles (`resolveRole`, `hasAnyRole`, `USER_ROLES`) | ~~P1~~ **traité (2026-05-09)** |
-| E | Toolchain : ESLint vs build, config Next (`next.config.ts`) | P2 |
+| E | Toolchain : ESLint vs build, config Next (`next.config.ts`) | ~~P2~~ **traité (2026-05-09)** |
 | F | Stratégie rendu : réduction du `force-dynamic` global si pertinent | P2 |
 | G | Qualité React : découpage, couche API client, patterns | P2 |
 | H | Accessibilité (a11y) ciblée | P3 |
@@ -140,14 +140,14 @@ Ce document consolide les constats des audits **phase 1** (qualité globale Next
 
 ### E.1 ESLint et build
 
-- [ ] **E.1.1** Décider : `eslint.ignoreDuringBuilds: false` dans `next.config.ts` **ou** politique explicite « le build CI utilise `npm run check` » — documenter dans `docs/QUALITY_GATES.md`.
-- [ ] **E.1.2** Si passage à `false`, corriger toutes les erreurs ESLint bloquantes puis valider `npm run check`.
+- [x] **E.1.1** `eslint.ignoreDuringBuilds: false` ; politique documentée dans `docs/QUALITY_GATES.md`.
+- [x] **E.1.2** `npm run check` vert (ESLint pendant `next build`).
 
 ### E.2 `next.config.ts`
 
-- [ ] **E.2.1** **Fallbacks Firebase** : retirer ou isoler les valeurs par défaut ; utiliser variables d’environnement obligatoires en CI / App Hosting ; documenter pour dev local.
-- [ ] **E.2.2** **`productionBrowserSourceMaps`** : décision produit / sécurité — garder, désactiver, ou activer seulement sur branches / sentry ; documenter.
-- [ ] **E.2.3** Commentaire sur `generateBuildId` / `standalone` : vérifier qu’ils restent justifiés avec la stratégie de déploiement actuelle.
+- [x] **E.2.1** Bloc `env` avec fallbacks Firebase **supprimé** ; injection standard Next depuis `process.env` ; `.env.example` + `SECURITY.md` mis à jour.
+- [x] **E.2.2** `productionBrowserSourceMaps: false` par défaut (réduit l’exposition du source client) ; commentaire dans `next.config.ts` pour réactivation ponctuelle / Sentry.
+- [x] **E.2.3** Commentaires à jour sur `output: "standalone"` (App Hosting / image autonome) et `generateBuildId` (invalidation cache entre builds).
 
 ---
 
@@ -252,3 +252,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 | 2026-05-09 | — | Epic B complété : `lib/http/cache-headers`, `withAuth` + toutes les routes `app/api` en `jsonNoStore` / `applyNoStoreHeaders`, doc `SECURITY.md` |
 | 2026-05-09 | — | Epic C complété : `export const runtime = "nodejs"` sur les 14 routes restantes ; tous les `app/api/**/route.ts` ont l’export |
 | 2026-05-09 | — | Epic D complété : rôles Discord API + session/verify + `useAuth` + `AuthGuard` alignés sur `USER_ROLES` / helpers |
+| 2026-05-09 | — | Epic E complété : ESLint dans `next build`, retrait fallbacks Firebase dans next.config, source maps prod désactivées, doc QUALITY_GATES + SECURITY |

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,46 +2,21 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   typescript: {
-    // Empêcher la compilation en cas d'erreurs TypeScript
     ignoreBuildErrors: false,
   },
   eslint: {
-    // Empêcher la compilation en cas d'erreurs ESLint
-    ignoreDuringBuilds: true,
+    // Aligné avec `npm run check` : le build échoue si ESLint échoue.
+    ignoreDuringBuilds: false,
   },
-  // Désactiver le pré-rendu statique pour éviter les erreurs Material-UI/React
-  // Les pages seront rendues dynamiquement
+  // Artefact Docker / App Hosting : serveur Node autonome avec `node server.js`.
   output: "standalone",
-  // Désactiver complètement la génération statique pour éviter les erreurs
-  // Toutes les pages seront rendues dynamiquement
-  generateBuildId: async () => {
-    return "build-" + Date.now();
-  },
-  productionBrowserSourceMaps: true,
-  // Ne pas définir webpack devtool en dev : Next.js impose la valeur adaptée au mode
-  // (voir https://nextjs.org/docs/messages/improper-devtool — source-map en dev dégrade fortement les perfs).
-  // Forcer l'injection des variables d'environnement au build
-  // Next.js injecte NEXT_PUBLIC_* dans le bundle client au moment du build
-  env: {
-    // Fallback pour les variables Firebase si elles ne sont pas définies dans apphosting.yaml
-    // Ces valeurs seront utilisées au build si les variables d'environnement ne sont pas disponibles
-    NEXT_PUBLIC_FIREBASE_API_KEY:
-      process.env.NEXT_PUBLIC_FIREBASE_API_KEY ||
-      "AIzaSyC9fsfuDqF0jjV8ocgCtqMpcPA-E6pZoNg",
-    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:
-      process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ||
-      "sqyping-teamup.firebaseapp.com",
-    NEXT_PUBLIC_FIREBASE_PROJECT_ID:
-      process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "sqyping-teamup",
-    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:
-      process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ||
-      "sqyping-teamup.firebasestorage.app",
-    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:
-      process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "567392028186",
-    NEXT_PUBLIC_FIREBASE_APP_ID:
-      process.env.NEXT_PUBLIC_FIREBASE_APP_ID ||
-      "1:567392028186:web:0fa11cf39ce060931eb3a3",
-  },
+  // Identifiant unique par build pour invalider le cache navigateur/CDN entre déploiements.
+  generateBuildId: async () => `build-${Date.now()}`,
+  // Désactivé par défaut : limite l’exposition du source client en prod. Réactiver ponctuellement
+  // pour du debug ou si un outil (ex. Sentry) nécessite des source maps côté navigateur.
+  productionBrowserSourceMaps: false,
+  // Les variables NEXT_PUBLIC_* sont injectées par Next.js depuis `process.env` au build
+  // (.env.local, CI, apphosting.yaml). Ne pas dupliquer de valeurs par défaut ici (voir Epic E).
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Epic E
- **`eslint.ignoreDuringBuilds: false`** — ESLint exécuté pendant `next build` ; doc dans `docs/QUALITY_GATES.md`.
- **Suppression des fallbacks Firebase** dans `next.config.ts` — `NEXT_PUBLIC_*` uniquement via environnement (`.env.local`, `apphosting.yaml`, CI).
- **`productionBrowserSourceMaps: false`** — réduit l’exposition du source en prod ; commentaire pour réactivation ponctuelle.
- Commentaires **`standalone`** / **`generateBuildId`** alignés avec App Hosting.

## Docs
`.env.example`, `SECURITY.md`, plan d’audit.

## Vérifications
- [x] `npm run check`

Made with [Cursor](https://cursor.com)