### PR TITLE
refactor(users): split UserManagement into focused modules

### DIFF
--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -182,7 +182,7 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 - [ ] **G.1.9** `AppSettings`
 - [ ] **G.1.10** `SystemMaintenance`
 - [~] **G.1.11** Autres fichiers > ~500 lignes restants (grep `wc -l`)  
-  _Avancement :_ `GlobalStats` puis `BackupRestore` découpés en sous-composants dédiés (`components/global-stats/*`, `components/backup-restore/*`) ; les composants racine deviennent des orchestrateurs.
+  _Avancement :_ `GlobalStats`, `BackupRestore` et `UserManagement` découpés en sous-composants dédiés (`components/global-stats/*`, `components/backup-restore/*`, `components/user-management/*`) ; les composants racine deviennent des orchestrateurs.
 
 **Critère :** Fichier principal < ~400 lignes **ou** justification inline (composant purement présentationnel sans logique).
 
@@ -258,3 +258,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 | 2026-05-09 | — | Epic F — F.1/F.2 : retrait `force-dynamic` / `runtime` du layout racine ; `LoginContent`, `ResetPasswordContent`, `VerifyEmailContent` + Suspense sur les pages correspondantes ; build statique OK pour les segments concernés |
 | 2026-05-09 | — | Epic G (lot 1) : `GlobalStats` découpé en sous-composants (`global-stats/*`) sans changement fonctionnel |
 | 2026-05-09 | — | Epic G (lot 2) : `BackupRestore` découpé en modules (`backup-restore/*`) pour isoler table, dialogs, types et utilitaires |
+| 2026-05-09 | — | Epic G (lot 3) : `UserManagement` découpé en modules (`user-management/*`) pour isoler table utilisateurs, formulaires, permissions, constantes et types |

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -1,162 +1,13 @@
 "use client";
 
-import React, { useState } from "react";
-import {
-  Card,
-  CardContent,
-  Typography,
-  Box,
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  FormControl,
-  FormLabel,
-  Select,
-  MenuItem,
-  Alert,
-  // List,
-  // ListItem,
-  // ListItemText,
-  // ListItemSecondaryAction,
-  IconButton,
-  Chip,
-  // Divider,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-  Switch,
-  FormControlLabel,
-  FormGroup,
-  Checkbox,
-  Avatar,
-  // Badge,
-  CircularProgress,
-} from "@mui/material";
-import {
-  // Person as PersonIcon,
-  Add as AddIcon,
-  Edit as EditIcon,
-  Delete as DeleteIcon,
-  Refresh as RefreshIcon,
-  Lock as LockIcon,
-  LockOpen as LockOpenIcon,
-  AdminPanelSettings as AdminIcon,
-  // PersonAdd as PersonAddIcon,
-  Security as SecurityIcon,
-  // Settings as SettingsIcon,
-  Warning as WarningIcon,
-  CheckCircle as CheckCircleIcon,
-  Error as ErrorIcon,
-  Info as InfoIcon,
-} from "@mui/icons-material";
-
-interface UserManagementProps {
-  users: User[];
-  onCreateUser: (user: CreateUser) => Promise<void>;
-  onUpdateUser: (id: string, user: UpdateUser) => Promise<void>;
-  onDeleteUser: (id: string) => Promise<void>;
-  onToggleUserStatus: (id: string) => Promise<void>;
-  onResetPassword: (id: string) => Promise<void>;
-  onAssignRole: (id: string, role: string) => Promise<void>;
-  onGetUserPermissions: (id: string) => Promise<Permission[]>;
-  onUpdateUserPermissions: (id: string, permissions: string[]) => Promise<void>;
-  loading?: boolean;
-}
-
-interface User {
-  id: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-  role: string;
-  status: "active" | "inactive" | "suspended" | "pending";
-  lastLogin?: string;
-  createdAt: string;
-  updatedAt: string;
-  permissions: string[];
-  profile: {
-    avatar?: string;
-    phone?: string;
-    department?: string;
-    position?: string;
-  };
-  preferences: {
-    language: string;
-    timezone: string;
-    notifications: {
-      email: boolean;
-      sms: boolean;
-      push: boolean;
-    };
-  };
-  security: {
-    twoFactorEnabled: boolean;
-    passwordChangedAt: string;
-    failedLoginAttempts: number;
-    lockedUntil?: string;
-  };
-}
-
-interface CreateUser {
-  email: string;
-  firstName: string;
-  lastName: string;
-  role: string;
-  password: string;
-  permissions: string[];
-  profile: {
-    phone?: string;
-    department?: string;
-    position?: string;
-  };
-  preferences: {
-    language: string;
-    timezone: string;
-    notifications: {
-      email: boolean;
-      sms: boolean;
-      push: boolean;
-    };
-  };
-}
-
-interface UpdateUser {
-  firstName?: string;
-  lastName?: string;
-  role?: string;
-  permissions?: string[];
-  profile?: {
-    phone?: string;
-    department?: string;
-    position?: string;
-  };
-  preferences?: {
-    language?: string;
-    timezone?: string;
-    notifications?: {
-      email?: boolean;
-      sms?: boolean;
-      push?: boolean;
-    };
-  };
-}
-
-interface Permission {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  resource: string;
-  action: string;
-}
+import { useState } from "react";
+import { Add as AddIcon, Refresh as RefreshIcon } from "@mui/icons-material";
+import { Alert, Box, Button, Typography } from "@mui/material";
+import { DEFAULT_NEW_USER } from "@/components/user-management/constants";
+import { PermissionsDialog } from "@/components/user-management/PermissionsDialog";
+import type { Permission, User, UserManagementProps } from "@/components/user-management/types";
+import { UserFormDialog } from "@/components/user-management/UserFormDialog";
+import { UsersTableCard } from "@/components/user-management/UsersTableCard";
 
 export function UserManagement({
   users,
@@ -172,56 +23,11 @@ export function UserManagement({
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [permissionsDialogOpen, setPermissionsDialogOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
-  const [newUser, setNewUser] = useState<CreateUser>({
-    email: "",
-    firstName: "",
-    lastName: "",
-    role: "user",
-    password: "",
-    permissions: [],
-    profile: {},
-    preferences: {
-      language: "fr",
-      timezone: "Europe/Paris",
-      notifications: {
-        email: true,
-        sms: false,
-        push: true,
-      },
-    },
-  });
+  const [newUser, setNewUser] = useState(DEFAULT_NEW_USER);
   const [userPermissions, setUserPermissions] = useState<Permission[]>([]);
   const [selectedPermissions, setSelectedPermissions] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
-
-  const roles = [
-    { value: "admin", label: "Administrateur", color: "error" },
-    { value: "manager", label: "Gestionnaire", color: "warning" },
-    { value: "user", label: "Utilisateur", color: "primary" },
-    { value: "viewer", label: "Observateur", color: "default" },
-  ];
-
-  const statuses = [
-    { value: "active", label: "Actif", color: "success" },
-    { value: "inactive", label: "Inactif", color: "default" },
-    { value: "suspended", label: "Suspendu", color: "error" },
-    { value: "pending", label: "En attente", color: "warning" },
-  ];
-
-  const languages = [
-    { value: "fr", label: "Français" },
-    { value: "en", label: "English" },
-    { value: "es", label: "Español" },
-    { value: "de", label: "Deutsch" },
-  ];
-
-  const timezones = [
-    { value: "Europe/Paris", label: "Europe/Paris" },
-    { value: "Europe/London", label: "Europe/London" },
-    { value: "America/New_York", label: "America/New_York" },
-    { value: "Asia/Tokyo", label: "Asia/Tokyo" },
-  ];
 
   const handleCreateUser = async () => {
     try {
@@ -229,24 +35,7 @@ export function UserManagement({
       setError(null);
       await onCreateUser(newUser);
       setCreateDialogOpen(false);
-      setNewUser({
-        email: "",
-        firstName: "",
-        lastName: "",
-        role: "user",
-        password: "",
-        permissions: [],
-        profile: {},
-        preferences: {
-          language: "fr",
-          timezone: "Europe/Paris",
-          notifications: {
-            email: true,
-            sms: false,
-            push: true,
-          },
-        },
-      });
+      setNewUser(DEFAULT_NEW_USER);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Erreur lors de la création"
@@ -346,42 +135,31 @@ export function UserManagement({
     }
   };
 
-  const getRoleColor = (role: string) => {
-    const roleObj = roles.find((r) => r.value === role);
-    return roleObj ? roleObj.color : "default";
+  const handleOpenCreateDialog = () => {
+    setSelectedUser(null);
+    setNewUser(DEFAULT_NEW_USER);
+    setCreateDialogOpen(true);
   };
 
-  const getStatusColor = (status: string) => {
-    const statusObj = statuses.find((s) => s.value === status);
-    return statusObj ? statusObj.color : "default";
+  const handleOpenEditDialog = (user: User) => {
+    setSelectedUser(user);
+    setNewUser({
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      role: user.role,
+      password: "",
+      permissions: user.permissions,
+      profile: user.profile,
+      preferences: user.preferences,
+    });
+    setEditDialogOpen(true);
   };
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "active":
-        return <CheckCircleIcon color="success" />;
-      case "inactive":
-        return <InfoIcon color="inherit" />;
-      case "suspended":
-        return <ErrorIcon color="error" />;
-      case "pending":
-        return <WarningIcon color="warning" />;
-      default:
-        return <InfoIcon color="inherit" />;
-    }
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString("fr-FR");
-  };
-
-  const isUserLocked = (user: User) => {
-    if (!user.security.lockedUntil) return false;
-    return new Date(user.security.lockedUntil) > new Date();
-  };
-
-  const getInitials = (firstName: string, lastName: string) => {
-    return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+  const handleCloseUserFormDialog = () => {
+    setCreateDialogOpen(false);
+    setEditDialogOpen(false);
+    setSelectedUser(null);
   };
 
   return (
@@ -404,7 +182,7 @@ export function UserManagement({
           <Button
             variant="contained"
             startIcon={<AddIcon />}
-            onClick={() => setCreateDialogOpen(true)}
+            onClick={handleOpenCreateDialog}
           >
             Nouvel utilisateur
           </Button>
@@ -417,525 +195,36 @@ export function UserManagement({
         </Alert>
       )}
 
-      <Card>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Utilisateurs ({users.length})
-          </Typography>
-          {loading ? (
-            <Box
-              display="flex"
-              justifyContent="center"
-              alignItems="center"
-              minHeight="200px"
-            >
-              <CircularProgress />
-            </Box>
-          ) : users.length === 0 ? (
-            <Alert severity="info">Aucun utilisateur trouvé</Alert>
-          ) : (
-            <TableContainer component={Paper} variant="outlined">
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Utilisateur</TableCell>
-                    <TableCell>Rôle</TableCell>
-                    <TableCell>Statut</TableCell>
-                    <TableCell>Dernière connexion</TableCell>
-                    <TableCell>Sécurité</TableCell>
-                    <TableCell>Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {users.map((user) => (
-                    <TableRow key={user.id} hover>
-                      <TableCell>
-                        <Box display="flex" alignItems="center" gap={2}>
-                          <Avatar
-                            {...(user.profile.avatar && {
-                              src: user.profile.avatar,
-                            })}
-                            sx={{ width: 32, height: 32 }}
-                          >
-                            {getInitials(user.firstName, user.lastName)}
-                          </Avatar>
-                          <Box>
-                            <Typography variant="body2" fontWeight="medium">
-                              {user.firstName} {user.lastName}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                            >
-                              {user.email}
-                            </Typography>
-                          </Box>
-                        </Box>
-                      </TableCell>
-                      <TableCell>
-                        <Chip
-                          label={
-                            roles.find((r) => r.value === user.role)?.label
-                          }
-                          color={
-                            getRoleColor(user.role) as
-                              | "default"
-                              | "primary"
-                              | "secondary"
-                              | "error"
-                              | "info"
-                              | "success"
-                              | "warning"
-                          }
-                          size="small"
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <Box display="flex" alignItems="center" gap={1}>
-                          {getStatusIcon(user.status)}
-                          <Chip
-                            label={
-                              statuses.find((s) => s.value === user.status)
-                                ?.label
-                            }
-                            color={
-                              getStatusColor(user.status) as
-                                | "default"
-                                | "primary"
-                                | "secondary"
-                                | "error"
-                                | "info"
-                                | "success"
-                                | "warning"
-                            }
-                            size="small"
-                          />
-                        </Box>
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="body2">
-                          {user.lastLogin
-                            ? formatDate(user.lastLogin)
-                            : "Jamais"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Box display="flex" alignItems="center" gap={1}>
-                          {user.security.twoFactorEnabled && (
-                            <Tooltip title="Authentification à deux facteurs activée">
-                              <SecurityIcon color="success" fontSize="small" />
-                            </Tooltip>
-                          )}
-                          {isUserLocked(user) && (
-                            <Tooltip title="Compte verrouillé">
-                              <LockIcon color="error" fontSize="small" />
-                            </Tooltip>
-                          )}
-                          {user.security.failedLoginAttempts > 0 && (
-                            <Tooltip
-                              title={`${user.security.failedLoginAttempts} tentatives échouées`}
-                            >
-                              <WarningIcon color="warning" fontSize="small" />
-                            </Tooltip>
-                          )}
-                        </Box>
-                      </TableCell>
-                      <TableCell>
-                        <Box display="flex" gap={1}>
-                          <Tooltip title="Modifier">
-                            <IconButton
-                              size="small"
-                              onClick={() => {
-                                setSelectedUser(user);
-                                setNewUser({
-                                  email: user.email,
-                                  firstName: user.firstName,
-                                  lastName: user.lastName,
-                                  role: user.role,
-                                  password: "",
-                                  permissions: user.permissions,
-                                  profile: user.profile,
-                                  preferences: user.preferences,
-                                });
-                                setEditDialogOpen(true);
-                              }}
-                            >
-                              <EditIcon />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title="Permissions">
-                            <IconButton
-                              size="small"
-                              onClick={() => handleViewPermissions(user)}
-                            >
-                              <AdminIcon />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title="Réinitialiser le mot de passe">
-                            <IconButton
-                              size="small"
-                              onClick={() => handleResetPassword(user.id)}
-                            >
-                              <LockOpenIcon />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title="Supprimer">
-                            <IconButton
-                              size="small"
-                              onClick={() => handleDeleteUser(user.id)}
-                            >
-                              <DeleteIcon />
-                            </IconButton>
-                          </Tooltip>
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </CardContent>
-      </Card>
+      <UsersTableCard
+        users={users}
+        loading={loading}
+        onEditUser={handleOpenEditDialog}
+        onViewPermissions={handleViewPermissions}
+        onResetPassword={handleResetPassword}
+        onDeleteUser={handleDeleteUser}
+      />
 
-      {/* Dialog de création/modification */}
-      <Dialog
-        open={createDialogOpen || editDialogOpen}
-        onClose={() => {
-          setCreateDialogOpen(false);
-          setEditDialogOpen(false);
-          setSelectedUser(null);
-        }}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>
-          {createDialogOpen ? "Créer un utilisateur" : "Modifier l&apos;utilisateur"}
-        </DialogTitle>
-        <DialogContent>
-          <Box sx={{ pt: 2 }}>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <TextField
-                  fullWidth
-                  label="Prénom"
-                  value={newUser.firstName}
-                  onChange={(e) =>
-                    setNewUser({
-                      ...newUser,
-                      firstName: e.target.value,
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <TextField
-                  fullWidth
-                  label="Nom"
-                  value={newUser.lastName}
-                  onChange={(e) =>
-                    setNewUser({
-                      ...newUser,
-                      lastName: e.target.value,
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <TextField
-                  fullWidth
-                  label="Email"
-                  type="email"
-                  value={newUser.email}
-                  onChange={(e) =>
-                    setNewUser({
-                      ...newUser,
-                      email: e.target.value,
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <FormControl fullWidth>
-                  <FormLabel>Rôle</FormLabel>
-                  <Select
-                    value={newUser.role}
-                    onChange={(e) =>
-                      setNewUser({
-                        ...newUser,
-                        role: e.target.value,
-                      })
-                    }
-                  >
-                    {roles.map((role) => (
-                      <MenuItem key={role.value} value={role.value}>
-                        {role.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-              {createDialogOpen && (
-                <Box sx={{ width: "100%" }}>
-                  <TextField
-                    fullWidth
-                    label="Mot de passe"
-                    type="password"
-                    value={newUser.password}
-                    onChange={(e) =>
-                      setNewUser({
-                        ...newUser,
-                        password: e.target.value,
-                      })
-                    }
-                  />
-                </Box>
-              )}
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <TextField
-                  fullWidth
-                  label="Téléphone"
-                  value={newUser.profile.phone || ""}
-                  onChange={(e) =>
-                    setNewUser({
-                      ...newUser,
-                      profile: {
-                        ...newUser.profile,
-                        phone: e.target.value,
-                      },
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <TextField
-                  fullWidth
-                  label="Département"
-                  value={newUser.profile.department || ""}
-                  onChange={(e) =>
-                    setNewUser({
-                      ...newUser,
-                      profile: {
-                        ...newUser.profile,
-                        department: e.target.value,
-                      },
-                    })
-                  }
-                />
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <FormControl fullWidth>
-                  <FormLabel>Langue</FormLabel>
-                  <Select
-                    value={newUser.preferences.language}
-                    onChange={(e) =>
-                      setNewUser({
-                        ...newUser,
-                        preferences: {
-                          ...newUser.preferences,
-                          language: e.target.value,
-                        },
-                      })
-                    }
-                  >
-                    {languages.map((lang) => (
-                      <MenuItem key={lang.value} value={lang.value}>
-                        {lang.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
-                <FormControl fullWidth>
-                  <FormLabel>Fuseau horaire</FormLabel>
-                  <Select
-                    value={newUser.preferences.timezone}
-                    onChange={(e) =>
-                      setNewUser({
-                        ...newUser,
-                        preferences: {
-                          ...newUser.preferences,
-                          timezone: e.target.value,
-                        },
-                      })
-                    }
-                  >
-                    {timezones.map((tz) => (
-                      <MenuItem key={tz.value} value={tz.value}>
-                        {tz.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box sx={{ width: "100%" }}>
-                <Typography variant="subtitle2" gutterBottom>
-                  Notifications
-                </Typography>
-                <FormGroup row>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={newUser.preferences.notifications.email}
-                        onChange={(e) =>
-                          setNewUser({
-                            ...newUser,
-                            preferences: {
-                              ...newUser.preferences,
-                              notifications: {
-                                ...newUser.preferences.notifications,
-                                email: e.target.checked,
-                              },
-                            },
-                          })
-                        }
-                      />
-                    }
-                    label="Email"
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={newUser.preferences.notifications.sms}
-                        onChange={(e) =>
-                          setNewUser({
-                            ...newUser,
-                            preferences: {
-                              ...newUser.preferences,
-                              notifications: {
-                                ...newUser.preferences.notifications,
-                                sms: e.target.checked,
-                              },
-                            },
-                          })
-                        }
-                      />
-                    }
-                    label="SMS"
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={newUser.preferences.notifications.push}
-                        onChange={(e) =>
-                          setNewUser({
-                            ...newUser,
-                            preferences: {
-                              ...newUser.preferences,
-                              notifications: {
-                                ...newUser.preferences.notifications,
-                                push: e.target.checked,
-                              },
-                            },
-                          })
-                        }
-                      />
-                    }
-                    label="Push"
-                  />
-                </FormGroup>
-              </Box>
-            </Box>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setCreateDialogOpen(false);
-              setEditDialogOpen(false);
-              setSelectedUser(null);
-            }}
-          >
-            Annuler
-          </Button>
-          <Button
-            onClick={createDialogOpen ? handleCreateUser : handleUpdateUser}
-            variant="contained"
-            startIcon={createDialogOpen ? <AddIcon /> : <EditIcon />}
-            disabled={
-              processing ||
-              !newUser.firstName ||
-              !newUser.lastName ||
-              !newUser.email
-            }
-          >
-            {processing
-              ? "Traitement..."
-              : createDialogOpen
-              ? "Créer"
-              : "Modifier"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <UserFormDialog
+        createDialogOpen={createDialogOpen}
+        editDialogOpen={editDialogOpen}
+        processing={processing}
+        selectedUser={selectedUser}
+        newUser={newUser}
+        onClose={handleCloseUserFormDialog}
+        onNewUserChange={setNewUser}
+        onSubmit={createDialogOpen ? handleCreateUser : handleUpdateUser}
+      />
 
-      {/* Dialog des permissions */}
-      <Dialog
+      <PermissionsDialog
         open={permissionsDialogOpen}
+        processing={processing}
+        selectedUser={selectedUser}
+        permissions={userPermissions}
+        selectedPermissions={selectedPermissions}
         onClose={() => setPermissionsDialogOpen(false)}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>
-          Permissions de {selectedUser?.firstName} {selectedUser?.lastName}
-        </DialogTitle>
-        <DialogContent>
-          <Box sx={{ pt: 2 }}>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Sélectionnez les permissions à accorder à cet utilisateur.
-            </Typography>
-            <FormGroup>
-              {userPermissions.map((permission) => (
-                <FormControlLabel
-                  key={permission.id}
-                  control={
-                    <Checkbox
-                      checked={selectedPermissions.includes(permission.id)}
-                      onChange={(e) => {
-                        if (e.target.checked) {
-                          setSelectedPermissions([
-                            ...selectedPermissions,
-                            permission.id,
-                          ]);
-                        } else {
-                          setSelectedPermissions(
-                            selectedPermissions.filter(
-                              (p) => p !== permission.id
-                            )
-                          );
-                        }
-                      }}
-                    />
-                  }
-                  label={
-                    <Box>
-                      <Typography variant="body2" fontWeight="medium">
-                        {permission.name}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {permission.description}
-                      </Typography>
-                    </Box>
-                  }
-                />
-              ))}
-            </FormGroup>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setPermissionsDialogOpen(false)}>
-            Annuler
-          </Button>
-          <Button
-            onClick={handleUpdatePermissions}
-            variant="contained"
-            startIcon={<AdminIcon />}
-            disabled={processing}
-          >
-            {processing ? "Mise à jour..." : "Mettre à jour"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onSelectionChange={setSelectedPermissions}
+        onSubmit={handleUpdatePermissions}
+      />
     </Box>
   );
 }

--- a/src/components/user-management/PermissionsDialog.tsx
+++ b/src/components/user-management/PermissionsDialog.tsx
@@ -1,0 +1,93 @@
+import { AdminPanelSettings as AdminIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  Typography,
+} from "@mui/material";
+import type { Permission, User } from "./types";
+
+interface PermissionsDialogProps {
+  open: boolean;
+  processing: boolean;
+  selectedUser: User | null;
+  permissions: Permission[];
+  selectedPermissions: string[];
+  onClose: () => void;
+  onSelectionChange: (permissions: string[]) => void;
+  onSubmit: () => void;
+}
+
+export function PermissionsDialog({
+  open,
+  processing,
+  selectedUser,
+  permissions,
+  selectedPermissions,
+  onClose,
+  onSelectionChange,
+  onSubmit,
+}: PermissionsDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        Permissions de {selectedUser?.firstName} {selectedUser?.lastName}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 2 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Sélectionnez les permissions à accorder à cet utilisateur.
+          </Typography>
+          <FormGroup>
+            {permissions.map((permission) => (
+              <FormControlLabel
+                key={permission.id}
+                control={
+                  <Checkbox
+                    checked={selectedPermissions.includes(permission.id)}
+                    onChange={(event) => {
+                      if (event.target.checked) {
+                        onSelectionChange([...selectedPermissions, permission.id]);
+                      } else {
+                        onSelectionChange(
+                          selectedPermissions.filter((item) => item !== permission.id)
+                        );
+                      }
+                    }}
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography variant="body2" fontWeight="medium">
+                      {permission.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {permission.description}
+                    </Typography>
+                  </Box>
+                }
+              />
+            ))}
+          </FormGroup>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Annuler</Button>
+        <Button
+          onClick={onSubmit}
+          variant="contained"
+          startIcon={<AdminIcon />}
+          disabled={processing}
+        >
+          {processing ? "Mise à jour..." : "Mettre à jour"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/user-management/UserFormDialog.tsx
+++ b/src/components/user-management/UserFormDialog.tsx
@@ -1,0 +1,291 @@
+import { Add as AddIcon, Edit as EditIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
+  MenuItem,
+  Select,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { LANGUAGES, ROLES, TIMEZONES } from "./constants";
+import type { CreateUser, User } from "./types";
+
+interface UserFormDialogProps {
+  createDialogOpen: boolean;
+  editDialogOpen: boolean;
+  processing: boolean;
+  selectedUser: User | null;
+  newUser: CreateUser;
+  onClose: () => void;
+  onNewUserChange: (user: CreateUser) => void;
+  onSubmit: () => void;
+}
+
+export function UserFormDialog({
+  createDialogOpen,
+  editDialogOpen,
+  processing,
+  newUser,
+  onClose,
+  onNewUserChange,
+  onSubmit,
+}: UserFormDialogProps) {
+  const isCreateMode = createDialogOpen;
+
+  return (
+    <Dialog open={createDialogOpen || editDialogOpen} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        {isCreateMode ? "Créer un utilisateur" : "Modifier l&apos;utilisateur"}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 2 }}>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <TextField
+                fullWidth
+                label="Prénom"
+                value={newUser.firstName}
+                onChange={(event) =>
+                  onNewUserChange({
+                    ...newUser,
+                    firstName: event.target.value,
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <TextField
+                fullWidth
+                label="Nom"
+                value={newUser.lastName}
+                onChange={(event) =>
+                  onNewUserChange({
+                    ...newUser,
+                    lastName: event.target.value,
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <TextField
+                fullWidth
+                label="Email"
+                type="email"
+                value={newUser.email}
+                onChange={(event) =>
+                  onNewUserChange({
+                    ...newUser,
+                    email: event.target.value,
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <FormControl fullWidth>
+                <FormLabel>Rôle</FormLabel>
+                <Select
+                  value={newUser.role}
+                  onChange={(event) =>
+                    onNewUserChange({
+                      ...newUser,
+                      role: event.target.value,
+                    })
+                  }
+                >
+                  {ROLES.map((role) => (
+                    <MenuItem key={role.value} value={role.value}>
+                      {role.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+
+            {isCreateMode && (
+              <Box sx={{ width: "100%" }}>
+                <TextField
+                  fullWidth
+                  label="Mot de passe"
+                  type="password"
+                  value={newUser.password}
+                  onChange={(event) =>
+                    onNewUserChange({
+                      ...newUser,
+                      password: event.target.value,
+                    })
+                  }
+                />
+              </Box>
+            )}
+
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <TextField
+                fullWidth
+                label="Téléphone"
+                value={newUser.profile.phone ?? ""}
+                onChange={(event) =>
+                  onNewUserChange({
+                    ...newUser,
+                    profile: {
+                      ...newUser.profile,
+                      phone: event.target.value,
+                    },
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <TextField
+                fullWidth
+                label="Département"
+                value={newUser.profile.department ?? ""}
+                onChange={(event) =>
+                  onNewUserChange({
+                    ...newUser,
+                    profile: {
+                      ...newUser.profile,
+                      department: event.target.value,
+                    },
+                  })
+                }
+              />
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <FormControl fullWidth>
+                <FormLabel>Langue</FormLabel>
+                <Select
+                  value={newUser.preferences.language}
+                  onChange={(event) =>
+                    onNewUserChange({
+                      ...newUser,
+                      preferences: {
+                        ...newUser.preferences,
+                        language: event.target.value,
+                      },
+                    })
+                  }
+                >
+                  {LANGUAGES.map((language) => (
+                    <MenuItem key={language.value} value={language.value}>
+                      {language.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+            <Box sx={{ width: { xs: "100%", sm: "50%" } }}>
+              <FormControl fullWidth>
+                <FormLabel>Fuseau horaire</FormLabel>
+                <Select
+                  value={newUser.preferences.timezone}
+                  onChange={(event) =>
+                    onNewUserChange({
+                      ...newUser,
+                      preferences: {
+                        ...newUser.preferences,
+                        timezone: event.target.value,
+                      },
+                    })
+                  }
+                >
+                  {TIMEZONES.map((timezone) => (
+                    <MenuItem key={timezone.value} value={timezone.value}>
+                      {timezone.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+            <Box sx={{ width: "100%" }}>
+              <Typography variant="subtitle2" gutterBottom>
+                Notifications
+              </Typography>
+              <FormGroup row>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={newUser.preferences.notifications.email}
+                      onChange={(event) =>
+                        onNewUserChange({
+                          ...newUser,
+                          preferences: {
+                            ...newUser.preferences,
+                            notifications: {
+                              ...newUser.preferences.notifications,
+                              email: event.target.checked,
+                            },
+                          },
+                        })
+                      }
+                    />
+                  }
+                  label="Email"
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={newUser.preferences.notifications.sms}
+                      onChange={(event) =>
+                        onNewUserChange({
+                          ...newUser,
+                          preferences: {
+                            ...newUser.preferences,
+                            notifications: {
+                              ...newUser.preferences.notifications,
+                              sms: event.target.checked,
+                            },
+                          },
+                        })
+                      }
+                    />
+                  }
+                  label="SMS"
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={newUser.preferences.notifications.push}
+                      onChange={(event) =>
+                        onNewUserChange({
+                          ...newUser,
+                          preferences: {
+                            ...newUser.preferences,
+                            notifications: {
+                              ...newUser.preferences.notifications,
+                              push: event.target.checked,
+                            },
+                          },
+                        })
+                      }
+                    />
+                  }
+                  label="Push"
+                />
+              </FormGroup>
+            </Box>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Annuler</Button>
+        <Button
+          onClick={onSubmit}
+          variant="contained"
+          startIcon={isCreateMode ? <AddIcon /> : <EditIcon />}
+          disabled={processing || !newUser.firstName || !newUser.lastName || !newUser.email}
+        >
+          {processing ? "Traitement..." : isCreateMode ? "Créer" : "Modifier"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/user-management/UsersTableCard.tsx
+++ b/src/components/user-management/UsersTableCard.tsx
@@ -1,0 +1,180 @@
+import {
+  AdminPanelSettings as AdminIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  Lock as LockIcon,
+  LockOpen as LockOpenIcon,
+  Security as SecurityIcon,
+  Warning as WarningIcon,
+} from "@mui/icons-material";
+import {
+  Alert,
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { ROLES, STATUSES } from "./constants";
+import type { User } from "./types";
+import {
+  formatDate,
+  getInitials,
+  getRoleColor,
+  getStatusColor,
+  getStatusIcon,
+  isUserLocked,
+} from "./utils";
+
+interface UsersTableCardProps {
+  users: User[];
+  loading: boolean;
+  onEditUser: (user: User) => void;
+  onViewPermissions: (user: User) => void;
+  onResetPassword: (id: string) => void;
+  onDeleteUser: (id: string) => void;
+}
+
+export function UsersTableCard({
+  users,
+  loading,
+  onEditUser,
+  onViewPermissions,
+  onResetPassword,
+  onDeleteUser,
+}: UsersTableCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Utilisateurs ({users.length})
+        </Typography>
+        {loading ? (
+          <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+            <CircularProgress />
+          </Box>
+        ) : users.length === 0 ? (
+          <Alert severity="info">Aucun utilisateur trouvé</Alert>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Utilisateur</TableCell>
+                  <TableCell>Rôle</TableCell>
+                  <TableCell>Statut</TableCell>
+                  <TableCell>Dernière connexion</TableCell>
+                  <TableCell>Sécurité</TableCell>
+                  <TableCell>Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {users.map((user) => (
+                  <TableRow key={user.id} hover>
+                    <TableCell>
+                      <Box display="flex" alignItems="center" gap={2}>
+                        <Avatar
+                          {...(user.profile.avatar ? { src: user.profile.avatar } : {})}
+                          sx={{ width: 32, height: 32 }}
+                        >
+                          {getInitials(user.firstName, user.lastName)}
+                        </Avatar>
+                        <Box>
+                          <Typography variant="body2" fontWeight="medium">
+                            {user.firstName} {user.lastName}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {user.email}
+                          </Typography>
+                        </Box>
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={ROLES.find((role) => role.value === user.role)?.label ?? user.role}
+                        color={getRoleColor(user.role)}
+                        size="small"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Box display="flex" alignItems="center" gap={1}>
+                        {getStatusIcon(user.status)}
+                        <Chip
+                          label={
+                            STATUSES.find((status) => status.value === user.status)?.label ??
+                            user.status
+                          }
+                          color={getStatusColor(user.status)}
+                          size="small"
+                        />
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2">
+                        {user.lastLogin ? formatDate(user.lastLogin) : "Jamais"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Box display="flex" alignItems="center" gap={1}>
+                        {user.security.twoFactorEnabled && (
+                          <Tooltip title="Authentification à deux facteurs activée">
+                            <SecurityIcon color="success" fontSize="small" />
+                          </Tooltip>
+                        )}
+                        {isUserLocked(user.security.lockedUntil) && (
+                          <Tooltip title="Compte verrouillé">
+                            <LockIcon color="error" fontSize="small" />
+                          </Tooltip>
+                        )}
+                        {user.security.failedLoginAttempts > 0 && (
+                          <Tooltip title={`${user.security.failedLoginAttempts} tentatives échouées`}>
+                            <WarningIcon color="warning" fontSize="small" />
+                          </Tooltip>
+                        )}
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Box display="flex" gap={1}>
+                        <Tooltip title="Modifier">
+                          <IconButton size="small" onClick={() => onEditUser(user)}>
+                            <EditIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Permissions">
+                          <IconButton size="small" onClick={() => onViewPermissions(user)}>
+                            <AdminIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Réinitialiser le mot de passe">
+                          <IconButton size="small" onClick={() => onResetPassword(user.id)}>
+                            <LockOpenIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Supprimer">
+                          <IconButton size="small" onClick={() => onDeleteUser(user.id)}>
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/user-management/constants.ts
+++ b/src/components/user-management/constants.ts
@@ -1,0 +1,48 @@
+import type { CreateUser } from "./types";
+
+export const ROLES = [
+  { value: "admin", label: "Administrateur", color: "error" },
+  { value: "manager", label: "Gestionnaire", color: "warning" },
+  { value: "user", label: "Utilisateur", color: "primary" },
+  { value: "viewer", label: "Observateur", color: "default" },
+] as const;
+
+export const STATUSES = [
+  { value: "active", label: "Actif", color: "success" },
+  { value: "inactive", label: "Inactif", color: "default" },
+  { value: "suspended", label: "Suspendu", color: "error" },
+  { value: "pending", label: "En attente", color: "warning" },
+] as const;
+
+export const LANGUAGES = [
+  { value: "fr", label: "Français" },
+  { value: "en", label: "English" },
+  { value: "es", label: "Español" },
+  { value: "de", label: "Deutsch" },
+] as const;
+
+export const TIMEZONES = [
+  { value: "Europe/Paris", label: "Europe/Paris" },
+  { value: "Europe/London", label: "Europe/London" },
+  { value: "America/New_York", label: "America/New_York" },
+  { value: "Asia/Tokyo", label: "Asia/Tokyo" },
+] as const;
+
+export const DEFAULT_NEW_USER: CreateUser = {
+  email: "",
+  firstName: "",
+  lastName: "",
+  role: "user",
+  password: "",
+  permissions: [],
+  profile: {},
+  preferences: {
+    language: "fr",
+    timezone: "Europe/Paris",
+    notifications: {
+      email: true,
+      sms: false,
+      push: true,
+    },
+  },
+};

--- a/src/components/user-management/types.ts
+++ b/src/components/user-management/types.ts
@@ -1,0 +1,99 @@
+export interface UserManagementProps {
+  users: User[];
+  onCreateUser: (user: CreateUser) => Promise<void>;
+  onUpdateUser: (id: string, user: UpdateUser) => Promise<void>;
+  onDeleteUser: (id: string) => Promise<void>;
+  onToggleUserStatus: (id: string) => Promise<void>;
+  onResetPassword: (id: string) => Promise<void>;
+  onAssignRole: (id: string, role: string) => Promise<void>;
+  onGetUserPermissions: (id: string) => Promise<Permission[]>;
+  onUpdateUserPermissions: (id: string, permissions: string[]) => Promise<void>;
+  loading?: boolean;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  status: "active" | "inactive" | "suspended" | "pending";
+  lastLogin?: string;
+  createdAt: string;
+  updatedAt: string;
+  permissions: string[];
+  profile: {
+    avatar?: string;
+    phone?: string;
+    department?: string;
+    position?: string;
+  };
+  preferences: {
+    language: string;
+    timezone: string;
+    notifications: {
+      email: boolean;
+      sms: boolean;
+      push: boolean;
+    };
+  };
+  security: {
+    twoFactorEnabled: boolean;
+    passwordChangedAt: string;
+    failedLoginAttempts: number;
+    lockedUntil?: string;
+  };
+}
+
+export interface CreateUser {
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  password: string;
+  permissions: string[];
+  profile: {
+    phone?: string;
+    department?: string;
+    position?: string;
+  };
+  preferences: {
+    language: string;
+    timezone: string;
+    notifications: {
+      email: boolean;
+      sms: boolean;
+      push: boolean;
+    };
+  };
+}
+
+export interface UpdateUser {
+  firstName?: string;
+  lastName?: string;
+  role?: string;
+  permissions?: string[];
+  profile?: {
+    phone?: string;
+    department?: string;
+    position?: string;
+  };
+  preferences?: {
+    language?: string;
+    timezone?: string;
+    notifications?: {
+      email?: boolean;
+      sms?: boolean;
+      push?: boolean;
+    };
+  };
+}
+
+export interface Permission {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  resource: string;
+  action: string;
+}

--- a/src/components/user-management/utils.tsx
+++ b/src/components/user-management/utils.tsx
@@ -1,0 +1,56 @@
+import {
+  CheckCircle as CheckCircleIcon,
+  Error as ErrorIcon,
+  Info as InfoIcon,
+  Warning as WarningIcon,
+} from "@mui/icons-material";
+import { ROLES, STATUSES } from "./constants";
+
+type MuiColor =
+  | "default"
+  | "primary"
+  | "secondary"
+  | "error"
+  | "info"
+  | "success"
+  | "warning";
+
+export function getRoleColor(role: string): MuiColor {
+  const roleObj = ROLES.find((item) => item.value === role);
+  return (roleObj?.color as MuiColor | undefined) ?? "default";
+}
+
+export function getStatusColor(status: string): MuiColor {
+  const statusObj = STATUSES.find((item) => item.value === status);
+  return (statusObj?.color as MuiColor | undefined) ?? "default";
+}
+
+export function getStatusIcon(status: string) {
+  switch (status) {
+    case "active":
+      return <CheckCircleIcon color="success" />;
+    case "inactive":
+      return <InfoIcon color="inherit" />;
+    case "suspended":
+      return <ErrorIcon color="error" />;
+    case "pending":
+      return <WarningIcon color="warning" />;
+    default:
+      return <InfoIcon color="inherit" />;
+  }
+}
+
+export function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString("fr-FR");
+}
+
+export function isUserLocked(lockedUntil?: string): boolean {
+  if (!lockedUntil) {
+    return false;
+  }
+  return new Date(lockedUntil) > new Date();
+}
+
+export function getInitials(firstName: string, lastName: string): string {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}


### PR DESCRIPTION
## Summary
- split `UserManagement` into dedicated modules under `components/user-management/*`
- extract domain types and static options into `types.ts` and `constants.ts`
- isolate reusable display helpers in `utils.tsx`
- keep `UserManagement.tsx` focused on state orchestration and handlers
- update Epic G progress in the audit action plan

## Test plan
- [x] `npm run check:dev`
- [x] `npm run check`

Made with [Cursor](https://cursor.com)