### PR TITLE
refactor(backup): split BackupRestore into focused modules

### DIFF
--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -182,7 +182,7 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 - [ ] **G.1.9** `AppSettings`
 - [ ] **G.1.10** `SystemMaintenance`
 - [~] **G.1.11** Autres fichiers > ~500 lignes restants (grep `wc -l`)  
-  _Avancement :_ `GlobalStats` découpé en sous-composants (`components/global-stats/*`) ; le composant racine devient un orchestrateur.
+  _Avancement :_ `GlobalStats` puis `BackupRestore` découpés en sous-composants dédiés (`components/global-stats/*`, `components/backup-restore/*`) ; les composants racine deviennent des orchestrateurs.
 
 **Critère :** Fichier principal < ~400 lignes **ou** justification inline (composant purement présentationnel sans logique).
 
@@ -257,3 +257,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 | 2026-05-09 | — | Epic E complété : ESLint dans `next build`, retrait fallbacks Firebase dans next.config, source maps prod désactivées, doc QUALITY_GATES + SECURITY |
 | 2026-05-09 | — | Epic F — F.1/F.2 : retrait `force-dynamic` / `runtime` du layout racine ; `LoginContent`, `ResetPasswordContent`, `VerifyEmailContent` + Suspense sur les pages correspondantes ; build statique OK pour les segments concernés |
 | 2026-05-09 | — | Epic G (lot 1) : `GlobalStats` découpé en sous-composants (`global-stats/*`) sans changement fonctionnel |
+| 2026-05-09 | — | Epic G (lot 2) : `BackupRestore` découpé en modules (`backup-restore/*`) pour isoler table, dialogs, types et utilitaires |

--- a/src/components/BackupRestore.tsx
+++ b/src/components/BackupRestore.tsx
@@ -1,161 +1,20 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import {
-  Card,
-  CardContent,
-  Typography,
-  Box,
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  FormControl,
-  FormLabel,
-  FormControlLabel,
-  Switch,
-  Select,
-  MenuItem,
-  Alert,
-  // List,
-  // ListItem,
-  // ListItemText,
-  // ListItemSecondaryAction,
-  IconButton,
-  Chip,
-  // Divider,
-  // Grid,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-  // LinearProgress,
-  CircularProgress,
-} from "@mui/material";
+import { useState } from "react";
 import {
   Backup as BackupIcon,
-  Restore as RestoreIcon,
-  Download as DownloadIcon,
-  Upload as UploadIcon,
-  Delete as DeleteIcon,
   Refresh as RefreshIcon,
   Schedule as ScheduleIcon,
-  CheckCircle as CheckCircleIcon,
-  Error as ErrorIcon,
-  // Warning as WarningIcon,
-  Info as InfoIcon,
-  // Storage as StorageIcon,
-  // CloudDownload as CloudDownloadIcon,
-  // CloudUpload as CloudUploadIcon,
   Settings as SettingsIcon,
+  Upload as UploadIcon,
 } from "@mui/icons-material";
+import { Alert, Box, Button, Card, CardContent, Typography } from "@mui/material";
+import { BackupsTableCard } from "@/components/backup-restore/BackupsTableCard";
+import { DEFAULT_BACKUP_OPTIONS } from "@/components/backup-restore/constants";
+import { CreateBackupDialog } from "@/components/backup-restore/CreateBackupDialog";
+import type { Backup, BackupOptions, BackupRestoreProps } from "@/components/backup-restore/types";
+import { UploadBackupDialog } from "@/components/backup-restore/UploadBackupDialog";
 
-interface BackupRestoreProps {
-  backups: Backup[];
-  onCreateBackup: (options: BackupOptions) => Promise<void>;
-  onRestoreBackup: (backupId: string) => Promise<void>;
-  onDeleteBackup: (backupId: string) => Promise<void>;
-  onDownloadBackup: (backupId: string) => Promise<void>;
-  onUploadBackup: (file: File) => Promise<void>;
-  onScheduleBackup: (schedule: BackupSchedule) => Promise<void>;
-  onGetBackupSettings: () => Promise<BackupSettings>;
-  onUpdateBackupSettings: (settings: BackupSettings) => Promise<void>;
-  loading?: boolean;
-}
-
-interface Backup {
-  id: string;
-  name: string;
-  type: "full" | "incremental" | "differential";
-  status: "completed" | "failed" | "in_progress" | "scheduled";
-  size: number;
-  createdAt: string;
-  createdBy: string;
-  description?: string;
-  metadata: {
-    version: string;
-    environment: string;
-    dataTypes: string[];
-    compression: boolean;
-    encryption: boolean;
-  };
-  scheduleId?: string;
-  parentBackupId?: string;
-  checksum: string;
-  location: string;
-  retention: {
-    expiresAt?: string;
-    autoDelete: boolean;
-  };
-}
-
-interface BackupOptions {
-  name: string;
-  type: "full" | "incremental" | "differential";
-  description?: string;
-  dataTypes: string[];
-  compression: boolean;
-  encryption: boolean;
-  password?: string;
-  scheduleId?: string;
-  parentBackupId?: string;
-}
-
-interface BackupSchedule {
-  id: string;
-  name: string;
-  type: "full" | "incremental" | "differential";
-  frequency: "daily" | "weekly" | "monthly";
-  time: string;
-  days: number[];
-  enabled: boolean;
-  retention: number;
-  dataTypes: string[];
-  compression: boolean;
-  encryption: boolean;
-}
-
-interface BackupSettings {
-  storage: {
-    type: "local" | "s3" | "azure" | "gcp";
-    path: string;
-    credentials: {
-      [key: string]: string;
-    };
-  };
-  compression: {
-    enabled: boolean;
-    algorithm: "gzip" | "bzip2" | "lz4";
-    level: number;
-  };
-  encryption: {
-    enabled: boolean;
-    algorithm: "aes256" | "aes128";
-    keyRotation: number;
-  };
-  retention: {
-    maxBackups: number;
-    maxAge: number;
-    autoDelete: boolean;
-  };
-  scheduling: {
-    enabled: boolean;
-    timezone: string;
-    maxConcurrent: number;
-  };
-  notifications: {
-    enabled: boolean;
-    onSuccess: boolean;
-    onFailure: boolean;
-    onCompletion: boolean;
-  };
-}
 
 export function BackupRestore({
   backups,
@@ -175,14 +34,7 @@ BackupRestoreProps) {
   // const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   // const [selectedBackup, setSelectedBackup] = useState<Backup | null>(null);
-  const [newBackup, setNewBackup] = useState<BackupOptions>({
-    name: "",
-    type: "full",
-    description: "",
-    dataTypes: ["players", "teams", "matches"],
-    compression: true,
-    encryption: false,
-  });
+  const [newBackup, setNewBackup] = useState<BackupOptions>(DEFAULT_BACKUP_OPTIONS);
   // const [newSchedule, setNewSchedule] = useState<BackupSchedule>({
   //   id: "",
   //   name: "",
@@ -201,45 +53,13 @@ BackupRestoreProps) {
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
 
-  const dataTypes = [
-    { value: "players", label: "Joueurs" },
-    { value: "teams", label: "Équipes" },
-    { value: "matches", label: "Matchs" },
-    { value: "championships", label: "Championnats" },
-    { value: "availabilities", label: "Disponibilités" },
-    { value: "compositions", label: "Compositions" },
-    { value: "users", label: "Utilisateurs" },
-    { value: "settings", label: "Paramètres" },
-    { value: "audit_logs", label: "Logs d&apos;audit" },
-  ];
-
-  useEffect(() => {
-    loadSettings();
-  }, []);
-
-  const loadSettings = async () => {
-    try {
-      // const backupSettings = await onGetBackupSettings();
-      // setSettings(backupSettings);
-    } catch (err) {
-      console.error("Erreur lors du chargement des paramètres:", err);
-    }
-  };
-
   const handleCreateBackup = async () => {
     try {
       setProcessing(true);
       setError(null);
       await onCreateBackup(newBackup);
       setCreateDialogOpen(false);
-      setNewBackup({
-        name: "",
-        type: "full",
-        description: "",
-        dataTypes: ["players", "teams", "matches"],
-        compression: true,
-        encryption: false,
-      });
+      setNewBackup(DEFAULT_BACKUP_OPTIONS);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Erreur lors de la création"
@@ -358,74 +178,6 @@ BackupRestoreProps) {
   //   }
   // };
 
-  const getTypeIcon = (type: string) => {
-    switch (type) {
-      case "full":
-        return <BackupIcon color="primary" />;
-      case "incremental":
-        return <BackupIcon color="secondary" />;
-      case "differential":
-        return <BackupIcon color="info" />;
-      default:
-        return <BackupIcon color="inherit" />;
-    }
-  };
-
-  const getTypeColor = (type: string) => {
-    switch (type) {
-      case "full":
-        return "primary";
-      case "incremental":
-        return "secondary";
-      case "differential":
-        return "info";
-      default:
-        return "default";
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "completed":
-        return <CheckCircleIcon color="success" />;
-      case "failed":
-        return <ErrorIcon color="error" />;
-      case "in_progress":
-        return <CircularProgress size={20} />;
-      case "scheduled":
-        return <ScheduleIcon color="info" />;
-      default:
-        return <InfoIcon color="inherit" />;
-    }
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "completed":
-        return "success";
-      case "failed":
-        return "error";
-      case "in_progress":
-        return "info";
-      case "scheduled":
-        return "info";
-      default:
-        return "default";
-    }
-  };
-
-  const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return "0 Bytes";
-    const k = 1024;
-    const sizes = ["Bytes", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString("fr-FR");
-  };
-
   // const isBackupExpired = (backup: Backup) => {
   //   if (!backup.retention.expiresAt) return false;
   //   return new Date(backup.retention.expiresAt) < new Date();
@@ -473,137 +225,13 @@ BackupRestoreProps) {
 
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
         <Box sx={{ width: { xs: "100%", md: "66.67%" } }}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Sauvegardes disponibles
-              </Typography>
-              {backups.length === 0 ? (
-                <Alert severity="info">Aucune sauvegarde disponible</Alert>
-              ) : (
-                <TableContainer component={Paper} variant="outlined">
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Nom</TableCell>
-                        <TableCell>Type</TableCell>
-                        <TableCell>Statut</TableCell>
-                        <TableCell>Taille</TableCell>
-                        <TableCell>Date</TableCell>
-                        <TableCell>Actions</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {backups.map((backup) => (
-                        <TableRow key={backup.id} hover>
-                          <TableCell>
-                            <Box>
-                              <Typography variant="body2" fontWeight="medium">
-                                {backup.name}
-                              </Typography>
-                              {backup.description && (
-                                <Typography
-                                  variant="caption"
-                                  color="text.secondary"
-                                >
-                                  {backup.description}
-                                </Typography>
-                              )}
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Box display="flex" alignItems="center" gap={1}>
-                              {getTypeIcon(backup.type)}
-                              <Chip
-                                label={backup.type}
-                                color={
-                                  getTypeColor(backup.type) as
-                                    | "default"
-                                    | "primary"
-                                    | "secondary"
-                                    | "error"
-                                    | "info"
-                                    | "success"
-                                    | "warning"
-                                }
-                                size="small"
-                              />
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Box display="flex" alignItems="center" gap={1}>
-                              {getStatusIcon(backup.status)}
-                              <Chip
-                                label={backup.status}
-                                color={
-                                  getStatusColor(backup.status) as
-                                    | "default"
-                                    | "primary"
-                                    | "secondary"
-                                    | "error"
-                                    | "info"
-                                    | "success"
-                                    | "warning"
-                                }
-                                size="small"
-                              />
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Typography variant="body2">
-                              {formatFileSize(backup.size)}
-                            </Typography>
-                          </TableCell>
-                          <TableCell>
-                            <Typography variant="body2">
-                              {formatDate(backup.createdAt)}
-                            </Typography>
-                          </TableCell>
-                          <TableCell>
-                            <Box display="flex" gap={1}>
-                              <Tooltip title="Restaurer">
-                                <IconButton
-                                  size="small"
-                                  onClick={() => handleRestoreBackup(backup)}
-                                  disabled={
-                                    processing || backup.status !== "completed"
-                                  }
-                                >
-                                  <RestoreIcon />
-                                </IconButton>
-                              </Tooltip>
-                              <Tooltip title="Télécharger">
-                                <IconButton
-                                  size="small"
-                                  onClick={() =>
-                                    handleDownloadBackup(backup.id)
-                                  }
-                                  disabled={
-                                    processing || backup.status !== "completed"
-                                  }
-                                >
-                                  <DownloadIcon />
-                                </IconButton>
-                              </Tooltip>
-                              <Tooltip title="Supprimer">
-                                <IconButton
-                                  size="small"
-                                  onClick={() => handleDeleteBackup(backup.id)}
-                                  disabled={processing}
-                                >
-                                  <DeleteIcon />
-                                </IconButton>
-                              </Tooltip>
-                            </Box>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              )}
-            </CardContent>
-          </Card>
+          <BackupsTableCard
+            backups={backups}
+            processing={processing}
+            onRestoreBackup={handleRestoreBackup}
+            onDownloadBackup={handleDownloadBackup}
+            onDeleteBackup={handleDeleteBackup}
+          />
         </Box>
 
         <Box sx={{ width: { xs: "100%", md: "33.33%" } }}>
@@ -651,202 +279,23 @@ BackupRestoreProps) {
         </Box>
       </Box>
 
-      {/* Dialog de création */}
-      <Dialog
+      <CreateBackupDialog
         open={createDialogOpen}
+        backup={newBackup}
+        processing={processing}
         onClose={() => setCreateDialogOpen(false)}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Créer une sauvegarde</DialogTitle>
-        <DialogContent>
-          <Box sx={{ pt: 2 }}>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <TextField
-                  fullWidth
-                  label="Nom de la sauvegarde"
-                  value={newBackup.name}
-                  onChange={(e) =>
-                    setNewBackup({
-                      ...newBackup,
-                      name: e.target.value,
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <FormControl fullWidth>
-                  <FormLabel>Type</FormLabel>
-                  <Select
-                    value={newBackup.type}
-                    onChange={(e) =>
-                      setNewBackup({
-                        ...newBackup,
-                        type: e.target.value as
-                          | "full"
-                          | "incremental"
-                          | "differential",
-                      })
-                    }
-                  >
-                    <MenuItem value="full">Complète</MenuItem>
-                    <MenuItem value="incremental">Incrémentale</MenuItem>
-                    <MenuItem value="differential">Différentielle</MenuItem>
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box sx={{ width: "100%" }}>
-                <TextField
-                  fullWidth
-                  label="Description"
-                  multiline
-                  rows={2}
-                  value={newBackup.description}
-                  onChange={(e) =>
-                    setNewBackup({
-                      ...newBackup,
-                      description: e.target.value,
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: "100%" }}>
-                <FormControl fullWidth>
-                  <FormLabel>Types de données</FormLabel>
-                  <Select
-                    multiple
-                    value={newBackup.dataTypes}
-                    onChange={(e) =>
-                      setNewBackup({
-                        ...newBackup,
-                        dataTypes: e.target.value as string[],
-                      })
-                    }
-                    renderValue={(selected) => (
-                      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                        {selected.map((value) => (
-                          <Chip
-                            key={value}
-                            label={
-                              dataTypes.find((dt) => dt.value === value)?.label
-                            }
-                            size="small"
-                          />
-                        ))}
-                      </Box>
-                    )}
-                  >
-                    {dataTypes.map((type) => (
-                      <MenuItem key={type.value} value={type.value}>
-                        {type.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={newBackup.compression}
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                        setNewBackup({
-                          ...newBackup,
-                          compression: e.target.checked,
-                        })
-                      }
-                    />
-                  }
-                  label="Compression"
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={newBackup.encryption}
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                        setNewBackup({
-                          ...newBackup,
-                          encryption: e.target.checked,
-                        })
-                      }
-                    />
-                  }
-                  label="Chiffrement"
-                />
-              </Box>
-              {newBackup.encryption && (
-                <Box sx={{ width: "100%" }}>
-                  <TextField
-                    fullWidth
-                    label="Mot de passe"
-                    type="password"
-                    value={newBackup.password || ""}
-                    onChange={(e) =>
-                      setNewBackup({
-                        ...newBackup,
-                        password: e.target.value,
-                      })
-                    }
-                  />
-                </Box>
-              )}
-            </Box>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setCreateDialogOpen(false)}>Annuler</Button>
-          <Button
-            onClick={handleCreateBackup}
-            variant="contained"
-            startIcon={<BackupIcon />}
-            disabled={processing || !newBackup.name}
-          >
-            {processing ? "Création..." : "Créer"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onBackupChange={setNewBackup}
+        onCreate={handleCreateBackup}
+      />
 
-      {/* Dialog d&apos;upload */}
-      <Dialog
+      <UploadBackupDialog
         open={uploadDialogOpen}
+        processing={processing}
+        selectedFile={selectedFile}
         onClose={() => setUploadDialogOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Importer une sauvegarde</DialogTitle>
-        <DialogContent>
-          <Box sx={{ pt: 2 }}>
-            <Alert severity="info" sx={{ mb: 2 }}>
-              Sélectionnez un fichier de sauvegarde à importer.
-            </Alert>
-            <TextField
-              fullWidth
-              type="file"
-              inputProps={{ accept: ".backup,.zip,.tar.gz" }}
-              onChange={(e) => {
-                const file = (e.target as HTMLInputElement).files?.[0];
-                if (file) {
-                  setSelectedFile(file);
-                }
-              }}
-            />
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setUploadDialogOpen(false)}>Annuler</Button>
-          <Button
-            onClick={handleUploadBackup}
-            variant="contained"
-            startIcon={<UploadIcon />}
-            disabled={processing || !selectedFile}
-          >
-            {processing ? "Import..." : "Importer"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onSelectFile={setSelectedFile}
+        onUpload={handleUploadBackup}
+      />
     </Box>
   );
 }

--- a/src/components/backup-restore/BackupsTableCard.tsx
+++ b/src/components/backup-restore/BackupsTableCard.tsx
@@ -1,0 +1,152 @@
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Delete as DeleteIcon,
+  Download as DownloadIcon,
+  Restore as RestoreIcon,
+} from "@mui/icons-material";
+import type { Backup } from "./types";
+import {
+  formatBackupDate,
+  formatFileSize,
+  getBackupStatusColor,
+  getBackupStatusIcon,
+  getBackupTypeColor,
+  getBackupTypeIcon,
+} from "./utils";
+
+interface BackupsTableCardProps {
+  backups: Backup[];
+  processing: boolean;
+  onRestoreBackup: (backup: Backup) => void;
+  onDownloadBackup: (backupId: string) => void;
+  onDeleteBackup: (backupId: string) => void;
+}
+
+export function BackupsTableCard({
+  backups,
+  processing,
+  onRestoreBackup,
+  onDownloadBackup,
+  onDeleteBackup,
+}: BackupsTableCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Sauvegardes disponibles
+        </Typography>
+        {backups.length === 0 ? (
+          <Alert severity="info">Aucune sauvegarde disponible</Alert>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Nom</TableCell>
+                  <TableCell>Type</TableCell>
+                  <TableCell>Statut</TableCell>
+                  <TableCell>Taille</TableCell>
+                  <TableCell>Date</TableCell>
+                  <TableCell>Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {backups.map((backup) => (
+                  <TableRow key={backup.id} hover>
+                    <TableCell>
+                      <Box>
+                        <Typography variant="body2" fontWeight="medium">
+                          {backup.name}
+                        </Typography>
+                        {backup.description && (
+                          <Typography variant="caption" color="text.secondary">
+                            {backup.description}
+                          </Typography>
+                        )}
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Box display="flex" alignItems="center" gap={1}>
+                        {getBackupTypeIcon(backup.type)}
+                        <Chip
+                          label={backup.type}
+                          color={getBackupTypeColor(backup.type)}
+                          size="small"
+                        />
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Box display="flex" alignItems="center" gap={1}>
+                        {getBackupStatusIcon(backup.status)}
+                        <Chip
+                          label={backup.status}
+                          color={getBackupStatusColor(backup.status)}
+                          size="small"
+                        />
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2">{formatFileSize(backup.size)}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2">
+                        {formatBackupDate(backup.createdAt)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Box display="flex" gap={1}>
+                        <Tooltip title="Restaurer">
+                          <IconButton
+                            size="small"
+                            onClick={() => onRestoreBackup(backup)}
+                            disabled={processing || backup.status !== "completed"}
+                          >
+                            <RestoreIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Télécharger">
+                          <IconButton
+                            size="small"
+                            onClick={() => onDownloadBackup(backup.id)}
+                            disabled={processing || backup.status !== "completed"}
+                          >
+                            <DownloadIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Supprimer">
+                          <IconButton
+                            size="small"
+                            onClick={() => onDeleteBackup(backup.id)}
+                            disabled={processing}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/backup-restore/CreateBackupDialog.tsx
+++ b/src/components/backup-restore/CreateBackupDialog.tsx
@@ -1,0 +1,191 @@
+import {
+  Backup as BackupIcon,
+} from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  MenuItem,
+  Select,
+  Switch,
+  TextField,
+} from "@mui/material";
+import { BACKUP_DATA_TYPES } from "./constants";
+import type { BackupOptions } from "./types";
+
+interface CreateBackupDialogProps {
+  open: boolean;
+  backup: BackupOptions;
+  processing: boolean;
+  onClose: () => void;
+  onBackupChange: (backup: BackupOptions) => void;
+  onCreate: () => void;
+}
+
+export function CreateBackupDialog({
+  open,
+  backup,
+  processing,
+  onClose,
+  onBackupChange,
+  onCreate,
+}: CreateBackupDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Créer une sauvegarde</DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 2 }}>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <TextField
+                fullWidth
+                label="Nom de la sauvegarde"
+                value={backup.name}
+                onChange={(event) =>
+                  onBackupChange({
+                    ...backup,
+                    name: event.target.value,
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <FormControl fullWidth>
+                <FormLabel>Type</FormLabel>
+                <Select
+                  value={backup.type}
+                  onChange={(event) =>
+                    onBackupChange({
+                      ...backup,
+                      type: event.target.value as BackupOptions["type"],
+                    })
+                  }
+                >
+                  <MenuItem value="full">Complète</MenuItem>
+                  <MenuItem value="incremental">Incrémentale</MenuItem>
+                  <MenuItem value="differential">Différentielle</MenuItem>
+                </Select>
+              </FormControl>
+            </Box>
+            <Box sx={{ width: "100%" }}>
+              <TextField
+                fullWidth
+                label="Description"
+                multiline
+                rows={2}
+                value={backup.description}
+                onChange={(event) =>
+                  onBackupChange({
+                    ...backup,
+                    description: event.target.value,
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: "100%" }}>
+              <FormControl fullWidth>
+                <FormLabel>Types de données</FormLabel>
+                <Select
+                  multiple
+                  value={backup.dataTypes}
+                  onChange={(event) =>
+                    onBackupChange({
+                      ...backup,
+                      dataTypes: event.target.value as string[],
+                    })
+                  }
+                  renderValue={(selected) => (
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                      {selected.map((value) => (
+                        <Chip
+                          key={value}
+                          label={
+                            BACKUP_DATA_TYPES.find((dataType) => dataType.value === value)
+                              ?.label ?? value
+                          }
+                          size="small"
+                        />
+                      ))}
+                    </Box>
+                  )}
+                >
+                  {BACKUP_DATA_TYPES.map((dataType) => (
+                    <MenuItem key={dataType.value} value={dataType.value}>
+                      {dataType.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={backup.compression}
+                    onChange={(event) =>
+                      onBackupChange({
+                        ...backup,
+                        compression: event.target.checked,
+                      })
+                    }
+                  />
+                }
+                label="Compression"
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={backup.encryption}
+                    onChange={(event) =>
+                      onBackupChange({
+                        ...backup,
+                        encryption: event.target.checked,
+                      })
+                    }
+                  />
+                }
+                label="Chiffrement"
+              />
+            </Box>
+            {backup.encryption && (
+              <Box sx={{ width: "100%" }}>
+                <TextField
+                  fullWidth
+                  label="Mot de passe"
+                  type="password"
+                  value={backup.password ?? ""}
+                  onChange={(event) =>
+                    onBackupChange({
+                      ...backup,
+                      password: event.target.value,
+                    })
+                  }
+                />
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Annuler</Button>
+        <Button
+          onClick={onCreate}
+          variant="contained"
+          startIcon={<BackupIcon />}
+          disabled={processing || !backup.name}
+        >
+          {processing ? "Création..." : "Créer"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/backup-restore/UploadBackupDialog.tsx
+++ b/src/components/backup-restore/UploadBackupDialog.tsx
@@ -1,0 +1,62 @@
+import { Upload as UploadIcon } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from "@mui/material";
+
+interface UploadBackupDialogProps {
+  open: boolean;
+  processing: boolean;
+  selectedFile: File | null;
+  onClose: () => void;
+  onSelectFile: (file: File | null) => void;
+  onUpload: () => void;
+}
+
+export function UploadBackupDialog({
+  open,
+  processing,
+  selectedFile,
+  onClose,
+  onSelectFile,
+  onUpload,
+}: UploadBackupDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Importer une sauvegarde</DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 2 }}>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Sélectionnez un fichier de sauvegarde à importer.
+          </Alert>
+          <TextField
+            fullWidth
+            type="file"
+            inputProps={{ accept: ".backup,.zip,.tar.gz" }}
+            onChange={(event) => {
+              const file = (event.target as HTMLInputElement).files?.[0] ?? null;
+              onSelectFile(file);
+            }}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Annuler</Button>
+        <Button
+          onClick={onUpload}
+          variant="contained"
+          startIcon={<UploadIcon />}
+          disabled={processing || !selectedFile}
+        >
+          {processing ? "Import..." : "Importer"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/backup-restore/constants.ts
+++ b/src/components/backup-restore/constants.ts
@@ -1,0 +1,22 @@
+import type { BackupOptions } from "./types";
+
+export const BACKUP_DATA_TYPES = [
+  { value: "players", label: "Joueurs" },
+  { value: "teams", label: "Équipes" },
+  { value: "matches", label: "Matchs" },
+  { value: "championships", label: "Championnats" },
+  { value: "availabilities", label: "Disponibilités" },
+  { value: "compositions", label: "Compositions" },
+  { value: "users", label: "Utilisateurs" },
+  { value: "settings", label: "Paramètres" },
+  { value: "audit_logs", label: "Logs d&apos;audit" },
+] as const;
+
+export const DEFAULT_BACKUP_OPTIONS: BackupOptions = {
+  name: "",
+  type: "full",
+  description: "",
+  dataTypes: ["players", "teams", "matches"],
+  compression: true,
+  encryption: false,
+};

--- a/src/components/backup-restore/types.ts
+++ b/src/components/backup-restore/types.ts
@@ -1,0 +1,100 @@
+export interface Backup {
+  id: string;
+  name: string;
+  type: "full" | "incremental" | "differential";
+  status: "completed" | "failed" | "in_progress" | "scheduled";
+  size: number;
+  createdAt: string;
+  createdBy: string;
+  description?: string;
+  metadata: {
+    version: string;
+    environment: string;
+    dataTypes: string[];
+    compression: boolean;
+    encryption: boolean;
+  };
+  scheduleId?: string;
+  parentBackupId?: string;
+  checksum: string;
+  location: string;
+  retention: {
+    expiresAt?: string;
+    autoDelete: boolean;
+  };
+}
+
+export interface BackupOptions {
+  name: string;
+  type: "full" | "incremental" | "differential";
+  description?: string;
+  dataTypes: string[];
+  compression: boolean;
+  encryption: boolean;
+  password?: string;
+  scheduleId?: string;
+  parentBackupId?: string;
+}
+
+export interface BackupSchedule {
+  id: string;
+  name: string;
+  type: "full" | "incremental" | "differential";
+  frequency: "daily" | "weekly" | "monthly";
+  time: string;
+  days: number[];
+  enabled: boolean;
+  retention: number;
+  dataTypes: string[];
+  compression: boolean;
+  encryption: boolean;
+}
+
+export interface BackupSettings {
+  storage: {
+    type: "local" | "s3" | "azure" | "gcp";
+    path: string;
+    credentials: {
+      [key: string]: string;
+    };
+  };
+  compression: {
+    enabled: boolean;
+    algorithm: "gzip" | "bzip2" | "lz4";
+    level: number;
+  };
+  encryption: {
+    enabled: boolean;
+    algorithm: "aes256" | "aes128";
+    keyRotation: number;
+  };
+  retention: {
+    maxBackups: number;
+    maxAge: number;
+    autoDelete: boolean;
+  };
+  scheduling: {
+    enabled: boolean;
+    timezone: string;
+    maxConcurrent: number;
+  };
+  notifications: {
+    enabled: boolean;
+    onSuccess: boolean;
+    onFailure: boolean;
+    onCompletion: boolean;
+  };
+}
+
+export interface BackupRestoreProps {
+  backups: Backup[];
+  onCreateBackup: (options: BackupOptions) => Promise<void>;
+  onRestoreBackup: (backupId: string) => Promise<void>;
+  onDeleteBackup: (backupId: string) => Promise<void>;
+  onDownloadBackup: (backupId: string) => Promise<void>;
+  onUploadBackup: (file: File) => Promise<void>;
+  onScheduleBackup: (schedule: BackupSchedule) => Promise<void>;
+  onGetBackupSettings: () => Promise<BackupSettings>;
+  onUpdateBackupSettings: (settings: BackupSettings) => Promise<void>;
+  loading?: boolean;
+}

--- a/src/components/backup-restore/utils.tsx
+++ b/src/components/backup-restore/utils.tsx
@@ -1,0 +1,89 @@
+import {
+  Backup as BackupIcon,
+  CheckCircle as CheckCircleIcon,
+  Error as ErrorIcon,
+  Info as InfoIcon,
+  Schedule as ScheduleIcon,
+} from "@mui/icons-material";
+import { CircularProgress } from "@mui/material";
+
+type MuiColor =
+  | "default"
+  | "primary"
+  | "secondary"
+  | "error"
+  | "info"
+  | "success"
+  | "warning";
+
+export function getBackupTypeIcon(type: string) {
+  switch (type) {
+    case "full":
+      return <BackupIcon color="primary" />;
+    case "incremental":
+      return <BackupIcon color="secondary" />;
+    case "differential":
+      return <BackupIcon color="info" />;
+    default:
+      return <BackupIcon color="inherit" />;
+  }
+}
+
+export function getBackupTypeColor(type: string): MuiColor {
+  switch (type) {
+    case "full":
+      return "primary";
+    case "incremental":
+      return "secondary";
+    case "differential":
+      return "info";
+    default:
+      return "default";
+  }
+}
+
+export function getBackupStatusIcon(status: string) {
+  switch (status) {
+    case "completed":
+      return <CheckCircleIcon color="success" />;
+    case "failed":
+      return <ErrorIcon color="error" />;
+    case "in_progress":
+      return <CircularProgress size={20} />;
+    case "scheduled":
+      return <ScheduleIcon color="info" />;
+    default:
+      return <InfoIcon color="inherit" />;
+  }
+}
+
+export function getBackupStatusColor(status: string): MuiColor {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+      return "error";
+    case "in_progress":
+      return "info";
+    case "scheduled":
+      return "info";
+    default:
+      return "default";
+  }
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) {
+    return "0 Bytes";
+  }
+
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const sizeIndex = Math.floor(Math.log(bytes) / Math.log(k));
+  const value = bytes / Math.pow(k, sizeIndex);
+  return `${value.toFixed(2)} ${sizes[sizeIndex]}`;
+}
+
+export function formatBackupDate(dateString: string): string {
+  return new Date(dateString).toLocaleString("fr-FR");
+}


### PR DESCRIPTION
## Summary
- extract `BackupRestore` domain types and defaults to `backup-restore/types.ts` and `backup-restore/constants.ts`
- move display helpers and status/type formatting to `backup-restore/utils.tsx`
- split UI into `BackupsTableCard`, `CreateBackupDialog`, and `UploadBackupDialog` while keeping existing behavior
- update audit plan progression for Epic G lot 2

## Test plan
- [x] `npm run check:dev`
- [x] `npm run check`

Made with [Cursor](https://cursor.com)