### PR TITLE
refactor(stats): split GlobalStats into focused subcomponents

### DIFF
--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -181,7 +181,8 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 - [ ] **G.1.8** `AuditLogs`
 - [ ] **G.1.9** `AppSettings`
 - [ ] **G.1.10** `SystemMaintenance`
-- [ ] **G.1.11** Autres fichiers > ~500 lignes restants (grep `wc -l`)
+- [~] **G.1.11** Autres fichiers > ~500 lignes restants (grep `wc -l`)  
+  _Avancement :_ `GlobalStats` découpé en sous-composants (`components/global-stats/*`) ; le composant racine devient un orchestrateur.
 
 **Critère :** Fichier principal < ~400 lignes **ou** justification inline (composant purement présentationnel sans logique).
 
@@ -255,3 +256,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 | 2026-05-09 | — | Epic D complété : rôles Discord API + session/verify + `useAuth` + `AuthGuard` alignés sur `USER_ROLES` / helpers |
 | 2026-05-09 | — | Epic E complété : ESLint dans `next build`, retrait fallbacks Firebase dans next.config, source maps prod désactivées, doc QUALITY_GATES + SECURITY |
 | 2026-05-09 | — | Epic F — F.1/F.2 : retrait `force-dynamic` / `runtime` du layout racine ; `LoginContent`, `ResetPasswordContent`, `VerifyEmailContent` + Suspense sur les pages correspondantes ; build statique OK pour les segments concernés |
+| 2026-05-09 | — | Epic G (lot 1) : `GlobalStats` découpé en sous-composants (`global-stats/*`) sans changement fonctionnel |

--- a/src/components/GlobalStats.tsx
+++ b/src/components/GlobalStats.tsx
@@ -1,79 +1,17 @@
 "use client";
 
-import React, { useState } from "react";
-import {
-  Card,
-  CardContent,
-  Typography,
-  Box,
-  Button,
-  Chip,
-  LinearProgress,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemIcon,
-  Alert,
-  CircularProgress,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-} from "@mui/material";
-import {
-  TrendingUp as TrendingUpIcon,
-  TrendingDown as TrendingDownIcon,
-  People as PeopleIcon,
-  Sports as SportsIcon,
-  Event as EventIcon,
-  Assessment as AssessmentIcon,
-  Refresh as RefreshIcon,
-  Download as DownloadIcon,
-  Warning as WarningIcon,
-  CheckCircle as CheckCircleIcon,
-  Info as InfoIcon,
-} from "@mui/icons-material";
+import { useState } from "react";
+import { Download as DownloadIcon, Refresh as RefreshIcon } from "@mui/icons-material";
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { AlertsCard } from "@/components/global-stats/AlertsCard";
+import { BreakdownTableCard } from "@/components/global-stats/BreakdownTableCard";
+import { DistributionCard } from "@/components/global-stats/DistributionCard";
+import { OverviewCards } from "@/components/global-stats/OverviewCards";
+import { PerformanceCard } from "@/components/global-stats/PerformanceCard";
+import type { GlobalStatsData } from "@/components/global-stats/types";
 
 interface GlobalStatsProps {
-  stats: {
-    overview: {
-      totalPlayers: number;
-      totalTeams: number;
-      totalMatches: number;
-      totalChampionships: number;
-      activePlayers: number;
-      inactivePlayers: number;
-      upcomingMatches: number;
-      completedMatches: number;
-    };
-    trends: {
-      playerGrowth: number;
-      teamGrowth: number;
-      matchGrowth: number;
-      championshipGrowth: number;
-    };
-    performance: {
-      averageMatchDuration: number;
-      averagePlayerRating: number;
-      averageTeamRating: number;
-      winRate: number;
-      participationRate: number;
-    };
-    distribution: {
-      playersByGender: { male: number; female: number };
-      playersByAge: { junior: number; senior: number; veteran: number };
-      teamsByDivision: { [key: string]: number };
-      matchesByMonth: { [key: string]: number };
-    };
-    alerts: {
-      type: "warning" | "error" | "info" | "success";
-      message: string;
-      count: number;
-    }[];
-  };
+  stats: GlobalStatsData;
   onRefresh: () => Promise<void>;
   onExport: (format: "csv" | "pdf" | "excel") => Promise<void>;
   loading?: boolean;
@@ -92,8 +30,6 @@ export function GlobalStats({
     try {
       setRefreshing(true);
       await onRefresh();
-    } catch (error) {
-      console.error("Erreur lors du rafraîchissement:", error);
     } finally {
       setRefreshing(false);
     }
@@ -103,46 +39,8 @@ export function GlobalStats({
     try {
       setExporting(format);
       await onExport(format);
-    } catch (error) {
-      console.error("Erreur lors de l&apos;export:", error);
     } finally {
       setExporting(null);
-    }
-  };
-
-  const getTrendIcon = (trend: number) => {
-    if (trend > 0) return <TrendingUpIcon color="success" />;
-    if (trend < 0) return <TrendingDownIcon color="error" />;
-    return <TrendingUpIcon color="disabled" />;
-  };
-
-  const getAlertIcon = (type: string) => {
-    switch (type) {
-      case "warning":
-        return <WarningIcon color="warning" />;
-      case "error":
-        return <WarningIcon color="error" />;
-      case "info":
-        return <InfoIcon color="info" />;
-      case "success":
-        return <CheckCircleIcon color="success" />;
-      default:
-        return <InfoIcon color="inherit" />;
-    }
-  };
-
-  const getAlertColor = (type: string) => {
-    switch (type) {
-      case "warning":
-        return "warning";
-      case "error":
-        return "error";
-      case "info":
-        return "info";
-      case "success":
-        return "success";
-      default:
-        return "default";
     }
   };
 
@@ -205,408 +103,39 @@ export function GlobalStats({
       </Box>
 
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
-        <Box sx={{ width: { xs: "100%", md: "25%" } }}>
-          <Card>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <PeopleIcon color="primary" sx={{ mr: 1 }} />
-                <Typography variant="h6">Joueurs</Typography>
-              </Box>
-              <Typography variant="h4" gutterBottom>
-                {stats.overview.totalPlayers}
-              </Typography>
-              <Box display="flex" alignItems="center" mb={1}>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mr: 1 }}
-                >
-                  Actifs: {stats.overview.activePlayers}
-                </Typography>
-                <Chip
-                  label={`${(
-                    (stats.overview.activePlayers /
-                      stats.overview.totalPlayers) *
-                    100
-                  ).toFixed(1)}%`}
-                  color="success"
-                  size="small"
-                />
-              </Box>
-              <Box display="flex" alignItems="center">
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mr: 1 }}
-                >
-                  Inactifs: {stats.overview.inactivePlayers}
-                </Typography>
-                <Chip
-                  label={`${(
-                    (stats.overview.inactivePlayers /
-                      stats.overview.totalPlayers) *
-                    100
-                  ).toFixed(1)}%`}
-                  color="default"
-                  size="small"
-                />
-              </Box>
-            </CardContent>
-          </Card>
-        </Box>
+        <OverviewCards stats={stats} />
 
-        <Box sx={{ width: { xs: "100%", md: "25%" } }}>
-          <Card>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <SportsIcon color="primary" sx={{ mr: 1 }} />
-                <Typography variant="h6">Équipes</Typography>
-              </Box>
-              <Typography variant="h4" gutterBottom>
-                {stats.overview.totalTeams}
-              </Typography>
-              <Box display="flex" alignItems="center">
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mr: 1 }}
-                >
-                  Croissance: {stats.trends.teamGrowth > 0 ? "+" : ""}
-                  {stats.trends.teamGrowth}%
-                </Typography>
-                {getTrendIcon(stats.trends.teamGrowth)}
-              </Box>
-            </CardContent>
-          </Card>
-        </Box>
-
-        <Box sx={{ width: { xs: "100%", md: "25%" } }}>
-          <Card>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <EventIcon color="primary" sx={{ mr: 1 }} />
-                <Typography variant="h6">Matchs</Typography>
-              </Box>
-              <Typography variant="h4" gutterBottom>
-                {stats.overview.totalMatches}
-              </Typography>
-              <Box display="flex" alignItems="center" mb={1}>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mr: 1 }}
-                >
-                  À venir: {stats.overview.upcomingMatches}
-                </Typography>
-                <Chip
-                  label={`${(
-                    (stats.overview.upcomingMatches /
-                      stats.overview.totalMatches) *
-                    100
-                  ).toFixed(1)}%`}
-                  color="info"
-                  size="small"
-                />
-              </Box>
-              <Box display="flex" alignItems="center">
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mr: 1 }}
-                >
-                  Terminés: {stats.overview.completedMatches}
-                </Typography>
-                <Chip
-                  label={`${(
-                    (stats.overview.completedMatches /
-                      stats.overview.totalMatches) *
-                    100
-                  ).toFixed(1)}%`}
-                  color="success"
-                  size="small"
-                />
-              </Box>
-            </CardContent>
-          </Card>
-        </Box>
-
-        <Box sx={{ width: { xs: "100%", md: "25%" } }}>
-          <Card>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <AssessmentIcon color="primary" sx={{ mr: 1 }} />
-                <Typography variant="h6">Championnats</Typography>
-              </Box>
-              <Typography variant="h4" gutterBottom>
-                {stats.overview.totalChampionships}
-              </Typography>
-              <Box display="flex" alignItems="center">
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mr: 1 }}
-                >
-                  Croissance: {stats.trends.championshipGrowth > 0 ? "+" : ""}
-                  {stats.trends.championshipGrowth}%
-                </Typography>
-                {getTrendIcon(stats.trends.championshipGrowth)}
-              </Box>
-            </CardContent>
-          </Card>
+        <Box sx={{ width: { xs: "100%", md: "50%" } }}>
+          <PerformanceCard performance={stats.performance} />
         </Box>
 
         <Box sx={{ width: { xs: "100%", md: "50%" } }}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Performance
-              </Typography>
-              <List dense>
-                <ListItem>
-                  <ListItemText
-                    primary="Durée moyenne des matchs"
-                    secondary={`${stats.performance.averageMatchDuration} minutes`}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Classement moyen des joueurs"
-                    secondary={stats.performance.averagePlayerRating.toFixed(1)}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Classement moyen des équipes"
-                    secondary={stats.performance.averageTeamRating.toFixed(1)}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Taux de victoire"
-                    secondary={`${(stats.performance.winRate * 100).toFixed(
-                      1
-                    )}%`}
-                  />
-                  <LinearProgress
-                    variant="determinate"
-                    value={stats.performance.winRate * 100}
-                    sx={{ width: 100, ml: 2 }}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Taux de participation"
-                    secondary={`${(
-                      stats.performance.participationRate * 100
-                    ).toFixed(1)}%`}
-                  />
-                  <LinearProgress
-                    variant="determinate"
-                    value={stats.performance.participationRate * 100}
-                    sx={{ width: 100, ml: 2 }}
-                  />
-                </ListItem>
-              </List>
-            </CardContent>
-          </Card>
+          <DistributionCard
+            distribution={stats.distribution}
+            totalPlayers={stats.overview.totalPlayers}
+          />
         </Box>
 
         <Box sx={{ width: { xs: "100%", md: "50%" } }}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Distribution
-              </Typography>
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-                <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                  <Typography variant="subtitle2" gutterBottom>
-                    Par genre
-                  </Typography>
-                  <Box display="flex" alignItems="center" mb={1}>
-                    <Typography variant="body2" sx={{ mr: 1 }}>
-                      Hommes: {stats.distribution.playersByGender.male}
-                    </Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={
-                        (stats.distribution.playersByGender.male /
-                          stats.overview.totalPlayers) *
-                        100
-                      }
-                      sx={{ flexGrow: 1, ml: 1 }}
-                    />
-                  </Box>
-                  <Box display="flex" alignItems="center">
-                    <Typography variant="body2" sx={{ mr: 1 }}>
-                      Femmes: {stats.distribution.playersByGender.female}
-                    </Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={
-                        (stats.distribution.playersByGender.female /
-                          stats.overview.totalPlayers) *
-                        100
-                      }
-                      sx={{ flexGrow: 1, ml: 1 }}
-                    />
-                  </Box>
-                </Box>
-                <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                  <Typography variant="subtitle2" gutterBottom>
-                    Par âge
-                  </Typography>
-                  <Box display="flex" alignItems="center" mb={1}>
-                    <Typography variant="body2" sx={{ mr: 1 }}>
-                      Juniors: {stats.distribution.playersByAge.junior}
-                    </Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={
-                        (stats.distribution.playersByAge.junior /
-                          stats.overview.totalPlayers) *
-                        100
-                      }
-                      sx={{ flexGrow: 1, ml: 1 }}
-                    />
-                  </Box>
-                  <Box display="flex" alignItems="center" mb={1}>
-                    <Typography variant="body2" sx={{ mr: 1 }}>
-                      Seniors: {stats.distribution.playersByAge.senior}
-                    </Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={
-                        (stats.distribution.playersByAge.senior /
-                          stats.overview.totalPlayers) *
-                        100
-                      }
-                      sx={{ flexGrow: 1, ml: 1 }}
-                    />
-                  </Box>
-                  <Box display="flex" alignItems="center">
-                    <Typography variant="body2" sx={{ mr: 1 }}>
-                      Vétérans: {stats.distribution.playersByAge.veteran}
-                    </Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={
-                        (stats.distribution.playersByAge.veteran /
-                          stats.overview.totalPlayers) *
-                        100
-                      }
-                      sx={{ flexGrow: 1, ml: 1 }}
-                    />
-                  </Box>
-                </Box>
-              </Box>
-            </CardContent>
-          </Card>
+          <BreakdownTableCard
+            title="Équipes par division"
+            label="Division"
+            rows={stats.distribution.teamsByDivision}
+            total={stats.overview.totalTeams}
+          />
         </Box>
 
         <Box sx={{ width: { xs: "100%", md: "50%" } }}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Équipes par division
-              </Typography>
-              <TableContainer component={Paper} variant="outlined">
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Division</TableCell>
-                      <TableCell align="right">Nombre</TableCell>
-                      <TableCell align="right">Pourcentage</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {Object.entries(stats.distribution.teamsByDivision).map(
-                      ([division, count]) => (
-                        <TableRow key={division}>
-                          <TableCell>{division}</TableCell>
-                          <TableCell align="right">{count}</TableCell>
-                          <TableCell align="right">
-                            {(
-                              (count / stats.overview.totalTeams) *
-                              100
-                            ).toFixed(1)}
-                            %
-                          </TableCell>
-                        </TableRow>
-                      )
-                    )}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            </CardContent>
-          </Card>
-        </Box>
-
-        <Box sx={{ width: { xs: "100%", md: "50%" } }}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Matchs par mois
-              </Typography>
-              <TableContainer component={Paper} variant="outlined">
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Mois</TableCell>
-                      <TableCell align="right">Nombre</TableCell>
-                      <TableCell align="right">Pourcentage</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {Object.entries(stats.distribution.matchesByMonth).map(
-                      ([month, count]) => (
-                        <TableRow key={month}>
-                          <TableCell>{month}</TableCell>
-                          <TableCell align="right">{count}</TableCell>
-                          <TableCell align="right">
-                            {(
-                              (count / stats.overview.totalMatches) *
-                              100
-                            ).toFixed(1)}
-                            %
-                          </TableCell>
-                        </TableRow>
-                      )
-                    )}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            </CardContent>
-          </Card>
+          <BreakdownTableCard
+            title="Matchs par mois"
+            label="Mois"
+            rows={stats.distribution.matchesByMonth}
+            total={stats.overview.totalMatches}
+          />
         </Box>
 
         <Box sx={{ width: "100%" }}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Alertes et notifications
-              </Typography>
-              {stats.alerts.length === 0 ? (
-                <Alert severity="info">Aucune alerte en cours</Alert>
-              ) : (
-                <List dense>
-                  {stats.alerts.map((alert, index) => (
-                    <ListItem key={index}>
-                      <ListItemIcon>{getAlertIcon(alert.type)}</ListItemIcon>
-                      <ListItemText
-                        primary={alert.message}
-                        secondary={`${alert.count} occurrence(s)`}
-                      />
-                      <Chip
-                        label={alert.type}
-                        color={getAlertColor(alert.type)}
-                        size="small"
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              )}
-            </CardContent>
-          </Card>
+          <AlertsCard alerts={stats.alerts} />
         </Box>
       </Box>
     </Box>

--- a/src/components/global-stats/AlertsCard.tsx
+++ b/src/components/global-stats/AlertsCard.tsx
@@ -1,0 +1,80 @@
+import {
+  Alert,
+  Card,
+  CardContent,
+  Chip,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+import {
+  CheckCircle as CheckCircleIcon,
+  Info as InfoIcon,
+  Warning as WarningIcon,
+} from "@mui/icons-material";
+import type { ReactNode } from "react";
+import type { GlobalStatsData } from "./types";
+
+interface AlertsCardProps {
+  alerts: GlobalStatsData["alerts"];
+}
+
+function alertIcon(type: GlobalStatsData["alerts"][number]["type"]): ReactNode {
+  switch (type) {
+    case "warning":
+      return <WarningIcon color="warning" />;
+    case "error":
+      return <WarningIcon color="error" />;
+    case "info":
+      return <InfoIcon color="info" />;
+    case "success":
+      return <CheckCircleIcon color="success" />;
+    default:
+      return <InfoIcon color="inherit" />;
+  }
+}
+
+function alertColor(type: GlobalStatsData["alerts"][number]["type"]) {
+  switch (type) {
+    case "warning":
+      return "warning";
+    case "error":
+      return "error";
+    case "info":
+      return "info";
+    case "success":
+      return "success";
+    default:
+      return "default";
+  }
+}
+
+export function AlertsCard({ alerts }: AlertsCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Alertes et notifications
+        </Typography>
+        {alerts.length === 0 ? (
+          <Alert severity="info">Aucune alerte en cours</Alert>
+        ) : (
+          <List dense>
+            {alerts.map((alert, index) => (
+              <ListItem key={`${alert.type}-${index}`}>
+                <ListItemIcon>{alertIcon(alert.type)}</ListItemIcon>
+                <ListItemText
+                  primary={alert.message}
+                  secondary={`${alert.count} occurrence(s)`}
+                />
+                <Chip label={alert.type} color={alertColor(alert.type)} size="small" />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/global-stats/BreakdownTableCard.tsx
+++ b/src/components/global-stats/BreakdownTableCard.tsx
@@ -1,0 +1,63 @@
+import {
+  Card,
+  CardContent,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+
+interface BreakdownTableCardProps {
+  title: string;
+  label: string;
+  rows: Record<string, number>;
+  total: number;
+}
+
+function rowPercentage(value: number, total: number): string {
+  if (total <= 0) {
+    return "0.0";
+  }
+  return ((value / total) * 100).toFixed(1);
+}
+
+export function BreakdownTableCard({
+  title,
+  label,
+  rows,
+  total,
+}: BreakdownTableCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          {title}
+        </Typography>
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>{label}</TableCell>
+                <TableCell align="right">Nombre</TableCell>
+                <TableCell align="right">Pourcentage</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {Object.entries(rows).map(([key, count]) => (
+                <TableRow key={key}>
+                  <TableCell>{key}</TableCell>
+                  <TableCell align="right">{count}</TableCell>
+                  <TableCell align="right">{rowPercentage(count, total)}%</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/global-stats/DistributionCard.tsx
+++ b/src/components/global-stats/DistributionCard.tsx
@@ -1,0 +1,91 @@
+import { Box, Card, CardContent, LinearProgress, Typography } from "@mui/material";
+import type { GlobalStatsData } from "./types";
+
+interface DistributionCardProps {
+  distribution: GlobalStatsData["distribution"];
+  totalPlayers: number;
+}
+
+function percentage(value: number, total: number): number {
+  if (total <= 0) {
+    return 0;
+  }
+  return (value / total) * 100;
+}
+
+export function DistributionCard({
+  distribution,
+  totalPlayers,
+}: DistributionCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Distribution
+        </Typography>
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+          <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Par genre
+            </Typography>
+            <Box display="flex" alignItems="center" mb={1}>
+              <Typography variant="body2" sx={{ mr: 1 }}>
+                Hommes: {distribution.playersByGender.male}
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={percentage(distribution.playersByGender.male, totalPlayers)}
+                sx={{ flexGrow: 1, ml: 1 }}
+              />
+            </Box>
+            <Box display="flex" alignItems="center">
+              <Typography variant="body2" sx={{ mr: 1 }}>
+                Femmes: {distribution.playersByGender.female}
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={percentage(distribution.playersByGender.female, totalPlayers)}
+                sx={{ flexGrow: 1, ml: 1 }}
+              />
+            </Box>
+          </Box>
+          <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Par âge
+            </Typography>
+            <Box display="flex" alignItems="center" mb={1}>
+              <Typography variant="body2" sx={{ mr: 1 }}>
+                Juniors: {distribution.playersByAge.junior}
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={percentage(distribution.playersByAge.junior, totalPlayers)}
+                sx={{ flexGrow: 1, ml: 1 }}
+              />
+            </Box>
+            <Box display="flex" alignItems="center" mb={1}>
+              <Typography variant="body2" sx={{ mr: 1 }}>
+                Seniors: {distribution.playersByAge.senior}
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={percentage(distribution.playersByAge.senior, totalPlayers)}
+                sx={{ flexGrow: 1, ml: 1 }}
+              />
+            </Box>
+            <Box display="flex" alignItems="center">
+              <Typography variant="body2" sx={{ mr: 1 }}>
+                Vétérans: {distribution.playersByAge.veteran}
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={percentage(distribution.playersByAge.veteran, totalPlayers)}
+                sx={{ flexGrow: 1, ml: 1 }}
+              />
+            </Box>
+          </Box>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/global-stats/OverviewCards.tsx
+++ b/src/components/global-stats/OverviewCards.tsx
@@ -1,0 +1,160 @@
+import { Box, Card, CardContent, Chip, Typography } from "@mui/material";
+import {
+  Assessment as AssessmentIcon,
+  Event as EventIcon,
+  People as PeopleIcon,
+  Sports as SportsIcon,
+  TrendingDown as TrendingDownIcon,
+  TrendingUp as TrendingUpIcon,
+} from "@mui/icons-material";
+import type { ReactNode } from "react";
+import type { GlobalStatsData } from "./types";
+
+interface OverviewCardsProps {
+  stats: GlobalStatsData;
+}
+
+function ratioPercentage(value: number, total: number): string {
+  if (total <= 0) {
+    return "0.0";
+  }
+  return ((value / total) * 100).toFixed(1);
+}
+
+function TrendIndicator({ trend }: { trend: number }): ReactNode {
+  if (trend > 0) {
+    return <TrendingUpIcon color="success" />;
+  }
+  if (trend < 0) {
+    return <TrendingDownIcon color="error" />;
+  }
+  return <TrendingUpIcon color="disabled" />;
+}
+
+export function OverviewCards({ stats }: OverviewCardsProps) {
+  return (
+    <>
+      <Box sx={{ width: { xs: "100%", md: "25%" } }}>
+        <Card>
+          <CardContent>
+            <Box display="flex" alignItems="center" mb={2}>
+              <PeopleIcon color="primary" sx={{ mr: 1 }} />
+              <Typography variant="h6">Joueurs</Typography>
+            </Box>
+            <Typography variant="h4" gutterBottom>
+              {stats.overview.totalPlayers}
+            </Typography>
+            <Box display="flex" alignItems="center" mb={1}>
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                Actifs: {stats.overview.activePlayers}
+              </Typography>
+              <Chip
+                label={`${ratioPercentage(
+                  stats.overview.activePlayers,
+                  stats.overview.totalPlayers
+                )}%`}
+                color="success"
+                size="small"
+              />
+            </Box>
+            <Box display="flex" alignItems="center">
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                Inactifs: {stats.overview.inactivePlayers}
+              </Typography>
+              <Chip
+                label={`${ratioPercentage(
+                  stats.overview.inactivePlayers,
+                  stats.overview.totalPlayers
+                )}%`}
+                color="default"
+                size="small"
+              />
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+
+      <Box sx={{ width: { xs: "100%", md: "25%" } }}>
+        <Card>
+          <CardContent>
+            <Box display="flex" alignItems="center" mb={2}>
+              <SportsIcon color="primary" sx={{ mr: 1 }} />
+              <Typography variant="h6">Équipes</Typography>
+            </Box>
+            <Typography variant="h4" gutterBottom>
+              {stats.overview.totalTeams}
+            </Typography>
+            <Box display="flex" alignItems="center">
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                Croissance: {stats.trends.teamGrowth > 0 ? "+" : ""}
+                {stats.trends.teamGrowth}%
+              </Typography>
+              <TrendIndicator trend={stats.trends.teamGrowth} />
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+
+      <Box sx={{ width: { xs: "100%", md: "25%" } }}>
+        <Card>
+          <CardContent>
+            <Box display="flex" alignItems="center" mb={2}>
+              <EventIcon color="primary" sx={{ mr: 1 }} />
+              <Typography variant="h6">Matchs</Typography>
+            </Box>
+            <Typography variant="h4" gutterBottom>
+              {stats.overview.totalMatches}
+            </Typography>
+            <Box display="flex" alignItems="center" mb={1}>
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                À venir: {stats.overview.upcomingMatches}
+              </Typography>
+              <Chip
+                label={`${ratioPercentage(
+                  stats.overview.upcomingMatches,
+                  stats.overview.totalMatches
+                )}%`}
+                color="info"
+                size="small"
+              />
+            </Box>
+            <Box display="flex" alignItems="center">
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                Terminés: {stats.overview.completedMatches}
+              </Typography>
+              <Chip
+                label={`${ratioPercentage(
+                  stats.overview.completedMatches,
+                  stats.overview.totalMatches
+                )}%`}
+                color="success"
+                size="small"
+              />
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+
+      <Box sx={{ width: { xs: "100%", md: "25%" } }}>
+        <Card>
+          <CardContent>
+            <Box display="flex" alignItems="center" mb={2}>
+              <AssessmentIcon color="primary" sx={{ mr: 1 }} />
+              <Typography variant="h6">Championnats</Typography>
+            </Box>
+            <Typography variant="h4" gutterBottom>
+              {stats.overview.totalChampionships}
+            </Typography>
+            <Box display="flex" alignItems="center">
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                Croissance: {stats.trends.championshipGrowth > 0 ? "+" : ""}
+                {stats.trends.championshipGrowth}%
+              </Typography>
+              <TrendIndicator trend={stats.trends.championshipGrowth} />
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+    </>
+  );
+}

--- a/src/components/global-stats/PerformanceCard.tsx
+++ b/src/components/global-stats/PerformanceCard.tsx
@@ -1,0 +1,68 @@
+import {
+  Card,
+  CardContent,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+import type { GlobalStatsData } from "./types";
+
+interface PerformanceCardProps {
+  performance: GlobalStatsData["performance"];
+}
+
+export function PerformanceCard({ performance }: PerformanceCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Performance
+        </Typography>
+        <List dense>
+          <ListItem>
+            <ListItemText
+              primary="Durée moyenne des matchs"
+              secondary={`${performance.averageMatchDuration} minutes`}
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              primary="Classement moyen des joueurs"
+              secondary={performance.averagePlayerRating.toFixed(1)}
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              primary="Classement moyen des équipes"
+              secondary={performance.averageTeamRating.toFixed(1)}
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              primary="Taux de victoire"
+              secondary={`${(performance.winRate * 100).toFixed(1)}%`}
+            />
+            <LinearProgress
+              variant="determinate"
+              value={performance.winRate * 100}
+              sx={{ width: 100, ml: 2 }}
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              primary="Taux de participation"
+              secondary={`${(performance.participationRate * 100).toFixed(1)}%`}
+            />
+            <LinearProgress
+              variant="determinate"
+              value={performance.participationRate * 100}
+              sx={{ width: 100, ml: 2 }}
+            />
+          </ListItem>
+        </List>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/global-stats/types.ts
+++ b/src/components/global-stats/types.ts
@@ -1,0 +1,38 @@
+export type GlobalStatsAlertType = "warning" | "error" | "info" | "success";
+
+export interface GlobalStatsData {
+  overview: {
+    totalPlayers: number;
+    totalTeams: number;
+    totalMatches: number;
+    totalChampionships: number;
+    activePlayers: number;
+    inactivePlayers: number;
+    upcomingMatches: number;
+    completedMatches: number;
+  };
+  trends: {
+    playerGrowth: number;
+    teamGrowth: number;
+    matchGrowth: number;
+    championshipGrowth: number;
+  };
+  performance: {
+    averageMatchDuration: number;
+    averagePlayerRating: number;
+    averageTeamRating: number;
+    winRate: number;
+    participationRate: number;
+  };
+  distribution: {
+    playersByGender: { male: number; female: number };
+    playersByAge: { junior: number; senior: number; veteran: number };
+    teamsByDivision: Record<string, number>;
+    matchesByMonth: Record<string, number>;
+  };
+  alerts: {
+    type: GlobalStatsAlertType;
+    message: string;
+    count: number;
+  }[];
+}


### PR DESCRIPTION
## Summary
- split `src/components/GlobalStats.tsx` into focused view modules under `src/components/global-stats/*`
- centralize global stats data typing in `global-stats/types.ts`
- update audit action plan to mark Epic G.1.11 as in progress with this first extraction lot

## Test plan
- [x] `npm run check:dev`
- [x] `npm run check`

Made with [Cursor](https://cursor.com)