### PR TITLE
fix(fftt): fiabiliser sync compositions et phase de brûlage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/swagger-ui-react": "^5.18.0",
+        "@types/xml2js": "^0.4.14",
         "dotenv": "^17.2.3",
         "eslint": "^9",
         "eslint-config-next": "15.5.3",
@@ -6705,6 +6706,15 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/swagger-ui-react": "^5.18.0",
+    "@types/xml2js": "^0.4.14",
     "dotenv": "^17.2.3",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",

--- a/src/app/api/fftt/opponent-compositions/route.ts
+++ b/src/app/api/fftt/opponent-compositions/route.ts
@@ -17,6 +17,22 @@ import {
 
 export const runtime = "nodejs";
 
+async function createInitializedFFTTApi(retries = 1) {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const api = createFFTTAPI();
+    try {
+      await api.initialize();
+      return api;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
 /** Normalise un nom d'équipe pour la comparaison (majuscules, trim, espaces réduits). */
 function normalizeTeamName(name: string): string {
   return (name || "").trim().replace(/\s+/g, " ").toUpperCase();
@@ -237,8 +253,7 @@ export async function GET(req: NextRequest) {
     }
 
     const { clubCode } = getFFTTConfig();
-    const api = createFFTTAPI();
-    await api.initialize();
+    const api = await createInitializedFFTTApi();
 
     const equipes = (await api.getEquipesByClub(clubCode)) as Array<{
       idEquipe: number;

--- a/src/app/api/fftt/pool-ranking/route.ts
+++ b/src/app/api/fftt/pool-ranking/route.ts
@@ -13,6 +13,22 @@ import {
 
 export const runtime = "nodejs";
 
+async function createInitializedFFTTApi(retries = 1) {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const api = createFFTTAPI();
+    try {
+      await api.initialize();
+      return api;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
 export interface PoolRankingEntry {
   classement: number;
   nomEquipe: string;
@@ -79,8 +95,7 @@ export async function GET(req: NextRequest) {
       phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
 
     const { clubCode } = getFFTTConfig();
-    const api = createFFTTAPI();
-    await api.initialize();
+    const api = await createInitializedFFTTApi();
 
     const equipes = (await api.getEquipesByClub(clubCode)) as FFTTEquipeLike[];
     const teamIdTrim = teamId.trim();
@@ -197,10 +212,8 @@ export async function GET(req: NextRequest) {
     );
   } catch (error) {
     console.error("[api/fftt/pool-ranking]", error);
-    const message =
-      error instanceof Error ? error.message : "Erreur lors du chargement du classement";
     return jsonNoStore(
-      { error: message },
+      { error: "Impossible de charger le classement pour le moment" },
       { status: 500 }
     );
   }

--- a/src/app/joueurs/page.tsx
+++ b/src/app/joueurs/page.tsx
@@ -34,6 +34,7 @@ import { useTeamData } from "@/hooks/useTeamData";
 import { useDiscordMembers } from "@/hooks/useDiscordMembers";
 import { USER_ROLES } from "@/lib/auth/roles";
 import { useTeamManagementStore } from "@/stores/teamManagementStore";
+import { getPhaseOfNextChampionnatEquipesMatch } from "@/lib/shared/phase-utils";
 import {
   applyJoueursFilters,
   getPlayersForTab,
@@ -69,7 +70,7 @@ function TabPanel(props: TabPanelProps) {
 // Composant pour afficher les suggestions de mentions Discord
 
 export default function JoueursPage() {
-  const { currentPhase } = useTeamData();
+  const { equipes, currentPhase } = useTeamData();
   const updatePlayerInStore = useTeamManagementStore(
     (state) => state.updatePlayer
   );
@@ -98,6 +99,11 @@ export default function JoueursPage() {
   const { members: discordMembers } = useDiscordMembers();
 
   const playerService = useMemo(() => new FirestorePlayerService(), []);
+
+  const burnoutPhase = useMemo<"aller" | "retour">(() => {
+    const phaseOfNextMatch = getPhaseOfNextChampionnatEquipesMatch(equipes);
+    return phaseOfNextMatch ?? currentPhase ?? "aller";
+  }, [currentPhase, equipes]);
 
   const loadPlayers = useCallback(async () => {
     try {
@@ -630,7 +636,7 @@ export default function JoueursPage() {
           ) : (
             <PlayersActiveTable
               players={filteredPlayers}
-              currentPhase={currentPhase}
+              currentPhase={burnoutPhase}
               hasInvalidDiscordMentions={hasInvalidDiscordMentions}
               onEditPlayer={handleEditPlayer}
               onToggleParticipation={handleToggleParticipation}

--- a/src/components/equipes/EquipeAccordion.tsx
+++ b/src/components/equipes/EquipeAccordion.tsx
@@ -70,15 +70,55 @@ function ourSideIsA(match: Match): boolean {
   return countA >= countB;
 }
 
+type CompositionPlayer = {
+  licence?: string;
+  nom?: string;
+  prenom?: string;
+  points?: number | null;
+};
+
+function hasNamedPlayers(players: CompositionPlayer[]): boolean {
+  return players.some(
+    (p) => ((p.nom ?? "").trim().length > 0 || (p.prenom ?? "").trim().length > 0)
+  );
+}
+
+function getSQYCompositionPlayers(match: Match): CompositionPlayer[] {
+  const joueursSQY = (match.joueursSQY ?? []) as CompositionPlayer[];
+  if (joueursSQY.length > 0 && hasNamedPlayers(joueursSQY)) {
+    return joueursSQY;
+  }
+
+  const resultats = match.resultatsIndividuels;
+  if (!resultats) return [];
+
+  const joueursA = Object.values(resultats.joueursA ?? {});
+  const joueursB = Object.values(resultats.joueursB ?? {});
+  if (joueursA.length === 0 && joueursB.length === 0) {
+    return [];
+  }
+
+  const nomEquipeA = (resultats.nomEquipeA ?? "").toUpperCase();
+  const nomEquipeB = (resultats.nomEquipeB ?? "").toUpperCase();
+  const sqyInA = nomEquipeA.includes("SQY PING");
+  const sqyInB = nomEquipeB.includes("SQY PING");
+
+  if (sqyInA && !sqyInB) return joueursA;
+  if (sqyInB && !sqyInA) return joueursB;
+
+  // Fallback défensif si les noms d'équipe sont absents/incohérents.
+  return ourSideIsA(match) ? joueursA : joueursB;
+}
+
 /**
  * Calcule victoires/défaites par joueur pour un match (simples uniquement, logique partagée avec l'API).
  */
 function computeVictoiresDefaitesForMatch(
-  match: Match
+  match: Match,
+  compositionPlayers: CompositionPlayer[]
 ): Map<string, { victoires: number; defaites: number }> {
   const parties = match.resultatsIndividuels?.parties;
-  const joueursSQY = match.joueursSQY ?? [];
-  if (!parties || parties.length === 0 || joueursSQY.length === 0) {
+  if (!parties || parties.length === 0 || compositionPlayers.length === 0) {
     return new Map();
   }
   const partieLike = parties.map((p) => ({
@@ -89,7 +129,7 @@ function computeVictoiresDefaitesForMatch(
   }));
   const sideACountsAsOurs = ourSideIsA(match);
   const getPlayerKey = (playerName: string): string | null => {
-    const joueur = joueursSQY.find((j) =>
+    const joueur = compositionPlayers.find((j) =>
       playerNameMatches(playerName, j.nom ?? "", j.prenom ?? "")
     );
     if (!joueur) return null;
@@ -128,7 +168,8 @@ export function EquipeAccordion({
       (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
     );
     return sorted.map((m) => {
-      const vdByPlayer = computeVictoiresDefaitesForMatch(m);
+      const compositionPlayers = getSQYCompositionPlayers(m);
+      const vdByPlayer = computeVictoiresDefaitesForMatch(m, compositionPlayers);
       return {
         date:
           typeof m.date === "string"
@@ -137,7 +178,7 @@ export function EquipeAccordion({
         journee: m.journee,
         otherTeamName: m.opponent || "Adversaire",
         ...(m.score ? { score: m.score } : {}),
-        composition: (m.joueursSQY || []).map((j) => {
+        composition: compositionPlayers.map((j) => {
           const key =
             (j.licence ?? "").trim() ||
             `${(j.nom ?? "").trim()}|${(j.prenom ?? "").trim()}`;

--- a/src/lib/shared/fftt-utils.ts
+++ b/src/lib/shared/fftt-utils.ts
@@ -1,4 +1,5 @@
 import { FFTTAPI } from "@omichalo/ffttapi-node";
+import xml2js from "xml2js";
 import {
   FFTTEquipe,
   FFTTJoueur,
@@ -6,6 +7,45 @@ import {
   FFTTDetailsRencontre,
 } from "./fftt-types";
 import { Player } from "@/types/team-management";
+
+let xml2jsPatched = false;
+
+function normalizeXmlObjectPrototypes(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeXmlObjectPrototypes(item));
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (Object.getPrototypeOf(record) === null) {
+      Object.setPrototypeOf(record, Object.prototype);
+    }
+
+    Object.keys(record).forEach((key) => {
+      record[key] = normalizeXmlObjectPrototypes(record[key]);
+    });
+  }
+
+  return value;
+}
+
+function patchXml2jsParseStringPromise(): void {
+  if (xml2jsPatched) {
+    return;
+  }
+
+  const originalParseStringPromise = xml2js.parseStringPromise.bind(xml2js);
+  xml2js.parseStringPromise = async (
+    ...args: Parameters<typeof originalParseStringPromise>
+  ): ReturnType<typeof originalParseStringPromise> => {
+    const parsed = await originalParseStringPromise(...args);
+    return normalizeXmlObjectPrototypes(parsed) as Awaited<
+      ReturnType<typeof originalParseStringPromise>
+    >;
+  };
+
+  xml2jsPatched = true;
+}
 
 // Configuration FFTT partagée
 export const getFFTTConfig = () => {
@@ -24,6 +64,7 @@ export const getFFTTConfig = () => {
 
 // Instance FFTT API partagée
 export const createFFTTAPI = () => {
+  patchXml2jsParseStringPromise();
   const config = getFFTTConfig();
   return new FFTTAPI(config.id, config.pwd);
 };

--- a/src/lib/shared/player-sync.ts
+++ b/src/lib/shared/player-sync.ts
@@ -1,5 +1,5 @@
 import { FFTTAPI } from "@omichalo/ffttapi-node";
-import { getFFTTConfig } from "./fftt-utils";
+import { createFFTTAPI, getFFTTConfig } from "./fftt-utils";
 import { FFTTJoueurDetails } from "./fftt-types";
 import type { Firestore, DocumentReference } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
@@ -31,7 +31,7 @@ export class PlayerSyncService {
 
   constructor() {
     const config = getFFTTConfig();
-    this.ffttApi = new FFTTAPI(config.id, config.pwd);
+    this.ffttApi = createFFTTAPI();
     this.clubCode = config.clubCode;
   }
 

--- a/src/lib/shared/team-matches-sync-save.ts
+++ b/src/lib/shared/team-matches-sync-save.ts
@@ -2,6 +2,70 @@ import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import type { MatchData } from "./team-matches-sync-types";
 
+type SyncPlayer = NonNullable<MatchData["joueursSQY"]>[number];
+type ResultPlayer = { nom: string; prenom: string; points?: number };
+
+function normalizeName(value: string | undefined): string {
+  return (value ?? "").trim().toUpperCase().replace(/\s+/g, " ");
+}
+
+function playerNameKey(player: { nom?: string; prenom?: string }): string {
+  return `${normalizeName(player.prenom)}|${normalizeName(player.nom)}`;
+}
+
+function buildPlayersFromResults(match: MatchData): ResultPlayer[] {
+  const details = match.resultatsIndividuels;
+  if (!details) return [];
+
+  const joueursA = Object.values(details.joueursA ?? {});
+  const joueursB = Object.values(details.joueursB ?? {});
+  if (joueursA.length === 0 && joueursB.length === 0) return [];
+
+  const nomEquipeA = normalizeName(details.nomEquipeA);
+  const nomEquipeB = normalizeName(details.nomEquipeB);
+
+  if (nomEquipeA.includes("SQY PING") && !nomEquipeB.includes("SQY PING")) {
+    return joueursA;
+  }
+  if (nomEquipeB.includes("SQY PING") && !nomEquipeA.includes("SQY PING")) {
+    return joueursB;
+  }
+
+  // Fallback défensif si les noms équipes sont absents/incohérents.
+  return joueursA.length >= joueursB.length ? joueursA : joueursB;
+}
+
+function reconcileJoueursSQY(match: MatchData): SyncPlayer[] {
+  const existingPlayers = (match.joueursSQY ?? []) as SyncPlayer[];
+  const resultPlayers = buildPlayersFromResults(match);
+  if (resultPlayers.length === 0) {
+    return existingPlayers;
+  }
+
+  const existingByName = new Map<string, SyncPlayer>();
+  existingPlayers.forEach((player, index) => {
+    const key = playerNameKey(player);
+    if (!existingByName.has(key)) {
+      existingByName.set(key, {
+        ...player,
+        id: player.id || `${key || "unknown"}_${index + 1}`,
+      });
+    }
+  });
+
+  return resultPlayers.map((player, index) => {
+    const key = playerNameKey(player);
+    const existing = existingByName.get(key);
+    return {
+      id: existing?.id || `${key || "unknown"}_${index + 1}`,
+      nom: player.nom || existing?.nom || "",
+      prenom: player.prenom || existing?.prenom || "",
+      licence: existing?.licence || "",
+      points: typeof existing?.points === "number" ? existing.points : (player.points ?? 0),
+      sexe: existing?.sexe || "M",
+    };
+  });
+}
 export async function saveMatchesToTeamSubcollections(
   matches: MatchData[],
   db: Firestore
@@ -104,6 +168,7 @@ export async function saveMatchesToTeamSubcollections(
             .collection("matches")
             .doc(matchId);
 
+          const reconciledJoueursSQY = reconcileJoueursSQY(match);
           const matchData = {
             ...match,
             date: Timestamp.fromDate(match.date),
@@ -146,7 +211,7 @@ export async function saveMatchesToTeamSubcollections(
           const serializableMatchData = {
             ...matchData,
             joueursSQY:
-              matchData.joueursSQY?.map((joueur) =>
+              reconciledJoueursSQY.map((joueur) =>
                 cleanPlayer({
                   licence: joueur.licence,
                   nom: (joueur as { nom?: string }).nom,

--- a/src/lib/shared/team-matches-sync.ts
+++ b/src/lib/shared/team-matches-sync.ts
@@ -1,5 +1,5 @@
 import { FFTTAPI } from "@omichalo/ffttapi-node";
-import { getFFTTConfig } from "./fftt-utils";
+import { createFFTTAPI, getFFTTConfig } from "./fftt-utils";
 import { FFTTEquipe, FFTTRencontre } from "./fftt-types";
 import { createBaseMatch, isFemaleTeam, determinePhaseFromDivision } from "./fftt-utils";
 import type { Firestore, DocumentReference } from "firebase-admin/firestore";
@@ -34,7 +34,7 @@ export class TeamMatchesSyncService {
 
   constructor() {
     const config = getFFTTConfig();
-    this.ffttApi = new FFTTAPI(config.id, config.pwd);
+    this.ffttApi = createFFTTAPI();
     this.clubCode = config.clubCode;
   }
 
@@ -139,27 +139,11 @@ export class TeamMatchesSyncService {
 
           let clubEquipeA, clubEquipeB;
           if (clubnum1Match && clubnum2Match) {
-            // Vérifier quelle équipe est SQY PING
-            const equip1Match = rencontre.lien.match(/equip_1=([^&]+)/);
-            const equip2Match = rencontre.lien.match(/equip_2=([^&]+)/);
-
-            if (equip1Match && equip1Match[1].includes("SQY+PING")) {
-              clubEquipeA = clubnum1Match[1];
-              clubEquipeB = clubnum2Match[1];
-            } else if (equip2Match && equip2Match[1].includes("SQY+PING")) {
-              clubEquipeA = clubnum2Match[1];
-              clubEquipeB = clubnum1Match[1];
-            } else {
-              // Fallback: utiliser les IDs d&apos;équipe comme clubs
-              clubEquipeA = extractClubIdFromLien(
-                rencontre.lien,
-                "clubnum_1"
-              );
-              clubEquipeB = extractClubIdFromLien(
-                rencontre.lien,
-                "clubnum_2"
-              );
-            }
+            // clubnum_1/clubnum_2 correspondent toujours à l'ordre équipe A/B du lien FFTT.
+            // Ne pas inverser selon SQY, sinon getDetailsRencontreByLien peut retourner
+            // des détails incomplets (joueurs manquants) pour certains matchs extérieurs.
+            clubEquipeA = clubnum1Match[1];
+            clubEquipeB = clubnum2Match[1];
           } else {
             // Fallback: utiliser les IDs d&apos;équipe comme clubs
             clubEquipeA = extractClubIdFromLien(
@@ -395,25 +379,9 @@ export class TeamMatchesSyncService {
 
             let clubEquipeA, clubEquipeB;
             if (clubnum1Match && clubnum2Match) {
-              // Vérifier quelle équipe est SQY PING
-              const equip1Match = rencontre.lien.match(/equip_1=([^&]+)/);
-              const equip2Match = rencontre.lien.match(/equip_2=([^&]+)/);
-
-              if (equip1Match && equip1Match[1].includes("SQY+PING")) {
-                clubEquipeA = clubnum1Match[1];
-                clubEquipeB = clubnum2Match[1];
-              } else if (equip2Match && equip2Match[1].includes("SQY+PING")) {
-                clubEquipeA = clubnum2Match[1];
-                clubEquipeB = clubnum1Match[1];
-              } else {
-                // Fallback: utiliser les IDs d&apos;équipe comme clubs
-                clubEquipeA =
-                  (rencontre as FFTTRencontre & { idClubA?: string }).idClubA ||
-                  "";
-                clubEquipeB =
-                  (rencontre as FFTTRencontre & { idClubB?: string }).idClubB ||
-                  "";
-              }
+              // clubnum_1/clubnum_2 correspondent à équipe A/B dans le lien FFTT.
+              clubEquipeA = clubnum1Match[1];
+              clubEquipeB = clubnum2Match[1];
             } else {
               // Fallback: utiliser les IDs d&apos;équipe comme clubs
               clubEquipeA = extractClubIdFromLien(

--- a/src/lib/shared/team-sync.ts
+++ b/src/lib/shared/team-sync.ts
@@ -1,5 +1,10 @@
 import { FFTTAPI } from "@omichalo/ffttapi-node";
-import { getFFTTConfig, isFemaleTeam, determinePhaseFromDivision } from "./fftt-utils";
+import {
+  createFFTTAPI,
+  getFFTTConfig,
+  isFemaleTeam,
+  determinePhaseFromDivision,
+} from "./fftt-utils";
 import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import type { FFTTEquipe } from "./fftt-types";
@@ -71,7 +76,7 @@ export class TeamSyncService {
 
   constructor() {
     const config = getFFTTConfig();
-    this.ffttApi = new FFTTAPI(config.id, config.pwd);
+    this.ffttApi = createFFTTAPI();
     this.clubCode = config.clubCode;
   }
 


### PR DESCRIPTION
## Summary
- corrige le crash FFTT `hasOwnProperty` en normalisant les objets XML parsés avant usage de la lib FFTT
- aligne la phase de brûlage de la page joueurs sur la même logique que disponibilités
- fiabilise les compositions (clubnum A/B + réconciliation `joueursSQY` depuis `resultatsIndividuels`) et ajoute un fallback d’affichage côté UI

## Test plan
- [x] `npm run check` (sur workspace principal)
- [x] `npm run check:dev` (hook pre-push)
- [ ] validation manuelle UI (cup + compositions J1/J4 équipe 20)

Made with [Cursor](https://cursor.com)