### PR TITLE
🛡️ Sentinel: [HIGH] Harden Firestore rules and fix email enumeration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** API routes starting with `/api` were excluded from the global middleware's protection, leaving them open to CSRF and potentially other attacks if not manually secured.
 **Learning:** Next.js middleware matchers often exclude `/api` to avoid affecting all API calls or because of different auth requirements, but this can lead to developers assuming all routes are protected when they aren't.
 **Prevention:** Always implement manual session verification and CSRF protection (e.g., `validateOrigin`) in every API route that performs state-changing operations, especially when using session cookies.
+
+## 2025-05-20 - Email Enumeration and Loose Firestore Rules
+**Vulnerability:** The `send-verification` API leaked user existence via 404 errors, and Firestore rules allowed any authenticated user to read/write sensitive data without email verification or strict ownership checks.
+**Learning:** Authenticated != Authorized. Even for authenticated users, sensitive operations should require email verification (`isVerified`) and strict field-level validation (e.g., `affectedKeys()` and map key ownership checks).
+**Prevention:** Always return generic success messages for auth flows to prevent enumeration. In Firestore rules, use a `isVerified()` helper and ensure players can only modify their own data within maps using cross-document lookups (e.g., `getPlayerId()`).

--- a/firestore.rules
+++ b/firestore.rules
@@ -17,14 +17,24 @@ service cloud.firestore {
         : "player";
     }
     
-    // Vérifie si l'utilisateur est admin
+    // Vérifie si l'utilisateur est authentifié et a son email vérifié
+    function isVerified() {
+      return isAuthenticated() && request.auth.token.email_verified == true;
+    }
+
+    // Vérifie si l'utilisateur est admin et a son email vérifié
     function isAdmin() {
-      return authRole() == "admin";
+      return isVerified() && authRole() == "admin";
     }
     
-    // Vérifie si l'utilisateur est coach ou admin
+    // Vérifie si l'utilisateur est coach ou admin, et a son email vérifié
     function isCoach() {
-      return isAdmin() || authRole() == "coach";
+      return isVerified() && (authRole() == "admin" || authRole() == "coach");
+    }
+
+    // Récupère le playerId de l'utilisateur depuis son document user
+    function getPlayerId() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.get('playerId', null);
     }
     
     // ============================================
@@ -65,7 +75,7 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés (documents individuels et list queries)
     // Écriture uniquement pour les admins/coaches (synchronisation FFTT)
     match /players/{playerId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
     }
     
@@ -73,7 +83,7 @@ service cloud.firestore {
     // Note: allow read dans match /players/{playerId} couvre les documents individuels,
     // mais les list queries nécessitent une règle explicite au niveau de la collection
     match /players/{document=**} {
-      allow list: if isAuthenticated();
+      allow list: if isVerified();
     }
     
     // ============================================
@@ -82,13 +92,13 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins/coaches
     match /teams/{teamId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
       
       // Sous-collection: teams/{teamId}/matches
       // Même règles que la collection parente
       match /matches/{matchId} {
-        allow read: if isAuthenticated();
+        allow read: if isVerified();
         allow write: if isCoach();
       }
     }
@@ -99,7 +109,7 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins/coaches
     match /matches/{matchId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
     }
     
@@ -109,7 +119,7 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins/coaches
     match /compositions/{compositionId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
     }
     
@@ -119,18 +129,40 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins/coaches
     match /compositionDefaults/{defaultsId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
     }
     
     // ============================================
     // Collection: availabilities
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Lecture pour tous les utilisateurs authentifiés avec email vérifié
+    // Écriture pour les admins/coachs ou pour les joueurs (uniquement leur propre entrée)
     match /availabilities/{availabilityId} {
-      allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow read: if isVerified();
+
+      // Seuls les admins et coachs peuvent créer un document de disponibilité (initialisation de la journée)
+      allow create: if isCoach() && isVerified();
+
+      // Mise à jour : admins/coachs (tout) ou joueurs (uniquement leur propre entrée)
+      allow update: if isVerified() && (
+        isCoach() || (
+          // Un joueur ne peut modifier QUE son entrée dans la map 'players'
+          // On vérifie que les métadonnées du document ne changent pas
+          !request.resource.data.diff(resource.data).affectedKeys()
+            .hasAny(['journee', 'phase', 'championshipType', 'idEpreuve', 'date', 'createdAt'])
+          && (
+            let pid = getPlayerId();
+            pid != null && (
+              // On vérifie que seule la clé correspondant au playerId de l'utilisateur a changé dans la map 'players'
+              request.resource.data.players.diff(resource.data.players).affectedKeys().hasOnly([pid])
+            )
+          )
+        )
+      );
+
+      // Suppression : uniquement admin
+      allow delete: if isAdmin() && isVerified();
     }
     
     // ============================================
@@ -139,7 +171,7 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins/coaches
     match /burnRecords/{burnRecordId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
     }
     
@@ -149,13 +181,13 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins
     match /clubSettings/{settingsId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isAdmin();
     }
     
     // Alias pour club_settings (si utilisé)
     match /club_settings/{settingsId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isAdmin();
     }
     
@@ -165,7 +197,7 @@ service cloud.firestore {
     // Lecture pour tous les utilisateurs authentifiés
     // Écriture uniquement pour les admins
     match /locations/{locationId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isAdmin();
     }
     
@@ -181,10 +213,10 @@ service cloud.firestore {
     // Collection: discordMessages
     // ============================================
     // Messages Discord envoyés pour les matchs
-    // Lecture pour tous les utilisateurs authentifiés
+    // Lecture pour tous les utilisateurs authentifiés avec email vérifié
     // Écriture uniquement pour les admins/coaches
     match /discordMessages/{messageId} {
-      allow read: if isAuthenticated();
+      allow read: if isVerified();
       allow write: if isCoach();
     }
     

--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -109,10 +109,9 @@ export async function POST(req: Request) {
         errorMessage.includes("USER_NOT_FOUND") ||
         errorMessage.includes("no user record")
       ) {
-        return jsonNoStore(
-          { error: "Utilisateur non trouvé", message: "Aucun compte n'est associé à cet email" },
-          { status: 404 }
-        );
+        // Pour des raisons de sécurité, on ne révèle pas si l'utilisateur existe
+        // Cela prévient l'énumération d'adresses email
+        return jsonNoStore({ ok: true });
       }
       
       if (
@@ -192,7 +191,8 @@ export async function POST(req: Request) {
     // Déterminer le code HTTP approprié
     let statusCode = 500;
     if (errorString.includes("user-not-found") || errorString.includes("USER_NOT_FOUND")) {
-      statusCode = 404;
+      // Pour des raisons de sécurité, on ne révèle pas si l'utilisateur existe
+      return jsonNoStore({ ok: true });
     } else if (errorString.includes("invalid-email") || errorString.includes("INVALID_EMAIL")) {
       statusCode = 400;
     } else if (errorString.includes("too-many-requests") || errorString.includes("TOO_MANY_REQUESTS")) {


### PR DESCRIPTION
This PR addresses several security gaps identified in the application's Firestore rules and authentication flow.

### 🔐 Firestore Rules Hardening
- **Defense in Depth:** Introduced an `isVerified()` helper that requires both authentication and a verified email address (`request.auth.token.email_verified == true`).
- **Access Control:** Updated rules for `players`, `teams`, `compositions`, `locations`, `clubSettings`, and `burnRecords` to enforce `isVerified()`.
- **IDOR Protection:** Implemented a robust ownership check for the `availabilities` collection. Players can now only update their own key within the `players` map, verified via a cross-document lookup to their user profile (`getPlayerId()`).
- **Data Integrity:** Used `affectedKeys()` to prevent players from modifying critical match metadata (journee, phase, etc.) within availability documents.

### 🛡️ Authentication Security
- **Email Enumeration Fix:** The `/api/auth/send-verification` endpoint now returns a generic `200 OK` response even when a user is not found. This prevents attackers from using the API to discover registered email addresses.

### 📝 Security Journal
- Added a new entry to `.jules/sentinel.md` documenting the "Authenticated != Authorized" learning and the patterns used to secure map-based documents in Firestore.

Verification:
- Read-back verification of all modified files.
- Full test suite passed (`npm test`).

---
*PR created automatically by Jules for task [6878987643692742107](https://jules.google.com/task/6878987643692742107) started by @omichalo*