### PR TITLE
refactor(settings): extract AppSettings domain models and UI helpers

### DIFF
--- a/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
+++ b/docs/technical/AUDIT_NEXTJS_REACT_ACTION_PLAN.md
@@ -182,7 +182,7 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 - [ ] **G.1.9** `AppSettings`
 - [ ] **G.1.10** `SystemMaintenance`
 - [~] **G.1.11** Autres fichiers > ~500 lignes restants (grep `wc -l`)  
-  _Avancement :_ `GlobalStats`, `BackupRestore`, `UserManagement`, `DataExportImport` et `AuditLogs` découpés en modules dédiés (`components/global-stats/*`, `components/backup-restore/*`, `components/user-management/*`, `components/data-export-import/*`, `components/audit-logs/*`) ; les composants racine deviennent des orchestrateurs.
+  _Avancement :_ `GlobalStats`, `BackupRestore`, `UserManagement`, `DataExportImport`, `AuditLogs` et `AppSettings` découpés en modules dédiés (`components/global-stats/*`, `components/backup-restore/*`, `components/user-management/*`, `components/data-export-import/*`, `components/audit-logs/*`, `components/app-settings/*`) ; les composants racine deviennent des orchestrateurs.
 
 **Critère :** Fichier principal < ~400 lignes **ou** justification inline (composant purement présentationnel sans logique).
 
@@ -261,3 +261,4 @@ Pour chaque fichier (traiter par ordre métier / douleur) :
 | 2026-05-09 | — | Epic G (lot 3) : `UserManagement` découpé en modules (`user-management/*`) pour isoler table utilisateurs, formulaires, permissions, constantes et types |
 | 2026-05-09 | — | Epic G (lot 4) : `DataExportImport` factorisé en types/constantes/utilitaires (`data-export-import/*`) avec composant principal recentré |
 | 2026-05-09 | — | Epic G (lot 5) : `AuditLogs` factorisé en types/constantes/utilitaires (`audit-logs/*`) avec composant principal simplifié |
+| 2026-05-09 | — | Epic G (lot 6) : `AppSettings` factorisé en types/constantes/utilitaires (`app-settings/*`) avec composants et actions simplifiés |

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Card,
   CardContent,
@@ -37,57 +37,14 @@ import {
   // Delete as DeleteIcon,
   // Add as AddIcon,
 } from "@mui/icons-material";
-
-interface AppSettingsProps {
-  settings: {
-    general: {
-      appName: string;
-      appVersion: string;
-      environment: "development" | "staging" | "production";
-      timezone: string;
-      language: string;
-      currency: string;
-      dateFormat: string;
-      timeFormat: "12h" | "24h";
-    };
-    features: {
-      enableNotifications: boolean;
-      enableAuditLog: boolean;
-      enableBackup: boolean;
-      enableMaintenance: boolean;
-      enableReports: boolean;
-      enableUserManagement: boolean;
-      enableThemeCustomization: boolean;
-    };
-    limits: {
-      maxUsers: number;
-      maxTeams: number;
-      maxPlayers: number;
-      maxMatches: number;
-      maxFileSize: number;
-      maxBackups: number;
-    };
-    security: {
-      sessionTimeout: number;
-      maxLoginAttempts: number;
-      passwordMinLength: number;
-      requireTwoFactor: boolean;
-      allowedOrigins: string[];
-      enableCORS: boolean;
-    };
-    performance: {
-      cacheEnabled: boolean;
-      cacheTtl: number;
-      maxConcurrentRequests: number;
-      requestTimeout: number;
-      enableCompression: boolean;
-      enableGzip: boolean;
-    };
-  };
-  onSaveSettings: (settings: Record<string, unknown>) => Promise<void>;
-  onResetSettings: () => Promise<void>;
-  onTestConnection: (type: string) => Promise<void>;
-}
+import { CONNECTION_TESTS, FEATURE_CONFIG } from "@/components/app-settings/constants";
+import type { AppSettingsProps } from "@/components/app-settings/types";
+import {
+  getEnvironmentColor,
+  getEnvironmentLabel,
+  getFeatureColor,
+  getFeatureStatus,
+} from "@/components/app-settings/utils";
 
 export function AppSettings({
   settings,
@@ -145,40 +102,6 @@ export function AppSettings({
   const handleCancel = () => {
     setEditDialogOpen(false);
     setEditingSettings(settings);
-  };
-
-  const getEnvironmentColor = (env: string) => {
-    switch (env) {
-      case "development":
-        return "info";
-      case "staging":
-        return "warning";
-      case "production":
-        return "success";
-      default:
-        return "default";
-    }
-  };
-
-  const getEnvironmentLabel = (env: string) => {
-    switch (env) {
-      case "development":
-        return "Développement";
-      case "staging":
-        return "Staging";
-      case "production":
-        return "Production";
-      default:
-        return env;
-    }
-  };
-
-  const getFeatureStatus = (enabled: boolean) => {
-    return enabled ? "Activé" : "Désactivé";
-  };
-
-  const getFeatureColor = (enabled: boolean) => {
-    return enabled ? "success" : "default";
   };
 
   return (
@@ -546,30 +469,17 @@ export function AppSettings({
           <Divider sx={{ my: 3 }} />
 
           <Box display="flex" gap={2} flexWrap="wrap">
-            <Button
-              variant="outlined"
-              startIcon={<RefreshIcon />}
-              onClick={() => handleTestConnection("database")}
-              disabled={testing === "database"}
-            >
-              {testing === "database" ? "Test..." : "Tester la base de données"}
-            </Button>
-            <Button
-              variant="outlined"
-              startIcon={<RefreshIcon />}
-              onClick={() => handleTestConnection("api")}
-              disabled={testing === "api"}
-            >
-              {testing === "api" ? "Test..." : "Tester l&apos;API"}
-            </Button>
-            <Button
-              variant="outlined"
-              startIcon={<RefreshIcon />}
-              onClick={() => handleTestConnection("cache")}
-              disabled={testing === "cache"}
-            >
-              {testing === "cache" ? "Test..." : "Tester le cache"}
-            </Button>
+            {CONNECTION_TESTS.map((connectionTest) => (
+              <Button
+                key={connectionTest.key}
+                variant="outlined"
+                startIcon={<RefreshIcon />}
+                onClick={() => handleTestConnection(connectionTest.key)}
+                disabled={testing === connectionTest.key}
+              >
+                {testing === connectionTest.key ? "Test..." : connectionTest.label}
+              </Button>
+            ))}
             <Button
               variant="outlined"
               startIcon={<RefreshIcon />}
@@ -743,30 +653,27 @@ export function AppSettings({
               Fonctionnalités
             </Typography>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 3 }}>
-              {Object.entries(editingSettings.features).map(([key, value]) => (
+              {FEATURE_CONFIG.map((feature) => (
                 <Box
                   sx={{ width: { xs: "100%", sm: "50%", md: "33.33%" } }}
-                  key={key}
+                  key={feature.key}
                 >
                   <FormControlLabel
                     control={
                       <Switch
-                        checked={value}
+                        checked={editingSettings.features[feature.key]}
                         onChange={(e) =>
                           setEditingSettings({
                             ...editingSettings,
                             features: {
                               ...editingSettings.features,
-                              [key]: e.target.checked,
+                              [feature.key]: e.target.checked,
                             },
                           })
                         }
                       />
                     }
-                    label={key
-                      .replace("enable", "")
-                      .replace(/([A-Z])/g, " $1")
-                      .trim()}
+                    label={feature.label}
                   />
                 </Box>
               ))}

--- a/src/components/app-settings/constants.ts
+++ b/src/components/app-settings/constants.ts
@@ -1,0 +1,15 @@
+export const FEATURE_CONFIG = [
+  { key: "enableNotifications", label: "Notifications" },
+  { key: "enableAuditLog", label: "Log d'audit" },
+  { key: "enableBackup", label: "Sauvegarde" },
+  { key: "enableMaintenance", label: "Maintenance" },
+  { key: "enableReports", label: "Rapports" },
+  { key: "enableUserManagement", label: "Gestion des utilisateurs" },
+  { key: "enableThemeCustomization", label: "Personnalisation du thème" },
+] as const;
+
+export const CONNECTION_TESTS = [
+  { key: "database", label: "Tester la base de données" },
+  { key: "api", label: "Tester l&apos;API" },
+  { key: "cache", label: "Tester le cache" },
+] as const;

--- a/src/components/app-settings/types.ts
+++ b/src/components/app-settings/types.ts
@@ -1,0 +1,52 @@
+export interface AppSettingsData {
+  general: {
+    appName: string;
+    appVersion: string;
+    environment: "development" | "staging" | "production";
+    timezone: string;
+    language: string;
+    currency: string;
+    dateFormat: string;
+    timeFormat: "12h" | "24h";
+  };
+  features: {
+    enableNotifications: boolean;
+    enableAuditLog: boolean;
+    enableBackup: boolean;
+    enableMaintenance: boolean;
+    enableReports: boolean;
+    enableUserManagement: boolean;
+    enableThemeCustomization: boolean;
+  };
+  limits: {
+    maxUsers: number;
+    maxTeams: number;
+    maxPlayers: number;
+    maxMatches: number;
+    maxFileSize: number;
+    maxBackups: number;
+  };
+  security: {
+    sessionTimeout: number;
+    maxLoginAttempts: number;
+    passwordMinLength: number;
+    requireTwoFactor: boolean;
+    allowedOrigins: string[];
+    enableCORS: boolean;
+  };
+  performance: {
+    cacheEnabled: boolean;
+    cacheTtl: number;
+    maxConcurrentRequests: number;
+    requestTimeout: number;
+    enableCompression: boolean;
+    enableGzip: boolean;
+  };
+}
+
+export interface AppSettingsProps {
+  settings: AppSettingsData;
+  onSaveSettings: (settings: AppSettingsData) => Promise<void>;
+  onResetSettings: () => Promise<void>;
+  onTestConnection: (type: string) => Promise<void>;
+}

--- a/src/components/app-settings/utils.ts
+++ b/src/components/app-settings/utils.ts
@@ -1,0 +1,42 @@
+type MuiColor =
+  | "default"
+  | "primary"
+  | "secondary"
+  | "error"
+  | "info"
+  | "success"
+  | "warning";
+
+export function getEnvironmentColor(environment: string): MuiColor {
+  switch (environment) {
+    case "development":
+      return "info";
+    case "staging":
+      return "warning";
+    case "production":
+      return "success";
+    default:
+      return "default";
+  }
+}
+
+export function getEnvironmentLabel(environment: string): string {
+  switch (environment) {
+    case "development":
+      return "Développement";
+    case "staging":
+      return "Staging";
+    case "production":
+      return "Production";
+    default:
+      return environment;
+  }
+}
+
+export function getFeatureStatus(enabled: boolean): string {
+  return enabled ? "Activé" : "Désactivé";
+}
+
+export function getFeatureColor(enabled: boolean): MuiColor {
+  return enabled ? "success" : "default";
+}


### PR DESCRIPTION
## Summary
- extract app settings shape/contracts into `components/app-settings/types.ts`
- move static feature/test configuration to `components/app-settings/constants.ts`
- centralize environment/feature display helpers in `components/app-settings/utils.ts`
- simplify `AppSettings.tsx` and remove duplicated inline helper logic
- update Epic G progress in the action plan

## Test plan
- [x] `npm run check:dev`
- [x] `npm run check`

Made with [Cursor](https://cursor.com)