### PR TITLE
🛡️ Sentinel: [HIGH] Harden Firestore rules for availabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** API routes starting with `/api` were excluded from the global middleware's protection, leaving them open to CSRF and potentially other attacks if not manually secured.
 **Learning:** Next.js middleware matchers often exclude `/api` to avoid affecting all API calls or because of different auth requirements, but this can lead to developers assuming all routes are protected when they aren't.
 **Prevention:** Always implement manual session verification and CSRF protection (e.g., `validateOrigin`) in every API route that performs state-changing operations, especially when using session cookies.
+
+## 2025-05-20 - Insecure Direct Object Reference (IDOR) in Availabilities
+**Vulnerability:** The `availabilities` collection used a single document per match day with a `players` map. The security rules allowed any authenticated user to write to these documents, enabling any player to modify or delete the availability status of any other player, or even change match metadata (e.g., the match date).
+**Learning:** Shared documents containing data for multiple users require granular field-level and key-level validation. Relying on `isAuthenticated()` for write access is a major security gap in multi-tenant or shared-resource architectures.
+**Prevention:** Use `request.resource.data.diff(resource.data).affectedKeys()` to protect metadata and `request.resource.data.players.diff(resource.data.players).affectedKeys().hasOnly([playerId])` to ensure users can only modify their own entries in a shared map.

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,6 +26,11 @@ service cloud.firestore {
     function isCoach() {
       return isAdmin() || authRole() == "coach";
     }
+
+    // Récupère le playerId de l'utilisateur depuis son document
+    function getPlayerId() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.get('playerId', null);
+    }
     
     // ============================================
     // Collection: users
@@ -127,10 +132,23 @@ service cloud.firestore {
     // Collection: availabilities
     // ============================================
     // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Les admins/coachs peuvent tout modifier.
+    // Les joueurs ne peuvent modifier que leur propre entrée dans la map 'players'
+    // et ne peuvent pas modifier les métadonnées du match.
     match /availabilities/{availabilityId} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow create: if isCoach() || (
+        isAuthenticated() && getPlayerId() != null
+        && request.resource.data.players.keys().hasOnly([getPlayerId()])
+      );
+      allow update: if isCoach() || (
+        isAuthenticated() && getPlayerId() != null
+        && !request.resource.data.diff(resource.data).affectedKeys()
+            .hasAny(['journee', 'phase', 'championshipType', 'idEpreuve', 'date', 'createdAt'])
+        && request.resource.data.players.diff(resource.data.players).affectedKeys()
+            .hasOnly([getPlayerId()])
+      );
+      allow delete: if isCoach();
     }
     
     // ============================================


### PR DESCRIPTION
This PR hardens the Firestore security rules for the `availabilities` collection. 

Previously, any authenticated user could perform any write operation on these documents, which are shared across all players for a given match day. This posed a significant risk as a malicious user could:
1. Falsify the availability status of other players.
2. Delete entire availability documents for a match day.
3. Modify match metadata like the date or journey number.

The fix introduces granular access control:
- **RBAC:** Admins and coaches retain full access to manage availabilities.
- **Ownership:** Players can now only `create` or `update` their own entry within the `players` map, verified by a cross-document lookup to their user profile.
- **Integrity:** Players are explicitly prevented from modifying match metadata fields or deleting documents.

Verified with `npm test` (all 30 tests passed).

---
*PR created automatically by Jules for task [18202982910109546077](https://jules.google.com/task/18202982910109546077) started by @omichalo*