### PR TITLE
feat(club-registration): parcours d'inscription hybride anonyme/connecté multi-rôle

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,34 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "clubRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "submitterUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "submittedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "clubRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "submitterUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -187,7 +187,36 @@ service cloud.firestore {
       allow read: if isAuthenticated();
       allow write: if isCoach();
     }
-    
+
+    // ============================================
+    // Collection: clubRegistrations
+    // ============================================
+    // Dossier d'inscription au club. Un soumettant (parent ou adulte qui s'inscrit lui-même)
+    // peut créer plusieurs dossiers (ex. inscription de 2 enfants). Le couplage 1 dossier ↔ 1 uid
+    // est volontairement abandonné.
+    //
+    // - read   : owner (submitterUid == uid) ou admin
+    // - create : owner se déclare comme submitterUid, schemaVersion strict
+    // - update : owner uniquement, tant que status != 'approved'
+    // - delete : interdit côté client (l'admin gère via Admin SDK)
+    match /clubRegistrations/{registrationId} {
+      allow read: if isAuthenticated()
+                  && (isAdmin() || resource.data.submitterUid == request.auth.uid);
+      allow create: if isAuthenticated()
+                    && request.resource.data.submitterUid == request.auth.uid
+                    && request.resource.data.schemaVersion == 1;
+      allow update: if isAuthenticated()
+                    && resource.data.submitterUid == request.auth.uid
+                    && request.resource.data.submitterUid == request.auth.uid
+                    && resource.data.get('status', 'draft') != 'approved';
+      allow delete: if false;
+    }
+    // List queries : autorisées aux utilisateurs authentifiés. Les requêtes sont filtrées
+    // côté serveur API par submitterUid (admin SDK contourne les rules de toute façon).
+    match /clubRegistrations/{document=**} {
+      allow list: if isAuthenticated();
+    }
+
     // ============================================
     // Règle par défaut : refuser tout accès non explicitement autorisé
     // ============================================

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,22 +13,32 @@ const PROTECTED_PREFIXES = [
   "/joueurs",
   "/joueur",
   "/settings",
+  "/club",
 ];
 
-// Routes publiques qui ne nécessitent pas d'authentification
+// Routes publiques (préfixe) qui ne nécessitent pas d'authentification.
+// Inclut le formulaire d'inscription au club, qui adopte un parcours hybride :
+// remplissage anonyme autorisé, l'authentification ne sera exigée qu'à la soumission.
 const PUBLIC_ROUTES = [
   "/login",
   "/signup",
   "/reset",
   "/reset-password",
   "/auth/verify-email",
+  "/club/inscription",
 ];
+
+// Routes publiques en match exact (utile pour les pages-redirections).
+const PUBLIC_EXACT_ROUTES = ["/club"];
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
   // Exclure les routes publiques
-  if (PUBLIC_ROUTES.some((route) => pathname.startsWith(route))) {
+  if (
+    PUBLIC_EXACT_ROUTES.includes(pathname) ||
+    PUBLIC_ROUTES.some((route) => pathname.startsWith(route))
+  ) {
     return NextResponse.next();
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -6193,6 +6194,81 @@
         "tailwindcss": "4.1.13"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
@@ -6314,6 +6390,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
     },
     "node_modules/@types/axios": {
       "version": "0.14.4",
@@ -8644,6 +8726,15 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -12786,6 +12877,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-bytes.js": {
       "version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/src/app/api/club/registration/route.ts
+++ b/src/app/api/club/registration/route.ts
@@ -1,0 +1,202 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { cookies } from "next/headers";
+import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { FieldValue } from "firebase-admin/firestore";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import { clubRegistrationPayloadSchema } from "@/lib/club-registration/schema";
+import { isMinorAt } from "@/lib/club-registration/age";
+import { checkRateLimit } from "@/lib/auth/rate-limit";
+
+const COLLECTION = "clubRegistrations";
+
+/**
+ * Feature flag : tant que `HYBRID_SUBMIT_ENABLED !== "true"`, la route POST renvoie 503.
+ * La PR 2 du parcours hybride activera réellement la soumission. La route GET reste utilisable
+ * pour récupérer un dossier existant par son `id` (lecture/édition future).
+ */
+const HYBRID_SUBMIT_ENABLED = process.env.HYBRID_SUBMIT_ENABLED === "true";
+
+/** Champs métier renvoyés au client (hors Timestamps bruts). */
+const REGISTRATION_CLIENT_FIELDS = [
+  "adherentRole",
+  "firstName",
+  "lastName",
+  "sex",
+  "birthCity",
+  "birthDate",
+  "adherentEmail",
+  "adherentPhonePrimary",
+  "adherentPhoneSecondary",
+  "addressLine1",
+  "addressLine2",
+  "postalCode",
+  "city",
+  "representatives",
+  "mainSectionId",
+  "additionalSectionIds",
+  "slotIds",
+  "medicalCertificateDeclaration",
+  "wantsRegistrationCertificate",
+  "familyRegistrationOrder",
+  "reductionTypes",
+  "passSportCode",
+  "firstFemaleRegistrationSqy",
+  "photoConsent",
+  "emergencyMedicalAuthorization",
+  "supervisionAcknowledgement",
+  "internalRulesAccepted",
+  "wantsCompetitorExtras",
+  "competitionJerseySize",
+  "competitionIds",
+  "isMinor",
+  "submitterUid",
+  "submitterAccountEmail",
+  "schemaVersion",
+  "status",
+] as const;
+
+function stripUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== "") {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/** GET /api/club/registration?id={registrationId} — lecture d'un dossier (owner ou admin). */
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const id = url.searchParams.get("id");
+    if (!id) {
+      return jsonNoStore({ error: "Paramètre 'id' requis" }, { status: 400 });
+    }
+
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.PLAYER, USER_ROLES.COACH, USER_ROLES.ADMIN])) {
+      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const db = getFirestoreAdmin();
+    const snap = await db.collection(COLLECTION).doc(id).get();
+    if (!snap.exists) {
+      return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
+    }
+    const data = snap.data();
+    if (!data) {
+      return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
+    }
+
+    const isAdmin = role === USER_ROLES.ADMIN;
+    if (!isAdmin && data.submitterUid !== decoded.uid) {
+      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const registration: Record<string, unknown> = { id: snap.id };
+    for (const key of REGISTRATION_CLIENT_FIELDS) {
+      if (data[key] !== undefined) {
+        registration[key] = data[key];
+      }
+    }
+    registration.submittedAt = data.submittedAt?.toDate?.()?.toISOString?.() ?? null;
+    registration.updatedAt = data.updatedAt?.toDate?.()?.toISOString?.() ?? null;
+
+    return jsonNoStore({ registration }, { status: 200 });
+  } catch (error) {
+    console.error("[api/club/registration GET]", error);
+    return jsonNoStore({ error: "Impossible de charger le dossier" }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/club/registration — création d'un nouveau dossier (auto-id Firestore).
+ * Désactivé tant que `HYBRID_SUBMIT_ENABLED !== "true"`.
+ */
+export async function POST(req: Request) {
+  try {
+    if (!HYBRID_SUBMIT_ENABLED) {
+      return jsonNoStore(
+        { error: "Soumission temporairement désactivée" },
+        { status: 503 }
+      );
+    }
+
+    if (!validateOrigin(req)) {
+      return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+    }
+
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+
+    if (!hasAnyRole(role, [USER_ROLES.PLAYER, USER_ROLES.COACH, USER_ROLES.ADMIN])) {
+      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const rate = checkRateLimit(`club-registration:${decoded.uid}`, 8, 60 * 60 * 1000);
+    if (!rate.allowed) {
+      return jsonNoStore(
+        { error: "Trop de soumissions dans la période autorisée. Réessayez plus tard." },
+        { status: 429 }
+      );
+    }
+
+    const json = (await req.json()) ?? {};
+    const parsed = clubRegistrationPayloadSchema.safeParse(json);
+
+    if (!parsed.success) {
+      const first = parsed.error.flatten();
+      return jsonNoStore(
+        { error: "Données invalides", fieldErrors: first.fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const payload = parsed.data;
+    const db = getFirestoreAdmin();
+
+    const baseFields = stripUndefined({ ...payload });
+    const now = FieldValue.serverTimestamp();
+
+    const docRef = await db.collection(COLLECTION).add({
+      ...baseFields,
+      isMinor: isMinorAt(payload.birthDate),
+      submitterUid: decoded.uid,
+      submitterAccountEmail: decoded.email ?? null,
+      schemaVersion: 1,
+      status: "submitted",
+      submittedAt: now,
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_SUBMITTED, decoded.uid, {
+      resource: "clubRegistration",
+      resourceId: docRef.id,
+      success: true,
+    });
+
+    return jsonNoStore({ success: true, id: docRef.id }, { status: 200 });
+  } catch (error) {
+    console.error("[api/club/registration POST]", error);
+    return jsonNoStore({ error: "Impossible d’enregistrer le dossier" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/registrations/route.ts
+++ b/src/app/api/club/registrations/route.ts
@@ -1,0 +1,64 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { cookies } from "next/headers";
+import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+
+const COLLECTION = "clubRegistrations";
+
+/** Champs renvoyés en mode "liste" (synthèse, pas la totalité du dossier). */
+const LIST_FIELDS = [
+  "adherentRole",
+  "firstName",
+  "lastName",
+  "birthDate",
+  "isMinor",
+  "mainSectionId",
+  "status",
+  "submitterUid",
+  "submitterAccountEmail",
+] as const;
+
+/** GET /api/club/registrations — liste des dossiers du soumettant connecté. */
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.PLAYER, USER_ROLES.COACH, USER_ROLES.ADMIN])) {
+      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const db = getFirestoreAdmin();
+    const snap = await db
+      .collection(COLLECTION)
+      .where("submitterUid", "==", decoded.uid)
+      .orderBy("submittedAt", "desc")
+      .limit(20)
+      .get();
+
+    const registrations = snap.docs.map((doc) => {
+      const data = doc.data();
+      const summary: Record<string, unknown> = { id: doc.id };
+      for (const key of LIST_FIELDS) {
+        if (data[key] !== undefined) {
+          summary[key] = data[key];
+        }
+      }
+      summary.submittedAt = data.submittedAt?.toDate?.()?.toISOString?.() ?? null;
+      summary.updatedAt = data.updatedAt?.toDate?.()?.toISOString?.() ?? null;
+      return summary;
+    });
+
+    return jsonNoStore({ registrations }, { status: 200 });
+  } catch (error) {
+    console.error("[api/club/registrations GET]", error);
+    return jsonNoStore({ error: "Impossible de charger les dossiers" }, { status: 500 });
+  }
+}

--- a/src/app/api/geocode/ban/route.ts
+++ b/src/app/api/geocode/ban/route.ts
@@ -1,0 +1,82 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { checkRateLimit } from "@/lib/auth/rate-limit";
+import type { BanFeature, BanSearchResponse } from "@/lib/geocoding/ban";
+import {
+  buildSupplementalBanQuery,
+  mergeBanFeaturesPreferHigherScore,
+} from "@/lib/geocoding/ban-supplemental-query";
+
+const BAN_SEARCH_URL = "https://api-adresse.data.gouv.fr/search/";
+
+async function fetchBanFeatures(query: string): Promise<BanFeature[]> {
+  const banUrl = new URL(BAN_SEARCH_URL);
+  banUrl.searchParams.set("q", query);
+  banUrl.searchParams.set("limit", "25");
+  const upstream = await fetch(banUrl.toString(), {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!upstream.ok) {
+    throw new Error(`BAN upstream ${upstream.status}`);
+  }
+  const data = (await upstream.json()) as BanSearchResponse;
+  return data.features ?? [];
+}
+
+function clientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+/**
+ * Proxy vers l’API Adresse (BAN / data.gouv), sans clé API.
+ * Pas d’auth obligatoire : données publiques ; limitation par IP pour éviter l’abus.
+ * (Une session Firebase peut échouer en local sans credentials → liste vide côté UI.)
+ */
+export async function GET(req: Request) {
+  try {
+    const ip = clientIp(req);
+    const rate = checkRateLimit(`ban-geo:${ip}`, 180, 60 * 1000);
+    if (!rate.allowed) {
+      return jsonNoStore({ error: "Trop de requêtes. Réessayez dans une minute." }, { status: 429 });
+    }
+
+    const url = new URL(req.url);
+    const q = url.searchParams.get("q")?.trim() ?? "";
+    if (q.length < 3) {
+      return jsonNoStore({ features: [] }, { status: 200 });
+    }
+    if (q.length > 200) {
+      return jsonNoStore({ error: "Requête trop longue" }, { status: 400 });
+    }
+
+    let raw: BanFeature[];
+    try {
+      raw = await fetchBanFeatures(q);
+    } catch {
+      return jsonNoStore({ error: "Service d’adresses indisponible" }, { status: 502 });
+    }
+
+    const supplement = buildSupplementalBanQuery(q);
+    if (supplement && supplement !== q.trim()) {
+      try {
+        const secondary = await fetchBanFeatures(supplement);
+        raw = mergeBanFeaturesPreferHigherScore(raw, secondary);
+      } catch {
+        /* ignore : la requête principale suffit */
+      }
+    }
+
+    /* Pas de filtre par segments ici : il écartait parfois toutes les lignes ; le client affiche les libellés BAN tels quels. */
+    return jsonNoStore({ features: raw.slice(0, 25) }, { status: 200 });
+  } catch (error) {
+    console.error("[api/geocode/ban]", error);
+    return jsonNoStore({ error: "Impossible de rechercher l’adresse" }, { status: 500 });
+  }
+}

--- a/src/app/club/inscription/page.tsx
+++ b/src/app/club/inscription/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Box, CircularProgress } from "@mui/material";
+import { ClubRegistrationWizard } from "@/components/club-registration/ClubRegistrationWizard";
+import { useAuth } from "@/hooks/useAuth";
+
+/**
+ * Page d'inscription au club (parcours hybride).
+ *
+ * Le formulaire est utilisable en mode anonyme (sauvegarde locale du brouillon)
+ * ainsi qu'en mode connecté. La connexion ne devient obligatoire qu'au moment
+ * de l'envoi du dossier au club (livré en PR 2).
+ *
+ * Les actions liées au compte (avatar, déconnexion, connexion) sont gérées
+ * globalement par le header dans `Layout.tsx`.
+ */
+export default function ClubInscriptionPage() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: { xs: 2, sm: 3 }, maxWidth: 960, mx: "auto" }}>
+      <ClubRegistrationWizard accountEmail={user?.email ?? null} />
+    </Box>
+  );
+}

--- a/src/app/club/page.tsx
+++ b/src/app/club/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+/** Évite une 404 si seul le préfixe /club est ouvert. */
+export default function ClubIndexPage() {
+  redirect("/club/inscription");
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -22,6 +22,7 @@ import {
   Assignment,
   PlaylistAddCheck,
   Home,
+  HowToReg,
 } from "@mui/icons-material";
 import { useAuth } from "@/hooks/useAuth";
 import Link from "next/link";
@@ -56,10 +57,20 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
           href: "/joueur",
           icon: <Home />,
         },
+        {
+          label: "Inscription club",
+          href: "/club/inscription",
+          icon: <HowToReg />,
+        },
       ];
     }
 
     const items: NavigationItem[] = [
+      {
+        label: "Inscription club",
+        href: "/club/inscription",
+        icon: <HowToReg />,
+      },
       { label: "Joueurs", href: "/joueurs", icon: <Person /> },
       { label: "Équipes", href: "/equipes", icon: <Groups /> },
       { label: "Disponibilités", href: "/disponibilites", icon: <Event /> },

--- a/src/components/club-registration/AccountEmailTransparencyBanner.tsx
+++ b/src/components/club-registration/AccountEmailTransparencyBanner.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Alert, Stack, Typography } from "@mui/material";
+
+type Props = {
+  /** Email du compte connecté, ou null en mode anonyme. */
+  accountEmail: string | null;
+};
+
+/**
+ * Bandeau persistant qui explique à l'utilisateur ce qui sera fait
+ * de l'adresse e-mail de son compte, en mode anonyme et connecté.
+ */
+export function AccountEmailTransparencyBanner({ accountEmail }: Props) {
+  return (
+    <Alert severity="info" variant="outlined">
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">
+          Comment votre adresse e-mail est utilisée
+        </Typography>
+        {accountEmail ? (
+          <Typography variant="body2">
+            Vous êtes connecté(e) en tant que <strong>{accountEmail}</strong>. Cette adresse
+            sera enregistrée dans le dossier comme adresse du soumettant et servira au club
+            pour le suivi de cette inscription.
+          </Typography>
+        ) : (
+          <Typography variant="body2">
+            Au moment d&apos;envoyer votre demande, vous serez invité(e) à vous connecter ou à
+            créer un compte. L&apos;adresse e-mail de ce compte sera enregistrée dans le
+            dossier comme adresse du soumettant.
+          </Typography>
+        )}
+        <Typography variant="caption" color="text.secondary">
+          Les e-mails de l&apos;adhérent et des représentants légaux sont distincts et se
+          renseignent dans le formulaire ci-dessous.
+        </Typography>
+      </Stack>
+    </Alert>
+  );
+}

--- a/src/components/club-registration/AddressBanSearch.tsx
+++ b/src/components/club-registration/AddressBanSearch.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Autocomplete, TextField, Typography } from "@mui/material";
+import type { HTMLAttributes } from "react";
+import type { BanFeature, ParsedBanAddress } from "@/lib/geocoding/ban";
+import { banFeatureToParsedAddress } from "@/lib/geocoding/ban";
+import { filterBanFeaturesByQuery } from "@/lib/geocoding/ban-query-filter";
+
+type Props = {
+  onAddressSelected: (a: { addressLine1: string; postalCode: string; city: string }) => void;
+  /** Libellé visible du champ (accessibilité) */
+  label?: string;
+  placeholder?: string;
+  /** Texte d’aide sous le champ (FormHelperText) */
+  helperText?: string;
+  disabled?: boolean;
+};
+
+const DEFAULT_LABEL = "Rechercher votre adresse";
+const DEFAULT_PLACEHOLDER = "Ex. 12 rue Victor Hugo, Paris";
+
+export function AddressBanSearch({
+  onAddressSelected,
+  label = DEFAULT_LABEL,
+  placeholder = DEFAULT_PLACEHOLDER,
+  helperText,
+  disabled = false,
+}: Props) {
+  const [input, setInput] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [options, setOptions] = useState<ParsedBanAddress[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(input), 350);
+    return () => clearTimeout(t);
+  }, [input]);
+
+  useEffect(() => {
+    if (debounced.length < 3) {
+      setOptions([]);
+      setLoadError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/geocode/ban?q=${encodeURIComponent(debounced)}`,
+          { credentials: "include" }
+        );
+        const data = (await res.json()) as { features?: BanFeature[]; error?: string };
+        if (!res.ok) {
+          if (!cancelled) {
+            setOptions([]);
+            setLoadError(data.error ?? "Recherche impossible");
+          }
+          return;
+        }
+        const raw = data.features ?? [];
+        const features = filterBanFeaturesByQuery(debounced, raw);
+        const parsed = features
+          .map((f, i) => banFeatureToParsedAddress(f, i))
+          .filter((x): x is ParsedBanAddress => x !== null)
+          .map((p, rowIndex) => ({
+            ...p,
+            /* Clé liste React : garantit l’unicité même si la BAN renvoie le même libellé deux fois */
+            optionId: `r${rowIndex}-${p.optionId}`,
+          }));
+        if (!cancelled) {
+          setOptions(parsed);
+        }
+      } catch {
+        if (!cancelled) {
+          setOptions([]);
+          setLoadError("Recherche impossible");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [debounced]);
+
+  return (
+    <div>
+      <Autocomplete
+        key={resetKey}
+        disabled={disabled}
+        options={options}
+        getOptionLabel={(o) => o.label}
+        getOptionKey={(option) => option.optionId}
+        isOptionEqualToValue={(a, b) => a.optionId === b.optionId}
+        renderOption={(props, option) => {
+          const { key, ...rest } = props as HTMLAttributes<HTMLLIElement> & {
+            key: string;
+          };
+          return (
+            <li key={key} {...rest}>
+              {option.label}
+            </li>
+          );
+        }}
+        filterOptions={(x) => x}
+        inputValue={input}
+        onInputChange={(_, value, reason) => {
+          if (reason === "input" || reason === "clear") {
+            setInput(value);
+          }
+        }}
+        value={null}
+        onChange={(_, v) => {
+          if (v) {
+            onAddressSelected({
+              addressLine1: v.addressLine1,
+              postalCode: v.postalCode,
+              city: v.city,
+            });
+            setInput("");
+            setResetKey((k) => k + 1);
+          }
+        }}
+        loading={loading}
+        noOptionsText={
+          debounced.length < 3
+            ? "Au moins 3 caractères"
+            : loading
+              ? "Recherche…"
+              : "Aucun résultat"
+        }
+        renderInput={(params) => {
+          const { size, InputLabelProps, inputProps, ...restParams } = params;
+          return (
+            <TextField
+              {...restParams}
+              inputProps={{
+                ...inputProps,
+                name: "clubRegistrationAddressSearch",
+                autoComplete: "off",
+              }}
+              size={size ?? "medium"}
+              label={label}
+              placeholder={placeholder}
+              helperText={helperText}
+              // @ts-expect-error InputLabelProps types mismatch from Autocomplete
+              InputLabelProps={InputLabelProps}
+            />
+          );
+        }}
+      />
+      {loadError ? (
+        <Typography variant="caption" color="error" sx={{ display: "block", mt: 0.5 }}>
+          {loadError}
+        </Typography>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  Stack,
+  Step,
+  StepButton,
+  Stepper,
+  Typography,
+} from "@mui/material";
+import { isValidFrenchPhoneSurface } from "@/lib/club-registration/phone-fr";
+import type { ClubRegistrationPayload } from "@/lib/club-registration/schema";
+import { clubRegistrationPayloadSchema } from "@/lib/club-registration/schema";
+import { isMinorAt } from "@/lib/club-registration/age";
+import type { RegistrationDraft } from "./registration-defaults";
+import { IdentityStep } from "./IdentityStep";
+import { SectionSlotsStep } from "./SectionSlotsStep";
+import { MedicalFamilyStep } from "./MedicalFamilyStep";
+import { LegalCompetitorStep } from "./LegalCompetitorStep";
+import { RecapStep } from "./RecapStep";
+import { useRegistrationDraft } from "./useRegistrationDraft";
+import { useRegistrationDraftStorage } from "./useRegistrationDraftStorage";
+import { DraftStorageDisclosure } from "./DraftStorageDisclosure";
+
+const STEPS = [
+  "Identité et coordonnées",
+  "Sections et créneaux",
+  "Certificat et aides",
+  "Consentements et compétition",
+  "Récapitulatif",
+];
+
+const STEPS_SHORT = ["Identité", "Sections", "Médical", "Autorisations", "Récap"];
+
+const SUBMIT_ENABLED = process.env.NEXT_PUBLIC_HYBRID_SUBMIT_ENABLED === "true";
+
+function validateStep(activeStep: number, draft: RegistrationDraft): string | null {
+  if (activeStep === 0) {
+    if (!draft.firstName.trim()) return "Indiquez le prénom de l’adhérent.";
+    if (!draft.lastName.trim()) return "Indiquez le nom de l’adhérent.";
+    if (!draft.birthCity.trim()) return "Indiquez la ville de naissance.";
+    if (!draft.birthDate) return "Indiquez la date de naissance.";
+
+    const minor = isMinorAt(draft.birthDate);
+    if (minor && draft.adherentRole === "self") {
+      return "La date de naissance correspond à un mineur : passez en mode « mineur dont je suis le représentant légal ».";
+    }
+
+    if (!draft.adherentPhonePrimary.trim()) return "Indiquez un téléphone principal.";
+    if (!isValidFrenchPhoneSurface(draft.adherentPhonePrimary)) {
+      return "Le téléphone principal doit être un numéro français valide (10 chiffres ou +33).";
+    }
+    const sec = draft.adherentPhoneSecondary?.trim();
+    if (sec && !isValidFrenchPhoneSurface(sec)) {
+      return "Le téléphone secondaire doit être un numéro français valide.";
+    }
+
+    if (draft.adherentEmail && draft.adherentEmail.trim() !== "") {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(draft.adherentEmail.trim())) {
+        return "L’adresse e-mail de l’adhérent est invalide.";
+      }
+    }
+
+    const addr1 = draft.addressLine1.trim();
+    const pc = draft.postalCode.trim();
+    const city = draft.city.trim();
+    if (!addr1 || !pc || !city) {
+      return "Veuillez sélectionner une adresse ou saisir l’adresse manuellement.";
+    }
+    if (!/^[0-9]{5}$/.test(pc)) {
+      return "Code postal français à 5 chiffres.";
+    }
+
+    if (draft.adherentRole === "minor_dependent" && draft.representatives.length === 0) {
+      return "Au moins un représentant légal est obligatoire pour l’inscription d’un mineur.";
+    }
+
+    for (let i = 0; i < draft.representatives.length; i++) {
+      const r = draft.representatives[i];
+      const isFirstRequired = draft.adherentRole === "minor_dependent" && i === 0;
+      if (isFirstRequired) {
+        if (!r.firstName.trim() || !r.lastName.trim()) {
+          return `Représentant ${i + 1} : prénom et nom obligatoires.`;
+        }
+        if (!r.email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(r.email.trim())) {
+          return `Représentant ${i + 1} : adresse e-mail invalide.`;
+        }
+        if (!r.phone.trim() || !isValidFrenchPhoneSurface(r.phone)) {
+          return `Représentant ${i + 1} : téléphone invalide.`;
+        }
+      } else {
+        // Représentant optionnel : si l'utilisateur a commencé à le remplir, on contrôle quand même
+        if (
+          r.firstName.trim() ||
+          r.lastName.trim() ||
+          r.email.trim() ||
+          r.phone.trim()
+        ) {
+          if (!r.firstName.trim() || !r.lastName.trim()) {
+            return `Représentant ${i + 1} : prénom et nom obligatoires si vous le renseignez.`;
+          }
+          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(r.email.trim())) {
+            return `Représentant ${i + 1} : adresse e-mail invalide.`;
+          }
+          if (!isValidFrenchPhoneSurface(r.phone)) {
+            return `Représentant ${i + 1} : téléphone invalide.`;
+          }
+        }
+      }
+    }
+
+    if (draft.representatives.length === 2) {
+      const a = draft.representatives[0].email.trim().toLowerCase();
+      const b = draft.representatives[1].email.trim().toLowerCase();
+      if (a && b && a === b) {
+        return "Les deux représentants doivent avoir des adresses e-mail différentes.";
+      }
+    }
+  }
+  if (activeStep === 1) {
+    if (draft.slotIds.length === 0) return "Sélectionnez au moins un créneau.";
+  }
+  if (activeStep === 3) {
+    if (!draft.rulesAccepted) return "Vous devez accepter le règlement intérieur pour continuer.";
+    if (draft.wantsCompetitorExtras && !draft.competitionJerseySize) {
+      return "Indiquez une taille de maillot pour la section compétiteur.";
+    }
+  }
+  return null;
+}
+
+/** Permet d’accéder à l’étape cible : retour libre ; étapes suivantes seulement si les étapes intermédiaires sont valides. */
+function canNavigateToStep(targetIndex: number, activeStep: number, draft: RegistrationDraft): boolean {
+  if (targetIndex <= activeStep) return true;
+  for (let s = activeStep; s < targetIndex; s++) {
+    if (validateStep(s, draft) !== null) return false;
+  }
+  return true;
+}
+
+type Props = {
+  /** Email du compte connecté, ou null en mode anonyme. */
+  accountEmail: string | null;
+};
+
+export function ClubRegistrationWizard({ accountEmail }: Props) {
+  const { draft, actions } = useRegistrationDraft();
+  const storage = useRegistrationDraftStorage();
+  const [activeStep, setActiveStep] = useState(0);
+  const [hydrating, setHydrating] = useState(true);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[] | undefined> | null>(null);
+  const hasHydratedRef = useRef(false);
+
+  /* Hydratation au mount : local-first, fallback éventuel sur le draft serveur (lecture seule pour l'instant). */
+  const storageLoad = storage.load;
+  const hydrate = actions.hydrate;
+  useEffect(() => {
+    if (hasHydratedRef.current) return;
+    hasHydratedRef.current = true;
+
+    const local = storageLoad();
+    if (local) {
+      hydrate(local);
+    }
+    setHydrating(false);
+  }, [hydrate, storageLoad]);
+
+  /**
+   * Auto-save à chaque changement de draft. On dépend uniquement de la fonction `save`
+   * (stable via `useCallback` dans le hook) pour éviter la boucle de re-render qui
+   * faisait clignoter le bandeau de statut à chaque frappe.
+   */
+  const storageSave = storage.save;
+  useEffect(() => {
+    if (hydrating) return;
+    storageSave(draft);
+  }, [draft, hydrating, storageSave]);
+
+  const handleNext = () => {
+    setSubmitError(null);
+    const err = validateStep(activeStep, draft);
+    if (err) {
+      setSubmitError(err);
+      return;
+    }
+    setActiveStep((s) => Math.min(s + 1, STEPS.length - 1));
+  };
+
+  const handleBack = () => {
+    setSubmitError(null);
+    setActiveStep((s) => Math.max(s - 1, 0));
+  };
+
+  const handleGoToStep = useCallback(
+    (to: number) => {
+      setSubmitError(null);
+      setFieldErrors(null);
+      if (to === activeStep) return;
+      if (to < activeStep) {
+        setActiveStep(to);
+        return;
+      }
+      for (let s = activeStep; s < to; s++) {
+        const err = validateStep(s, draft);
+        if (err) {
+          setSubmitError(err);
+          setActiveStep(s);
+          return;
+        }
+      }
+      setActiveStep(to);
+    },
+    [activeStep, draft]
+  );
+
+  const buildPayload = (): ClubRegistrationPayload => {
+    /* Le toggle `rulesAccepted` est interne à l'UI ; côté schéma on attend `internalRulesAccepted = true`. */
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+    const { rulesAccepted, ...rest } = draft;
+    const payload: ClubRegistrationPayload = {
+      ...rest,
+      internalRulesAccepted: true as const,
+      competitionJerseySize:
+        draft.wantsCompetitorExtras && draft.competitionJerseySize
+          ? draft.competitionJerseySize
+          : undefined,
+      competitionIds: draft.wantsCompetitorExtras ? draft.competitionIds : [],
+    };
+    return payload;
+  };
+
+  /**
+   * Soumission désactivée tant que le feature flag est off.
+   * En PR 2, ce handler ouvrira l'AuthDialog en mode anonyme ou postera directement.
+   */
+  const handleSubmit = async () => {
+    setSubmitError(null);
+    setFieldErrors(null);
+
+    const err = validateStep(3, draft);
+    if (err) {
+      setSubmitError(err);
+      setActiveStep(3);
+      return;
+    }
+
+    const payload = buildPayload();
+    const parsed = clubRegistrationPayloadSchema.safeParse(payload);
+    if (!parsed.success) {
+      setFieldErrors(parsed.error.flatten().fieldErrors as Record<string, string[] | undefined>);
+      setSubmitError("Certaines informations sont invalides ou incomplètes.");
+      return;
+    }
+
+    if (!SUBMIT_ENABLED) {
+      setSubmitError(
+        "La soumission en ligne sera disponible prochainement. Vos informations sont enregistrées localement."
+      );
+      return;
+    }
+
+    if (!accountEmail) {
+      setSubmitError(
+        "La soumission nécessite d’être connecté. La connexion intégrée arrive dans la prochaine livraison."
+      );
+      return;
+    }
+
+    /* PR 2 : POST /api/club/registration */
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="h4" component="h1">
+        Inscription au club
+      </Typography>
+      <Typography variant="body1" color="text.secondary">
+        Préparez votre dossier d’inscription en quelques étapes. Vous pourrez vous connecter
+        ou créer un compte juste avant l’envoi.
+      </Typography>
+
+      {submitError && <Alert severity="error">{submitError}</Alert>}
+      {fieldErrors && Object.keys(fieldErrors).length > 0 && (
+        <Alert severity="error">
+          Vérifiez les champs signalés par le serveur. Détail technique disponible pour le support.
+        </Alert>
+      )}
+
+      <Stepper
+        activeStep={activeStep}
+        nonLinear
+        alternativeLabel
+        sx={{ display: { xs: "none", md: "flex" } }}
+      >
+        {STEPS.map((label, index) => (
+          <Step key={label} completed={index < activeStep}>
+            <StepButton
+              color="inherit"
+              disabled={!canNavigateToStep(index, activeStep, draft)}
+              onClick={() => handleGoToStep(index)}
+            >
+              {label}
+            </StepButton>
+          </Step>
+        ))}
+      </Stepper>
+
+      <Stack spacing={1} sx={{ display: { md: "none" } }}>
+        <Typography variant="subtitle2" color="text.secondary">
+          Étape {activeStep + 1} / {STEPS.length} — {STEPS[activeStep]}
+        </Typography>
+        <Stack direction="row" flexWrap="wrap" useFlexGap sx={{ gap: 1 }}>
+          {STEPS.map((label, index) => (
+            <Button
+              key={label}
+              size="small"
+              variant={activeStep === index ? "contained" : "outlined"}
+              disabled={!canNavigateToStep(index, activeStep, draft)}
+              onClick={() => handleGoToStep(index)}
+              aria-current={activeStep === index ? "step" : undefined}
+            >
+              {index + 1}. {STEPS_SHORT[index] ?? label}
+            </Button>
+          ))}
+        </Stack>
+      </Stack>
+
+      <Card variant="outlined">
+        <CardContent>
+          {activeStep === 0 && (
+            <IdentityStep
+              draft={draft}
+              onPatch={actions.patchFields}
+              onSetAdherentRole={actions.setAdherentRole}
+              onSetSex={actions.setSex}
+              onAddRepresentative={actions.addRepresentative}
+              onUpdateRepresentative={actions.updateRepresentative}
+              onRemoveRepresentative={actions.removeRepresentative}
+            />
+          )}
+          {activeStep === 1 && <SectionSlotsStep draft={draft} onChange={actions.patchFields} />}
+          {activeStep === 2 && <MedicalFamilyStep draft={draft} onChange={actions.patchFields} />}
+          {activeStep === 3 && <LegalCompetitorStep draft={draft} onChange={actions.patchFields} />}
+          {activeStep === 4 && (
+            <RecapStep
+              draft={draft}
+              accountEmail={accountEmail}
+              onEditStep={(idx) => setActiveStep(idx)}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Stack
+        direction="row"
+        spacing={2}
+        justifyContent={activeStep === 0 ? "flex-end" : "space-between"}
+      >
+        {activeStep > 0 ? (
+          <Button onClick={handleBack}>Retour</Button>
+        ) : null}
+        {activeStep < STEPS.length - 1 ? (
+          <Button variant="contained" onClick={handleNext}>
+            Continuer
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!SUBMIT_ENABLED}
+          >
+            {SUBMIT_ENABLED
+              ? accountEmail
+                ? "Envoyer ma demande au club"
+                : "Se connecter pour envoyer"
+              : "Soumission disponible prochainement"}
+          </Button>
+        )}
+      </Stack>
+
+      <DraftStorageDisclosure
+        status={storage.status}
+        isDisabled={storage.isDisabled}
+        lastSavedAt={storage.lastSavedAt}
+        onDisable={storage.disable}
+        onEnable={storage.enable}
+        onClear={() => {
+          storage.clear();
+          actions.reset();
+          setActiveStep(0);
+        }}
+      />
+    </Stack>
+  );
+}

--- a/src/components/club-registration/DraftStorageDisclosure.tsx
+++ b/src/components/club-registration/DraftStorageDisclosure.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Link as MuiLink,
+  Popover,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { DraftStorageStatus } from "./useRegistrationDraftStorage";
+
+type Props = {
+  status: DraftStorageStatus;
+  isDisabled: boolean;
+  lastSavedAt: Date | null;
+  onDisable: () => void;
+  onEnable: () => void;
+  onClear: () => void;
+};
+
+function formatRelative(date: Date | null, now: number): string {
+  if (!date) return "";
+  const diffSec = Math.max(0, Math.round((now - date.getTime()) / 1000));
+  if (diffSec < 5) return "à l’instant";
+  if (diffSec < 60) return `il y a ${diffSec} s`;
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `il y a ${diffMin} min`;
+  return date.toLocaleString();
+}
+
+/**
+ * Pied de wizard discret pour la sauvegarde locale du brouillon.
+ *
+ * Cadre RGPD : un brouillon enregistré côté navigateur pour permettre à l'utilisateur
+ * de retrouver sa propre saisie relève du stockage strictement nécessaire au service
+ * que l'utilisateur a demandé (CNIL — lignes directrices sur les cookies et traceurs,
+ * art. 82 LCEN). Une information claire suffit, sans consentement préalable.
+ *
+ * On affiche uniquement l'horodatage du dernier enregistrement réussi (rafraîchi toutes
+ * les 30 s) pour éviter le clignotement à la saisie. Un lien "En savoir plus" ouvre un
+ * Popover avec le détail. Effacer / Désactiver restent toujours accessibles.
+ */
+export function DraftStorageDisclosure({
+  status,
+  isDisabled,
+  lastSavedAt,
+  onDisable,
+  onEnable,
+  onClear,
+}: Props) {
+  const [now, setNow] = useState<number>(() => Date.now());
+  const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
+  const infoButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (isDisabled) return;
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, [isDisabled]);
+
+  const openPopover = () => setPopoverAnchor(infoButtonRef.current);
+  const closePopover = () => setPopoverAnchor(null);
+
+  const statusLabel = isDisabled
+    ? "Sauvegarde locale désactivée"
+    : status === "saved" && lastSavedAt
+      ? `Brouillon enregistré localement ${formatRelative(lastSavedAt, now)}`
+      : "Aucun brouillon enregistré pour le moment";
+
+  return (
+    <Box
+      role="contentinfo"
+      sx={{
+        py: 1.5,
+        borderTop: 1,
+        borderColor: "divider",
+        color: "text.secondary",
+      }}
+    >
+      <Stack
+        direction="row"
+        spacing={1.5}
+        flexWrap="wrap"
+        useFlexGap
+        alignItems="center"
+        sx={{ fontSize: "0.8rem" }}
+      >
+        <Typography variant="caption" component="span">
+          {statusLabel}
+        </Typography>
+        <Typography variant="caption" component="span" aria-hidden>
+          ·
+        </Typography>
+        <MuiLink
+          ref={infoButtonRef}
+          component="button"
+          type="button"
+          variant="caption"
+          onClick={openPopover}
+          underline="hover"
+        >
+          En savoir plus
+        </MuiLink>
+
+        {isDisabled ? (
+          <>
+            <Typography variant="caption" component="span" aria-hidden>
+              ·
+            </Typography>
+            <MuiLink
+              component="button"
+              type="button"
+              variant="caption"
+              onClick={onEnable}
+              underline="hover"
+            >
+              Réactiver la sauvegarde
+            </MuiLink>
+          </>
+        ) : (
+          <>
+            <Typography variant="caption" component="span" aria-hidden>
+              ·
+            </Typography>
+            <MuiLink
+              component="button"
+              type="button"
+              variant="caption"
+              onClick={onClear}
+              underline="hover"
+            >
+              Effacer mon brouillon
+            </MuiLink>
+            <Typography variant="caption" component="span" aria-hidden>
+              ·
+            </Typography>
+            <MuiLink
+              component="button"
+              type="button"
+              variant="caption"
+              color="warning.main"
+              onClick={onDisable}
+              underline="hover"
+            >
+              Désactiver
+            </MuiLink>
+          </>
+        )}
+      </Stack>
+
+      <Popover
+        open={Boolean(popoverAnchor)}
+        anchorEl={popoverAnchor}
+        onClose={closePopover}
+        anchorOrigin={{ vertical: "top", horizontal: "left" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+        slotProps={{ paper: { sx: { maxWidth: 420, p: 2 } } }}
+      >
+        <Stack spacing={1}>
+          <Typography variant="subtitle2">Sauvegarde locale du brouillon</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Les informations que vous saisissez sont enregistrées dans la mémoire de ce
+            navigateur pour vous éviter de tout retaper si vous fermez l’onglet.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Aucune donnée n’est envoyée au serveur tant que vous n’avez pas cliqué sur
+            « Envoyer ma demande au club ». Le brouillon est supprimé localement après
+            envoi de votre dossier.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Vous pouvez à tout moment effacer votre brouillon ou désactiver complètement
+            cette sauvegarde locale via les liens ci-dessous.
+          </Typography>
+          <Box sx={{ pt: 0.5 }}>
+            <Button size="small" variant="text" onClick={closePopover}>
+              Fermer
+            </Button>
+          </Box>
+        </Stack>
+      </Popover>
+    </Box>
+  );
+}

--- a/src/components/club-registration/IdentityStep.tsx
+++ b/src/components/club-registration/IdentityStep.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import {
+  Alert,
+  Button,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  type SelectChangeEvent,
+} from "@mui/material";
+import {
+  extractNationalDigitsForMask,
+  formatFrenchPhoneMask,
+  isValidFrenchPhoneSurface,
+  toFrenchPhoneMaskedDisplay,
+} from "@/lib/club-registration/phone-fr";
+import { isMinorAt } from "@/lib/club-registration/age";
+import { getDevIdentityFixture } from "./dev-identity-fixture";
+import { PostalAddressSection } from "./PostalAddressSection";
+import { RepresentativesBlock } from "./RepresentativesBlock";
+import type { RegistrationDraft, Representative } from "./registration-defaults";
+
+const IS_DEV = process.env.NODE_ENV === "development";
+
+type Props = {
+  draft: RegistrationDraft;
+  onPatch: (patch: Partial<RegistrationDraft>) => void;
+  onSetAdherentRole: (role: RegistrationDraft["adherentRole"]) => void;
+  onSetSex: (sex: RegistrationDraft["sex"]) => void;
+  onAddRepresentative: () => void;
+  onUpdateRepresentative: (index: number, patch: Partial<Representative>) => void;
+  onRemoveRepresentative: (index: number) => void;
+};
+
+export function IdentityStep({
+  draft,
+  onPatch,
+  onSetAdherentRole,
+  onSetSex,
+  onAddRepresentative,
+  onUpdateRepresentative,
+  onRemoveRepresentative,
+}: Props) {
+  const primaryInvalid =
+    draft.adherentPhonePrimary.trim() !== "" &&
+    !isValidFrenchPhoneSurface(draft.adherentPhonePrimary);
+  const secondaryInvalid =
+    (draft.adherentPhoneSecondary ?? "").trim() !== "" &&
+    !isValidFrenchPhoneSurface(draft.adherentPhoneSecondary ?? "");
+
+  const handlePhoneChange =
+    (field: "adherentPhonePrimary" | "adherentPhoneSecondary") =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const digits = extractNationalDigitsForMask(e.target.value);
+      const masked = formatFrenchPhoneMask(digits);
+      onPatch({ [field]: masked } as Partial<RegistrationDraft>);
+    };
+
+  const handleSex = (e: SelectChangeEvent<string>) => {
+    onSetSex(e.target.value as RegistrationDraft["sex"]);
+  };
+
+  const handleAdherentRole = (e: ChangeEvent<HTMLInputElement>) => {
+    onSetAdherentRole(e.target.value as RegistrationDraft["adherentRole"]);
+  };
+
+  /* Représentants légaux : uniquement pour les inscriptions de mineurs.
+     Pour un adulte (self majeur ou other_adult), pas de bloc. */
+  const minorByDob = isMinorAt(draft.birthDate);
+  const showRepresentatives =
+    draft.adherentRole === "minor_dependent" || minorByDob;
+
+  return (
+    <Stack spacing={3}>
+      <FormControl component="fieldset" required>
+        <Typography variant="subtitle2" gutterBottom id="adherent-role-label">
+          Cette inscription concerne :
+        </Typography>
+        <RadioGroup
+          aria-labelledby="adherent-role-label"
+          value={draft.adherentRole}
+          onChange={handleAdherentRole}
+        >
+          <FormControlLabel value="self" control={<Radio />} label="Moi-même" />
+          <FormControlLabel
+            value="minor_dependent"
+            control={<Radio />}
+            label="Un mineur dont je suis le représentant légal"
+          />
+          <FormControlLabel
+            value="other_adult"
+            control={<Radio />}
+            label="Un autre adulte (cas particulier : tutelle, etc.)"
+          />
+        </RadioGroup>
+      </FormControl>
+
+      {minorByDob && draft.adherentRole === "self" ? (
+        <Alert severity="warning">
+          La date de naissance saisie correspond à un mineur. Sélectionnez plutôt
+          « un mineur dont je suis le représentant légal ».
+        </Alert>
+      ) : null}
+
+      {IS_DEV ? (
+        <Button
+          type="button"
+          variant="text"
+          size="small"
+          aria-label="Remplir le formulaire avec des données de test (développement uniquement)"
+          onClick={() => onPatch(getDevIdentityFixture())}
+          sx={{
+            alignSelf: "flex-start",
+            py: 0,
+            minHeight: 28,
+            fontSize: "0.7rem",
+            color: "text.disabled",
+            textTransform: "none",
+            "&:hover": { color: "text.secondary", backgroundColor: "action.hover" },
+          }}
+        >
+          Remplir (dev)
+        </Button>
+      ) : null}
+
+      <Typography variant="subtitle1" component="h3">
+        Identité de l’adhérent
+      </Typography>
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+        <TextField
+          required
+          label="Prénom de l’adhérent"
+          value={draft.firstName}
+          onChange={(e) => onPatch({ firstName: e.target.value })}
+          fullWidth
+          autoComplete="given-name"
+        />
+        <TextField
+          required
+          label="Nom de l’adhérent"
+          value={draft.lastName}
+          onChange={(e) => onPatch({ lastName: e.target.value })}
+          fullWidth
+          autoComplete="family-name"
+        />
+      </Stack>
+
+      <FormControl fullWidth required>
+        <InputLabel id="sex-label">Sexe</InputLabel>
+        <Select labelId="sex-label" label="Sexe" value={draft.sex} onChange={handleSex}>
+          <MenuItem value="female">Femme</MenuItem>
+          <MenuItem value="male">Homme</MenuItem>
+          <MenuItem value="other">Autre / Ne pas préciser</MenuItem>
+        </Select>
+      </FormControl>
+
+      <TextField
+        required
+        label="Ville de naissance"
+        value={draft.birthCity}
+        onChange={(e) => onPatch({ birthCity: e.target.value })}
+        fullWidth
+        name="clubRegistrationBirthCity"
+        autoComplete="section-club-birth address-level2"
+      />
+
+      <TextField
+        required
+        label="Date de naissance"
+        type="date"
+        value={draft.birthDate}
+        onChange={(e) => onPatch({ birthDate: e.target.value })}
+        fullWidth
+        name="clubRegistrationBirthDate"
+        autoComplete="section-club-birth bday"
+        slotProps={{ inputLabel: { shrink: true } }}
+        inputProps={{
+          min: "1900-01-01",
+          max: new Date().toISOString().slice(0, 10),
+        }}
+      />
+
+      <Typography variant="subtitle1" component="h3">
+        Contact de l’adhérent
+      </Typography>
+
+      <TextField
+        label="E-mail de l’adhérent (optionnel)"
+        type="email"
+        value={draft.adherentEmail ?? ""}
+        onChange={(e) => onPatch({ adherentEmail: e.target.value })}
+        fullWidth
+        autoComplete="email"
+        helperText="Si l’adhérent a sa propre adresse (ado, adulte) — sinon laissez vide."
+      />
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+        <TextField
+          required
+          label="Téléphone principal de l’adhérent"
+          value={toFrenchPhoneMaskedDisplay(draft.adherentPhonePrimary)}
+          onChange={handlePhoneChange("adherentPhonePrimary")}
+          fullWidth
+          autoComplete="tel-national"
+          placeholder="06 34 44 55 33"
+          inputMode="numeric"
+          error={primaryInvalid}
+          helperText={primaryInvalid ? "Numéro invalide" : undefined}
+        />
+        <TextField
+          label="Téléphone secondaire (optionnel)"
+          value={toFrenchPhoneMaskedDisplay(draft.adherentPhoneSecondary ?? "")}
+          onChange={handlePhoneChange("adherentPhoneSecondary")}
+          fullWidth
+          autoComplete="tel-national"
+          placeholder="06 34 44 55 33"
+          inputMode="numeric"
+          error={secondaryInvalid}
+          helperText={secondaryInvalid ? "Numéro invalide" : undefined}
+        />
+      </Stack>
+
+      <PostalAddressSection draft={draft} onChange={onPatch} />
+
+      {showRepresentatives ? (
+        <Stack spacing={1}>
+          <Typography variant="subtitle1" component="h3">
+            Représentants légaux
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Un représentant légal est obligatoire pour l’inscription d’un mineur. Vous
+            pouvez en ajouter un second (parent 2, tuteur).
+          </Typography>
+          <RepresentativesBlock
+            representatives={draft.representatives}
+            firstIsRequired
+            onAdd={onAddRepresentative}
+            onUpdate={onUpdateRepresentative}
+            onRemove={onRemoveRepresentative}
+          />
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/components/club-registration/LegalCompetitorStep.tsx
+++ b/src/components/club-registration/LegalCompetitorStep.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  Switch,
+  Typography,
+} from "@mui/material";
+import {
+  COMPETITION_OPTIONS,
+  CLUB_REGISTRATION_EXTERNAL_LINKS,
+  JERSEY_SIZES,
+} from "@/lib/club-registration/constants";
+import type { RegistrationDraft } from "./registration-defaults";
+
+type Props = {
+  draft: RegistrationDraft;
+  onChange: (patch: Partial<RegistrationDraft>) => void;
+};
+
+export function LegalCompetitorStep({ draft, onChange }: Props) {
+  const toggleCompetition = (id: (typeof COMPETITION_OPTIONS)[number]["id"]) => {
+    const set = new Set(draft.competitionIds);
+    if (set.has(id)) {
+      set.delete(id);
+    } else {
+      set.add(id);
+    }
+    onChange({ competitionIds: Array.from(set) });
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="subtitle1">Image et communication</Typography>
+      <Typography variant="body2" color="text.secondary">
+        Le club diffuse informations et photos sur{" "}
+        <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.siteClub} target="_blank" rel="noreferrer">
+          sqyping.fr
+        </a>{" "}
+        et les réseaux sociaux.
+      </Typography>
+      <FormControl component="fieldset">
+        <Typography variant="subtitle2" gutterBottom>
+          Acceptez-vous une diffusion d&apos;images à caractère sportif vous concernant (ou votre
+          enfant mineur) ?
+        </Typography>
+        <RadioGroup
+          value={draft.photoConsent}
+          onChange={(e) =>
+            onChange({
+              photoConsent: e.target.value as RegistrationDraft["photoConsent"],
+            })
+          }
+        >
+          <FormControlLabel value="accept" control={<Radio />} label="J&apos;accepte" />
+          <FormControlLabel value="refuse" control={<Radio />} label="Je refuse" />
+        </RadioGroup>
+      </FormControl>
+
+      <Typography variant="subtitle1">Mineurs — autorisations</Typography>
+      <FormControl component="fieldset">
+        <Typography variant="subtitle2" gutterBottom>
+          Autorisation d&apos;actes médicaux ou chirurgicaux en urgence pour mon enfant mineur (à
+          défaut : adhérent majeur non concerné).
+        </Typography>
+        <RadioGroup
+          value={draft.emergencyMedicalAuthorization}
+          onChange={(e) =>
+            onChange({
+              emergencyMedicalAuthorization: e.target
+                .value as RegistrationDraft["emergencyMedicalAuthorization"],
+            })
+          }
+        >
+          <FormControlLabel value="yes" control={<Radio />} label="Oui" />
+          <FormControlLabel
+            value="not_applicable_adult"
+            control={<Radio />}
+            label="Adhérent majeur — non concerné"
+          />
+        </RadioGroup>
+      </FormControl>
+
+      <FormControl component="fieldset">
+        <Typography variant="subtitle2" gutterBottom>
+          Je m&apos;engage à ce que mon enfant soit pris en charge par le responsable à l&apos;heure
+          des cours (sinon : adhérent majeur non concerné).
+        </Typography>
+        <RadioGroup
+          value={draft.supervisionAcknowledgement}
+          onChange={(e) =>
+            onChange({
+              supervisionAcknowledgement: e.target
+                .value as RegistrationDraft["supervisionAcknowledgement"],
+            })
+          }
+        >
+          <FormControlLabel value="yes" control={<Radio />} label="Oui" />
+          <FormControlLabel
+            value="not_applicable_adult"
+            control={<Radio />}
+            label="Adhérent majeur — non concerné"
+          />
+        </RadioGroup>
+      </FormControl>
+
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={draft.rulesAccepted}
+            onChange={(e) => onChange({ rulesAccepted: e.target.checked })}
+          />
+        }
+        label={
+          <Typography variant="body2" component="span">
+            J&apos;ai lu et j&apos;accepte le{" "}
+            <a
+              href={CLUB_REGISTRATION_EXTERNAL_LINKS.reglementInterieur}
+              target="_blank"
+              rel="noreferrer"
+            >
+              règlement intérieur
+            </a>
+            , et je reconnais que les données nécessaires à la licence sont transmises à la FFTT
+            conformément aux usages du club.
+          </Typography>
+        }
+      />
+
+      <Stack spacing={1}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={draft.wantsCompetitorExtras}
+              onChange={(e) => onChange({ wantsCompetitorExtras: e.target.checked })}
+            />
+          }
+          label="Section compétiteur : taille de maillot et compétitions"
+        />
+
+        {draft.wantsCompetitorExtras && (
+          <>
+            <FormControl fullWidth required={draft.wantsCompetitorExtras}>
+              <InputLabel id="jersey-label">Taille de maillot de compétition</InputLabel>
+              <Select
+                labelId="jersey-label"
+                label="Taille de maillot de compétition"
+                value={draft.competitionJerseySize ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    competitionJerseySize: e.target.value as RegistrationDraft["competitionJerseySize"],
+                  })
+                }
+              >
+                <MenuItem value="">
+                  <em>Choisir…</em>
+                </MenuItem>
+                {JERSEY_SIZES.map((size) => (
+                  <MenuItem key={size} value={size}>
+                    {size}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Typography variant="subtitle2">Compétitions envisagées</Typography>
+            <FormGroup>
+              {COMPETITION_OPTIONS.map((c) => (
+                <FormControlLabel
+                  key={c.id}
+                  control={
+                    <Checkbox
+                      checked={draft.competitionIds.includes(c.id)}
+                      onChange={() => toggleCompetition(c.id)}
+                    />
+                  }
+                  label={c.label}
+                />
+              ))}
+            </FormGroup>
+          </>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/club-registration/MedicalFamilyStep.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import {
+  Alert,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  CLUB_REGISTRATION_EXTERNAL_LINKS,
+  REDUCTION_OPTIONS,
+} from "@/lib/club-registration/constants";
+import type { RegistrationDraft } from "./registration-defaults";
+
+type Props = {
+  draft: RegistrationDraft;
+  onChange: (patch: Partial<RegistrationDraft>) => void;
+};
+
+export function MedicalFamilyStep({ draft, onChange }: Props) {
+  const toggleReduction = (id: (typeof REDUCTION_OPTIONS)[number]["id"]) => {
+    const set = new Set(draft.reductionTypes);
+    if (set.has(id)) {
+      set.delete(id);
+    } else {
+      set.add(id);
+    }
+    onChange({ reductionTypes: Array.from(set) });
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="subtitle1">Certificat médical</Typography>
+      <Typography variant="body2" color="text.secondary">
+        Téléchargez le questionnaire adapté si besoin :{" "}
+        <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMajeur} target="_blank" rel="noreferrer">
+          majeur
+        </a>
+        {" · "}
+        <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMineur} target="_blank" rel="noreferrer">
+          mineur
+        </a>
+        . En cas de certificat à fournir, vous pourrez le transmettre au secrétariat selon les
+        modalités du club.
+      </Typography>
+
+      <FormControl component="fieldset">
+        <RadioGroup
+          value={draft.medicalCertificateDeclaration}
+          onChange={(e) =>
+            onChange({
+              medicalCertificateDeclaration: e.target
+                .value as RegistrationDraft["medicalCertificateDeclaration"],
+            })
+          }
+        >
+          <FormControlLabel
+            value="under_40_all_no"
+            control={<Radio />}
+            label='Moins de 40 ans : j’atteste avoir répondu « Non » à tout le questionnaire médical.'
+          />
+          <FormControlLabel
+            value="over_40_cert_unchanged_all_no"
+            control={<Radio />}
+            label="Plus de 40 ans, certificat dans la même catégorie : j’atteste avoir répondu « Non » au questionnaire."
+          />
+          <FormControlLabel
+            value="questionnaire_yes_certificate_required"
+            control={<Radio />}
+            label='J’ai répondu « Oui » à au moins une question : certificat médical requis.'
+          />
+        </RadioGroup>
+      </FormControl>
+
+      <FormControl fullWidth>
+        <InputLabel id="cert-attestation-label">Attestation d’inscription</InputLabel>
+        <Select
+          labelId="cert-attestation-label"
+          label="Attestation d’inscription"
+          value={draft.wantsRegistrationCertificate ? "yes" : "no"}
+          onChange={(e) =>
+            onChange({ wantsRegistrationCertificate: e.target.value === "yes" })
+          }
+        >
+          <MenuItem value="no">Non</MenuItem>
+          <MenuItem value="yes">Oui</MenuItem>
+        </Select>
+      </FormControl>
+
+      <FormControl component="fieldset">
+        <Typography variant="subtitle2" gutterBottom>
+          Deuxième ou troisième inscription (ou plus) dans la même famille ?
+        </Typography>
+        <RadioGroup
+          value={draft.familyRegistrationOrder}
+          onChange={(e) =>
+            onChange({
+              familyRegistrationOrder: e.target
+                .value as RegistrationDraft["familyRegistrationOrder"],
+            })
+          }
+        >
+          <FormControlLabel value="none" control={<Radio />} label="Non" />
+          <FormControlLabel value="second" control={<Radio />} label="Oui, deuxième" />
+          <FormControlLabel
+            value="third_or_more"
+            control={<Radio />}
+            label="Oui, troisième ou plus"
+          />
+        </RadioGroup>
+      </FormControl>
+
+      <Stack spacing={0.5}>
+        <Typography variant="subtitle2">Réductions éventuelles</Typography>
+        <FormGroup>
+          {REDUCTION_OPTIONS.map((r) => (
+            <FormControlLabel
+              key={r.id}
+              control={
+                <Checkbox
+                  checked={draft.reductionTypes.includes(r.id)}
+                  onChange={() => toggleReduction(r.id)}
+                />
+              }
+              label={r.label}
+            />
+          ))}
+        </FormGroup>
+      </Stack>
+
+      <TextField
+        label="Code Pass Sport (si applicable)"
+        value={draft.passSportCode ?? ""}
+        onChange={(e) => onChange({ passSportCode: e.target.value })}
+        fullWidth
+      />
+
+      {draft.sex === "female" && (
+        <FormControl component="fieldset" required>
+          <Typography variant="subtitle2" gutterBottom>
+            Première inscription féminine au club SQY PING ?
+          </Typography>
+          <RadioGroup
+            value={draft.firstFemaleRegistrationSqy ? "yes" : "no"}
+            onChange={(e) =>
+              onChange({ firstFemaleRegistrationSqy: e.target.value === "yes" })
+            }
+          >
+            <FormControlLabel value="yes" control={<Radio />} label="Oui" />
+            <FormControlLabel value="no" control={<Radio />} label="Non" />
+          </RadioGroup>
+        </FormControl>
+      )}
+
+      <Alert severity="info">
+        Site du club :{" "}
+        <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.siteClub} target="_blank" rel="noreferrer">
+          sqyping.fr
+        </a>
+      </Alert>
+    </Stack>
+  );
+}

--- a/src/components/club-registration/PostalAddressSection.tsx
+++ b/src/components/club-registration/PostalAddressSection.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import Box from "@mui/material/Box";
+import Collapse from "@mui/material/Collapse";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { AddressBanSearch } from "./AddressBanSearch";
+import type { RegistrationDraft } from "./registration-defaults";
+
+type Props = {
+  draft: RegistrationDraft;
+  onChange: (patch: Partial<RegistrationDraft>) => void;
+};
+
+function hasAnyAddressValue(d: RegistrationDraft): boolean {
+  return (
+    d.addressLine1.trim().length > 0 ||
+    d.postalCode.trim().length > 0 ||
+    d.city.trim().length > 0 ||
+    (d.addressLine2 ?? "").trim().length > 0
+  );
+}
+
+export function PostalAddressSection({ draft, onChange }: Props) {
+  const [manualMode, setManualMode] = useState(false);
+  const [filledViaBan, setFilledViaBan] = useState(false);
+
+  const persistedOrEditedAddress = hasAnyAddressValue(draft);
+  const showDetailFields = manualMode || filledViaBan || persistedOrEditedAddress;
+
+  const handleBanSelect = (a: { addressLine1: string; postalCode: string; city: string }) => {
+    onChange({
+      addressLine1: a.addressLine1,
+      postalCode: a.postalCode,
+      city: a.city,
+    });
+    setFilledViaBan(true);
+    setManualMode(false);
+  };
+
+  const handleSwitchToManual = () => {
+    setManualMode(true);
+  };
+
+  const handleSwitchToSearch = () => {
+    setManualMode(false);
+  };
+
+  return (
+    <Stack component="section" spacing={2} aria-labelledby="club-registration-postal-heading">
+      <Typography id="club-registration-postal-heading" variant="subtitle1" component="h3">
+        Adresse postale
+      </Typography>
+
+      {!manualMode ? (
+        <Box>
+          <AddressBanSearch
+            onAddressSelected={handleBanSelect}
+            label="Rechercher votre adresse"
+            placeholder="Ex. 12 rue Victor Hugo, Paris"
+            helperText="Recherchez votre adresse dans la Base Adresse Nationale. Vous pourrez la compléter ensuite."
+          />
+          <Link
+            component="button"
+            type="button"
+            variant="body2"
+            onClick={handleSwitchToManual}
+            sx={{
+              alignSelf: "flex-start",
+              mt: 1,
+              cursor: "pointer",
+              border: 0,
+              background: "none",
+              font: "inherit",
+              textDecoration: "underline",
+            }}
+          >
+            Mon adresse n&apos;apparaît pas — saisir l&apos;adresse manuellement
+          </Link>
+        </Box>
+      ) : (
+        <Stack spacing={1}>
+          <Link
+            component="button"
+            type="button"
+            variant="body2"
+            onClick={handleSwitchToSearch}
+            sx={{
+              alignSelf: "flex-start",
+              cursor: "pointer",
+              border: 0,
+              background: "none",
+              font: "inherit",
+              textDecoration: "underline",
+            }}
+          >
+            Rechercher une adresse officielle
+          </Link>
+        </Stack>
+      )}
+
+      <Collapse in={showDetailFields} timeout={{ enter: 400, exit: 260 }}>
+        <Stack spacing={2} sx={{ pt: 0.5 }}>
+          {filledViaBan && !manualMode ? (
+            <Typography variant="subtitle2" color="text.secondary">
+              Adresse sélectionnée
+            </Typography>
+          ) : null}
+
+          <TextField
+            required
+            label="Rue et numéro"
+            value={draft.addressLine1}
+            onChange={(e) => onChange({ addressLine1: e.target.value })}
+            fullWidth
+            name="clubRegistrationAddressLine1"
+            autoComplete="section-club-residence street-address"
+          />
+          <TextField
+            label="Complément d’adresse"
+            value={draft.addressLine2 ?? ""}
+            onChange={(e) => onChange({ addressLine2: e.target.value })}
+            fullWidth
+            name="clubRegistrationAddressLine2"
+            autoComplete="section-club-residence address-line2"
+            helperText="Étage, bâtiment, résidence, appartement…"
+          />
+
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              required
+              label="Code postal"
+              value={draft.postalCode}
+              onChange={(e) => onChange({ postalCode: e.target.value })}
+              fullWidth
+              name="clubRegistrationPostalCode"
+              autoComplete="section-club-residence postal-code"
+              inputProps={{ inputMode: "numeric", maxLength: 5 }}
+            />
+            <TextField
+              required
+              label="Ville"
+              value={draft.city}
+              onChange={(e) => onChange({ city: e.target.value })}
+              fullWidth
+              name="clubRegistrationCity"
+              autoComplete="section-club-residence address-level2"
+            />
+          </Stack>
+        </Stack>
+      </Collapse>
+    </Stack>
+  );
+}

--- a/src/components/club-registration/RecapStep.tsx
+++ b/src/components/club-registration/RecapStep.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import {
+  CLUB_REGISTRATION_SITES,
+  COMPETITION_OPTIONS,
+  REDUCTION_OPTIONS,
+  SECTION_PRINCIPALE_OPTIONS,
+} from "@/lib/club-registration/constants";
+import { toFrenchPhoneMaskedDisplay } from "@/lib/club-registration/phone-fr";
+import type { RegistrationDraft, Representative } from "./registration-defaults";
+
+type Props = {
+  draft: RegistrationDraft;
+  accountEmail: string | null;
+  onEditStep: (stepIndex: number) => void;
+};
+
+const STEP_INDEX = {
+  identity: 0,
+  sections: 1,
+  medical: 2,
+  consents: 3,
+} as const;
+
+const ROLE_LABELS: Record<Representative["role"], string> = {
+  mother: "Mère",
+  father: "Père",
+  guardian: "Tuteur / Tutrice",
+  self: "Adhérent(e) lui/elle-même",
+  other: "Autre",
+};
+
+const SEX_LABELS: Record<RegistrationDraft["sex"], string> = {
+  female: "Femme",
+  male: "Homme",
+  other: "Autre / Ne pas préciser",
+};
+
+const ADHERENT_ROLE_LABELS: Record<RegistrationDraft["adherentRole"], string> = {
+  self: "Moi-même",
+  minor_dependent: "Un mineur dont je suis le représentant légal",
+  other_adult: "Un autre adulte",
+};
+
+const MEDICAL_LABELS: Record<RegistrationDraft["medicalCertificateDeclaration"], string> = {
+  under_40_all_no: "Moins de 40 ans : aucune réponse « Oui »",
+  over_40_cert_unchanged_all_no:
+    "Plus de 40 ans, certificat existant valide : aucune réponse « Oui »",
+  questionnaire_yes_certificate_required: "Au moins une réponse « Oui » : certificat requis",
+};
+
+const FAMILY_ORDER_LABELS: Record<RegistrationDraft["familyRegistrationOrder"], string> = {
+  none: "Première inscription",
+  second: "Deuxième inscription dans la famille",
+  third_or_more: "Troisième inscription ou plus",
+};
+
+const PHOTO_LABELS: Record<RegistrationDraft["photoConsent"], string> = {
+  accept: "J’accepte la diffusion d’images",
+  refuse: "Je refuse la diffusion d’images",
+};
+
+const CONSENT_LABELS: Record<RegistrationDraft["emergencyMedicalAuthorization"], string> = {
+  yes: "Oui",
+  not_applicable_adult: "Adhérent majeur — non concerné",
+};
+
+function findSectionLabel(id: string): string {
+  return (
+    SECTION_PRINCIPALE_OPTIONS.find((s) => s.id === id)?.label ?? id
+  );
+}
+
+function findSlotLabel(id: string): string {
+  for (const site of CLUB_REGISTRATION_SITES) {
+    const found = site.slots.find((s) => s.id === id);
+    if (found) return `${site.label} — ${found.label}`;
+  }
+  return id;
+}
+
+function findReductionLabel(id: string): string {
+  return REDUCTION_OPTIONS.find((r) => r.id === id)?.label ?? id;
+}
+
+function findCompetitionLabel(id: string): string {
+  return COMPETITION_OPTIONS.find((c) => c.id === id)?.label ?? id;
+}
+
+type Field = { label: string; value: React.ReactNode };
+
+function RecapBlock({
+  title,
+  onEdit,
+  fields,
+  emptyMessage,
+}: {
+  title: string;
+  onEdit: () => void;
+  fields: Field[];
+  emptyMessage?: string;
+}) {
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack spacing={2}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="subtitle1" component="h3">
+              {title}
+            </Typography>
+            <Button
+              size="small"
+              startIcon={<EditIcon fontSize="small" />}
+              onClick={onEdit}
+              aria-label={`Modifier ${title.toLowerCase()}`}
+            >
+              Modifier
+            </Button>
+          </Stack>
+
+          {fields.length === 0 && emptyMessage ? (
+            <Typography variant="body2" color="text.secondary">
+              {emptyMessage}
+            </Typography>
+          ) : (
+            <Stack spacing={1}>
+              {fields.map((f, i) => (
+                <Stack
+                  key={i}
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={{ xs: 0, sm: 2 }}
+                  alignItems={{ sm: "baseline" }}
+                >
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ minWidth: { sm: 200 } }}
+                  >
+                    {f.label}
+                  </Typography>
+                  <Typography variant="body2" component="div">
+                    {f.value || "—"}
+                  </Typography>
+                </Stack>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function RecapStep({ draft, accountEmail, onEditStep }: Props) {
+  const submitEnabled = process.env.NEXT_PUBLIC_HYBRID_SUBMIT_ENABLED === "true";
+
+  const additionalSections = draft.additionalSectionIds.map(findSectionLabel);
+  const slotLabels = draft.slotIds.map(findSlotLabel);
+  const reductions = draft.reductionTypes.map(findReductionLabel);
+  const competitions = draft.competitionIds.map(findCompetitionLabel);
+
+  const fullAddress = [
+    draft.addressLine1,
+    draft.addressLine2,
+    `${draft.postalCode} ${draft.city}`,
+  ]
+    .filter((s) => s && s.trim() !== "")
+    .join(" — ");
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="body2" color="text.secondary">
+        Vérifiez votre dossier avant envoi. Vous pouvez revenir sur n’importe quelle section
+        avec le bouton « Modifier ».
+      </Typography>
+
+      <RecapBlock
+        title="Cette inscription concerne"
+        onEdit={() => onEditStep(STEP_INDEX.identity)}
+        fields={[
+          { label: "Type d’inscription", value: ADHERENT_ROLE_LABELS[draft.adherentRole] },
+        ]}
+      />
+
+      <RecapBlock
+        title="Identité de l’adhérent"
+        onEdit={() => onEditStep(STEP_INDEX.identity)}
+        fields={[
+          { label: "Prénom", value: draft.firstName },
+          { label: "Nom", value: draft.lastName },
+          { label: "Sexe", value: SEX_LABELS[draft.sex] },
+          { label: "Né(e) le", value: draft.birthDate },
+          { label: "Ville de naissance", value: draft.birthCity },
+        ]}
+      />
+
+      <RecapBlock
+        title="Contact de l’adhérent"
+        onEdit={() => onEditStep(STEP_INDEX.identity)}
+        fields={[
+          { label: "E-mail", value: draft.adherentEmail || "—" },
+          {
+            label: "Téléphone principal",
+            value: toFrenchPhoneMaskedDisplay(draft.adherentPhonePrimary),
+          },
+          {
+            label: "Téléphone secondaire",
+            value: toFrenchPhoneMaskedDisplay(draft.adherentPhoneSecondary ?? ""),
+          },
+        ]}
+      />
+
+      <RecapBlock
+        title="Adresse postale"
+        onEdit={() => onEditStep(STEP_INDEX.identity)}
+        fields={[{ label: "Adresse", value: fullAddress }]}
+      />
+
+      {draft.representatives.length > 0 ? (
+        <RecapBlock
+          title="Représentants légaux"
+          onEdit={() => onEditStep(STEP_INDEX.identity)}
+          fields={draft.representatives.flatMap((rep, i) => [
+            {
+              label: `Représentant ${i + 1}`,
+              value: `${ROLE_LABELS[rep.role]} — ${rep.firstName} ${rep.lastName}`,
+            },
+            { label: `E-mail rep. ${i + 1}`, value: rep.email },
+            {
+              label: `Téléphone rep. ${i + 1}`,
+              value: toFrenchPhoneMaskedDisplay(rep.phone),
+            },
+          ])}
+        />
+      ) : null}
+
+      <RecapBlock
+        title="Sections et créneaux"
+        onEdit={() => onEditStep(STEP_INDEX.sections)}
+        fields={[
+          { label: "Section principale", value: findSectionLabel(draft.mainSectionId) },
+          {
+            label: "Sections complémentaires",
+            value:
+              additionalSections.length > 0 ? (
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {additionalSections.map((label) => (
+                    <Chip key={label} label={label} size="small" />
+                  ))}
+                </Stack>
+              ) : (
+                "—"
+              ),
+          },
+          {
+            label: "Créneaux",
+            value:
+              slotLabels.length > 0 ? (
+                <Stack spacing={0.5}>
+                  {slotLabels.map((label) => (
+                    <Typography key={label} variant="body2">
+                      • {label}
+                    </Typography>
+                  ))}
+                </Stack>
+              ) : (
+                "—"
+              ),
+          },
+        ]}
+      />
+
+      <RecapBlock
+        title="Médical et aides"
+        onEdit={() => onEditStep(STEP_INDEX.medical)}
+        fields={[
+          {
+            label: "Certificat médical",
+            value: MEDICAL_LABELS[draft.medicalCertificateDeclaration],
+          },
+          {
+            label: "Attestation d’inscription",
+            value: draft.wantsRegistrationCertificate ? "Oui" : "Non",
+          },
+          {
+            label: "Inscription dans la famille",
+            value: FAMILY_ORDER_LABELS[draft.familyRegistrationOrder],
+          },
+          {
+            label: "Réductions",
+            value:
+              reductions.length > 0 ? (
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {reductions.map((label) => (
+                    <Chip key={label} label={label} size="small" />
+                  ))}
+                </Stack>
+              ) : (
+                "—"
+              ),
+          },
+          { label: "Code Pass Sport", value: draft.passSportCode || "—" },
+          ...(draft.sex === "female"
+            ? [
+                {
+                  label: "1ʳᵉ inscription féminine au club",
+                  value: draft.firstFemaleRegistrationSqy ? "Oui" : "Non",
+                } as Field,
+              ]
+            : []),
+        ]}
+      />
+
+      <RecapBlock
+        title="Autorisations"
+        onEdit={() => onEditStep(STEP_INDEX.consents)}
+        fields={[
+          { label: "Image et communication", value: PHOTO_LABELS[draft.photoConsent] },
+          {
+            label: "Acte médical d’urgence (mineur)",
+            value: CONSENT_LABELS[draft.emergencyMedicalAuthorization],
+          },
+          {
+            label: "Prise en charge à l’heure des cours (mineur)",
+            value: CONSENT_LABELS[draft.supervisionAcknowledgement],
+          },
+          {
+            label: "Règlement intérieur",
+            value: draft.rulesAccepted ? "Accepté" : "Non accepté",
+          },
+        ]}
+      />
+
+      {draft.wantsCompetitorExtras ? (
+        <RecapBlock
+          title="Section compétiteur"
+          onEdit={() => onEditStep(STEP_INDEX.consents)}
+          fields={[
+            {
+              label: "Taille de maillot",
+              value: draft.competitionJerseySize ?? "—",
+            },
+            {
+              label: "Compétitions",
+              value:
+                competitions.length > 0 ? (
+                  <Stack spacing={0.5}>
+                    {competitions.map((label) => (
+                      <Typography key={label} variant="body2">
+                        • {label}
+                      </Typography>
+                    ))}
+                  </Stack>
+                ) : (
+                  "—"
+                ),
+            },
+          ]}
+        />
+      ) : null}
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1.5}>
+            <Typography variant="subtitle1" component="h3">
+              Adresses e-mail enregistrées dans le dossier
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {accountEmail
+                ? "L’adresse de votre compte est conservée comme adresse du soumettant et sert au club pour le suivi de cette inscription. Elle est distincte des adresses de l’adhérent et des représentants légaux."
+                : "L’adresse du compte que vous utiliserez pour vous connecter au moment de l’envoi sera conservée comme adresse du soumettant. Elle est distincte des adresses de l’adhérent et des représentants légaux."}
+            </Typography>
+
+            <Stack spacing={1}>
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={{ xs: 0, sm: 2 }}>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ minWidth: { sm: 200 } }}
+                >
+                  Soumettant (votre compte)
+                </Typography>
+                <Typography variant="body2">
+                  {accountEmail ? (
+                    <strong>{accountEmail}</strong>
+                  ) : (
+                    <em>(à confirmer à la connexion)</em>
+                  )}
+                </Typography>
+              </Stack>
+
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={{ xs: 0, sm: 2 }}>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ minWidth: { sm: 200 } }}
+                >
+                  Adhérent
+                </Typography>
+                <Typography variant="body2">{draft.adherentEmail || "—"}</Typography>
+              </Stack>
+
+              {draft.representatives.map((rep, i) => (
+                <Stack
+                  key={i}
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={{ xs: 0, sm: 2 }}
+                >
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ minWidth: { sm: 200 } }}
+                  >
+                    Représentant {i + 1} ({ROLE_LABELS[rep.role]})
+                  </Typography>
+                  <Typography variant="body2">{rep.email || "—"}</Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {!submitEnabled ? (
+        <Alert severity="info">
+          La soumission en ligne sera disponible prochainement. Cette page vous permet
+          dès aujourd’hui de préparer votre dossier ; il sera enregistré localement sur
+          cet appareil.
+        </Alert>
+      ) : null}
+
+      <Box />
+    </Stack>
+  );
+}

--- a/src/components/club-registration/RepresentativesBlock.tsx
+++ b/src/components/club-registration/RepresentativesBlock.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import {
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  type SelectChangeEvent,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import {
+  extractNationalDigitsForMask,
+  formatFrenchPhoneMask,
+  isValidFrenchPhoneSurface,
+  toFrenchPhoneMaskedDisplay,
+} from "@/lib/club-registration/phone-fr";
+import type { Representative } from "@/lib/club-registration/schema";
+
+type Props = {
+  representatives: Representative[];
+  /** Si vrai, le 1er représentant est obligatoire et non supprimable. */
+  firstIsRequired: boolean;
+  onAdd: () => void;
+  onUpdate: (index: number, patch: Partial<Representative>) => void;
+  onRemove: (index: number) => void;
+};
+
+const ROLE_OPTIONS: Array<{ value: Representative["role"]; label: string }> = [
+  { value: "mother", label: "Mère" },
+  { value: "father", label: "Père" },
+  { value: "guardian", label: "Tuteur / Tutrice légal(e)" },
+  { value: "self", label: "Adhérent(e) lui/elle-même" },
+  { value: "other", label: "Autre" },
+];
+
+function isInvalidEmail(value: string): boolean {
+  if (value.trim() === "") return false;
+  return !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+}
+
+export function RepresentativesBlock({
+  representatives,
+  firstIsRequired,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: Props) {
+  const handleField =
+    (index: number, field: keyof Representative) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onUpdate(index, { [field]: e.target.value } as Partial<Representative>);
+    };
+
+  const handleRole =
+    (index: number) =>
+    (e: SelectChangeEvent<Representative["role"]>) => {
+      onUpdate(index, { role: e.target.value as Representative["role"] });
+    };
+
+  const handlePhone =
+    (index: number) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const digits = extractNationalDigitsForMask(e.target.value);
+      onUpdate(index, { phone: formatFrenchPhoneMask(digits) });
+    };
+
+  return (
+    <Stack spacing={2}>
+      {representatives.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Aucun représentant légal pour ce dossier.
+        </Typography>
+      ) : null}
+
+      {representatives.map((rep, index) => {
+        const removable = !(firstIsRequired && index === 0);
+        const required = firstIsRequired && index === 0;
+        const phoneInvalid =
+          rep.phone.trim() !== "" && !isValidFrenchPhoneSurface(rep.phone);
+        const emailInvalid = isInvalidEmail(rep.email);
+
+        return (
+          <Card key={index} variant="outlined">
+            <CardContent>
+              <Stack spacing={2}>
+                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                  <Typography variant="subtitle2">
+                    Représentant légal {index + 1}
+                    {required ? " (obligatoire)" : " (optionnel)"}
+                  </Typography>
+                  {removable ? (
+                    <Tooltip title="Supprimer ce représentant">
+                      <IconButton
+                        aria-label={`Supprimer le représentant ${index + 1}`}
+                        size="small"
+                        onClick={() => onRemove(index)}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  ) : null}
+                </Stack>
+
+                <FormControl fullWidth>
+                  <InputLabel id={`rep-role-label-${index}`}>Lien avec l’adhérent</InputLabel>
+                  <Select
+                    labelId={`rep-role-label-${index}`}
+                    label="Lien avec l’adhérent"
+                    value={rep.role}
+                    onChange={handleRole(index)}
+                  >
+                    {ROLE_OPTIONS.map((opt) => (
+                      <MenuItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                  <TextField
+                    required={required}
+                    label="Prénom"
+                    value={rep.firstName}
+                    onChange={handleField(index, "firstName")}
+                    fullWidth
+                    autoComplete="off"
+                  />
+                  <TextField
+                    required={required}
+                    label="Nom"
+                    value={rep.lastName}
+                    onChange={handleField(index, "lastName")}
+                    fullWidth
+                    autoComplete="off"
+                  />
+                </Stack>
+
+                <TextField
+                  required={required}
+                  label="E-mail"
+                  type="email"
+                  value={rep.email}
+                  onChange={handleField(index, "email")}
+                  fullWidth
+                  autoComplete="off"
+                  error={emailInvalid}
+                  helperText={emailInvalid ? "Adresse e-mail invalide" : undefined}
+                />
+
+                <TextField
+                  required={required}
+                  label="Téléphone"
+                  value={toFrenchPhoneMaskedDisplay(rep.phone)}
+                  onChange={handlePhone(index)}
+                  fullWidth
+                  inputMode="numeric"
+                  placeholder="06 12 34 56 78"
+                  autoComplete="off"
+                  error={phoneInvalid}
+                  helperText={phoneInvalid ? "Numéro invalide" : undefined}
+                />
+              </Stack>
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      {representatives.length < 2 ? (
+        <Stack direction="row">
+          <Button variant="outlined" size="small" onClick={onAdd}>
+            + Ajouter un représentant légal
+          </Button>
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/components/club-registration/SectionSlotsStep.tsx
+++ b/src/components/club-registration/SectionSlotsStep.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  CLUB_REGISTRATION_SITES,
+  SECTION_PRINCIPALE_OPTIONS,
+} from "@/lib/club-registration/constants";
+import type { RegistrationDraft } from "./registration-defaults";
+
+type Props = {
+  draft: RegistrationDraft;
+  onChange: (patch: Partial<RegistrationDraft>) => void;
+};
+
+function siteIdsMatchingMainSection(mainSectionId: string): Set<string> {
+  const ids = new Set<string>();
+  for (const site of CLUB_REGISTRATION_SITES) {
+    if (site.id === mainSectionId) ids.add(site.id);
+  }
+  return ids;
+}
+
+export function SectionSlotsStep({ draft, onChange }: Props) {
+  const [expandedSiteIds, setExpandedSiteIds] = useState<Set<string>>(() =>
+    siteIdsMatchingMainSection(draft.mainSectionId)
+  );
+
+  /** À chaque changement de section principale : un seul bloc de créneaux ouvert (celui qui correspond à l’id). */
+  useEffect(() => {
+    setExpandedSiteIds(siteIdsMatchingMainSection(draft.mainSectionId));
+  }, [draft.mainSectionId]);
+
+  const toggleSlot = (id: string) => {
+    const set = new Set(draft.slotIds);
+    if (set.has(id)) {
+      set.delete(id);
+    } else {
+      set.add(id);
+    }
+    onChange({ slotIds: Array.from(set) });
+  };
+
+  const toggleAdditionalSection = (id: (typeof SECTION_PRINCIPALE_OPTIONS)[number]["id"]) => {
+    if (id === draft.mainSectionId) return;
+    const set = new Set(draft.additionalSectionIds);
+    if (set.has(id)) {
+      set.delete(id);
+    } else {
+      set.add(id);
+    }
+    onChange({ additionalSectionIds: Array.from(set) });
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="body2" color="text.secondary">
+        Choisissez votre section principale, d&apos;éventuelles sections complémentaires, puis les
+        créneaux auxquels vous souhaitez participer.
+      </Typography>
+
+      <FormControl fullWidth required>
+        <InputLabel id="main-section-label">Section principale</InputLabel>
+        <Select
+          labelId="main-section-label"
+          label="Section principale"
+          value={draft.mainSectionId}
+          onChange={(e) => {
+            const next = e.target.value as RegistrationDraft["mainSectionId"];
+            const cleaned = draft.additionalSectionIds.filter((x) => x !== next);
+            onChange({ mainSectionId: next, additionalSectionIds: cleaned });
+          }}
+        >
+          {SECTION_PRINCIPALE_OPTIONS.map((s) => (
+            <MenuItem key={s.id} value={s.id}>
+              {s.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <Stack spacing={0.5}>
+        <Typography variant="subtitle2">Autres sections</Typography>
+        <FormGroup>
+          {SECTION_PRINCIPALE_OPTIONS.filter((s) => s.id !== draft.mainSectionId).map((s) => (
+            <FormControlLabel
+              key={s.id}
+              control={
+                <Checkbox
+                  checked={draft.additionalSectionIds.includes(s.id)}
+                  onChange={() => toggleAdditionalSection(s.id)}
+                />
+              }
+              label={s.label}
+            />
+          ))}
+        </FormGroup>
+      </Stack>
+
+      <Typography variant="subtitle2">Créneaux souhaités</Typography>
+      {CLUB_REGISTRATION_SITES.map((site) => (
+        <Accordion
+          key={site.id}
+          disableGutters
+          expanded={expandedSiteIds.has(site.id)}
+          onChange={(_, expanded) => {
+            setExpandedSiteIds((prev) => {
+              const next = new Set(prev);
+              if (expanded) next.add(site.id);
+              else next.delete(site.id);
+              return next;
+            });
+          }}
+        >
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography fontWeight={600}>{site.label}</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <FormGroup>
+              {site.slots.map((slot) => (
+                <FormControlLabel
+                  key={slot.id}
+                  control={
+                    <Checkbox
+                      checked={draft.slotIds.includes(slot.id)}
+                      onChange={() => toggleSlot(slot.id)}
+                    />
+                  }
+                  label={slot.label}
+                />
+              ))}
+            </FormGroup>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/club-registration/dev-identity-fixture.ts
+++ b/src/components/club-registration/dev-identity-fixture.ts
@@ -1,0 +1,20 @@
+import type { RegistrationDraft } from "./registration-defaults";
+
+/** Données factices pour accélérer les tests manuels en local (non utilisé en production). */
+export function getDevIdentityFixture(): Partial<RegistrationDraft> {
+  return {
+    adherentRole: "self",
+    firstName: "Camille",
+    lastName: "DevTest",
+    sex: "male",
+    birthCity: "Paris",
+    birthDate: "1995-06-15",
+    adherentEmail: "",
+    adherentPhonePrimary: "06 12 34 56 78",
+    adherentPhoneSecondary: "",
+    addressLine1: "12 rue du Test",
+    addressLine2: "",
+    postalCode: "78280",
+    city: "Guyancourt",
+  };
+}

--- a/src/components/club-registration/registration-defaults.ts
+++ b/src/components/club-registration/registration-defaults.ts
@@ -1,0 +1,57 @@
+import type { ClubRegistrationPayload, Representative } from "@/lib/club-registration/schema";
+
+/**
+ * Forme du draft local. Conserve une bascule UI pour `internalRulesAccepted`
+ * (case à cocher contrôlée par l'utilisateur, alors que côté schéma on attend `true`).
+ */
+export type RegistrationDraft = Omit<ClubRegistrationPayload, "internalRulesAccepted"> & {
+  rulesAccepted: boolean;
+};
+
+export type { Representative };
+
+/** Représentant légal vide (pour ajout dynamique dans l'UI). */
+export function createEmptyRepresentative(): Representative {
+  return {
+    role: "mother",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+  };
+}
+
+export function createEmptyDraft(): RegistrationDraft {
+  return {
+    adherentRole: "self",
+    firstName: "",
+    lastName: "",
+    sex: "male",
+    birthCity: "",
+    birthDate: "",
+    adherentEmail: "",
+    adherentPhonePrimary: "",
+    adherentPhoneSecondary: "",
+    addressLine1: "",
+    addressLine2: "",
+    postalCode: "",
+    city: "",
+    representatives: [],
+    mainSectionId: "voisins",
+    additionalSectionIds: [],
+    slotIds: [],
+    medicalCertificateDeclaration: "under_40_all_no",
+    wantsRegistrationCertificate: false,
+    familyRegistrationOrder: "none",
+    reductionTypes: [],
+    passSportCode: "",
+    firstFemaleRegistrationSqy: undefined,
+    photoConsent: "accept",
+    emergencyMedicalAuthorization: "not_applicable_adult",
+    supervisionAcknowledgement: "not_applicable_adult",
+    rulesAccepted: false,
+    wantsCompetitorExtras: false,
+    competitionJerseySize: undefined,
+    competitionIds: [],
+  };
+}

--- a/src/components/club-registration/useRegistrationDraft.test.ts
+++ b/src/components/club-registration/useRegistrationDraft.test.ts
@@ -1,0 +1,152 @@
+import { registrationDraftReducer } from "./useRegistrationDraft";
+import { createEmptyDraft, createEmptyRepresentative } from "./registration-defaults";
+
+describe("registrationDraftReducer", () => {
+  it("PATCH_FIELDS fusionne les champs", () => {
+    const s = createEmptyDraft();
+    const next = registrationDraftReducer(s, {
+      type: "PATCH_FIELDS",
+      patch: { firstName: "Olivier", city: "Guyancourt" },
+    });
+    expect(next.firstName).toBe("Olivier");
+    expect(next.city).toBe("Guyancourt");
+  });
+
+  it("SET_ADHERENT_ROLE vers minor_dependent ajoute un représentant si vide", () => {
+    const s = createEmptyDraft();
+    const next = registrationDraftReducer(s, {
+      type: "SET_ADHERENT_ROLE",
+      role: "minor_dependent",
+    });
+    expect(next.adherentRole).toBe("minor_dependent");
+    expect(next.representatives).toHaveLength(1);
+  });
+
+  it("SET_ADHERENT_ROLE vers minor_dependent ne touche pas si représentants déjà présents", () => {
+    const s = {
+      ...createEmptyDraft(),
+      representatives: [
+        {
+          role: "mother" as const,
+          firstName: "Marie",
+          lastName: "X",
+          email: "marie@example.com",
+          phone: "0612345678",
+        },
+      ],
+    };
+    const next = registrationDraftReducer(s, {
+      type: "SET_ADHERENT_ROLE",
+      role: "minor_dependent",
+    });
+    expect(next.representatives).toHaveLength(1);
+    expect(next.representatives[0].firstName).toBe("Marie");
+  });
+
+  it("SET_ADHERENT_ROLE vers self vide les représentants existants", () => {
+    const s = {
+      ...createEmptyDraft(),
+      adherentRole: "minor_dependent" as const,
+      representatives: [
+        {
+          role: "mother" as const,
+          firstName: "Marie",
+          lastName: "X",
+          email: "marie@example.com",
+          phone: "0612345678",
+        },
+      ],
+    };
+    const next = registrationDraftReducer(s, {
+      type: "SET_ADHERENT_ROLE",
+      role: "self",
+    });
+    expect(next.adherentRole).toBe("self");
+    expect(next.representatives).toHaveLength(0);
+  });
+
+  it("SET_ADHERENT_ROLE vers other_adult vide les représentants existants", () => {
+    const s = {
+      ...createEmptyDraft(),
+      adherentRole: "minor_dependent" as const,
+      representatives: [
+        {
+          role: "mother" as const,
+          firstName: "Marie",
+          lastName: "X",
+          email: "marie@example.com",
+          phone: "0612345678",
+        },
+      ],
+    };
+    const next = registrationDraftReducer(s, {
+      type: "SET_ADHERENT_ROLE",
+      role: "other_adult",
+    });
+    expect(next.adherentRole).toBe("other_adult");
+    expect(next.representatives).toHaveLength(0);
+  });
+
+  it("SET_SEX à autre que female reset firstFemaleRegistrationSqy", () => {
+    const s = { ...createEmptyDraft(), firstFemaleRegistrationSqy: true };
+    const next = registrationDraftReducer(s, { type: "SET_SEX", sex: "male" });
+    expect(next.firstFemaleRegistrationSqy).toBeUndefined();
+  });
+
+  it("SET_SEX à female initialise firstFemaleRegistrationSqy à false", () => {
+    const s = createEmptyDraft();
+    expect(s.firstFemaleRegistrationSqy).toBeUndefined();
+    const next = registrationDraftReducer(s, { type: "SET_SEX", sex: "female" });
+    expect(next.firstFemaleRegistrationSqy).toBe(false);
+  });
+
+  it("ADD_REPRESENTATIVE ajoute jusqu'à 2", () => {
+    let s = createEmptyDraft();
+    s = registrationDraftReducer(s, { type: "ADD_REPRESENTATIVE" });
+    s = registrationDraftReducer(s, { type: "ADD_REPRESENTATIVE" });
+    expect(s.representatives).toHaveLength(2);
+    s = registrationDraftReducer(s, { type: "ADD_REPRESENTATIVE" });
+    expect(s.representatives).toHaveLength(2);
+  });
+
+  it("UPDATE_REPRESENTATIVE met à jour les champs ciblés", () => {
+    let s = registrationDraftReducer(createEmptyDraft(), {
+      type: "ADD_REPRESENTATIVE",
+      representative: createEmptyRepresentative(),
+    });
+    s = registrationDraftReducer(s, {
+      type: "UPDATE_REPRESENTATIVE",
+      index: 0,
+      patch: { firstName: "Marie", lastName: "Dupont" },
+    });
+    expect(s.representatives[0].firstName).toBe("Marie");
+    expect(s.representatives[0].lastName).toBe("Dupont");
+  });
+
+  it("REMOVE_REPRESENTATIVE retire l'élément ciblé", () => {
+    let s = registrationDraftReducer(createEmptyDraft(), {
+      type: "ADD_REPRESENTATIVE",
+      representative: { ...createEmptyRepresentative(), firstName: "A" },
+    });
+    s = registrationDraftReducer(s, {
+      type: "ADD_REPRESENTATIVE",
+      representative: { ...createEmptyRepresentative(), firstName: "B" },
+    });
+    s = registrationDraftReducer(s, { type: "REMOVE_REPRESENTATIVE", index: 0 });
+    expect(s.representatives).toHaveLength(1);
+    expect(s.representatives[0].firstName).toBe("B");
+  });
+
+  it("HYDRATE remplace tout l'état par le draft fourni", () => {
+    const s = createEmptyDraft();
+    const hydrated = { ...createEmptyDraft(), firstName: "Camille" };
+    const next = registrationDraftReducer(s, { type: "HYDRATE", draft: hydrated });
+    expect(next.firstName).toBe("Camille");
+  });
+
+  it("RESET ramène à un draft vide", () => {
+    const s = { ...createEmptyDraft(), firstName: "X" };
+    const next = registrationDraftReducer(s, { type: "RESET" });
+    expect(next.firstName).toBe("");
+  });
+});

--- a/src/components/club-registration/useRegistrationDraft.ts
+++ b/src/components/club-registration/useRegistrationDraft.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { useReducer, useCallback } from "react";
+import type { Representative } from "@/lib/club-registration/schema";
+import {
+  createEmptyDraft,
+  createEmptyRepresentative,
+  type RegistrationDraft,
+} from "./registration-defaults";
+
+/**
+ * Reducer typé pour le draft d'inscription.
+ *
+ * Encapsule les invariants métier qui dépendaient auparavant de plusieurs callbacks
+ * éparpillés dans les composants d'étape :
+ * - changement d'`adherentRole` → ajustement automatique de `representatives`
+ * - changement de `sex` → reset cohérent de `firstFemaleRegistrationSqy`
+ * - hydratation depuis localStorage ou serveur sans recopier la logique côté composants
+ */
+
+export type RegistrationDraftAction =
+  | { type: "PATCH_FIELDS"; patch: Partial<RegistrationDraft> }
+  | { type: "SET_ADHERENT_ROLE"; role: RegistrationDraft["adherentRole"] }
+  | { type: "SET_SEX"; sex: RegistrationDraft["sex"] }
+  | { type: "ADD_REPRESENTATIVE"; representative?: Representative }
+  | { type: "UPDATE_REPRESENTATIVE"; index: number; patch: Partial<Representative> }
+  | { type: "REMOVE_REPRESENTATIVE"; index: number }
+  | { type: "HYDRATE"; draft: RegistrationDraft }
+  | { type: "RESET" };
+
+export function registrationDraftReducer(
+  state: RegistrationDraft,
+  action: RegistrationDraftAction
+): RegistrationDraft {
+  switch (action.type) {
+    case "PATCH_FIELDS":
+      return { ...state, ...action.patch };
+
+    case "SET_ADHERENT_ROLE": {
+      const next: RegistrationDraft = { ...state, adherentRole: action.role };
+      if (action.role === "minor_dependent") {
+        if (state.representatives.length === 0) {
+          next.representatives = [createEmptyRepresentative()];
+        }
+      } else {
+        /* Adultes (self / other_adult) : pas de représentant légal dans le dossier. */
+        next.representatives = [];
+      }
+      return next;
+    }
+
+    case "SET_SEX": {
+      const next: RegistrationDraft = { ...state, sex: action.sex };
+      if (action.sex !== "female") {
+        next.firstFemaleRegistrationSqy = undefined;
+      } else if (state.firstFemaleRegistrationSqy === undefined) {
+        next.firstFemaleRegistrationSqy = false;
+      }
+      return next;
+    }
+
+    case "ADD_REPRESENTATIVE": {
+      if (state.representatives.length >= 2) return state;
+      return {
+        ...state,
+        representatives: [
+          ...state.representatives,
+          action.representative ?? createEmptyRepresentative(),
+        ],
+      };
+    }
+
+    case "UPDATE_REPRESENTATIVE": {
+      const list = state.representatives.slice();
+      const target = list[action.index];
+      if (!target) return state;
+      list[action.index] = { ...target, ...action.patch };
+      return { ...state, representatives: list };
+    }
+
+    case "REMOVE_REPRESENTATIVE": {
+      if (action.index < 0 || action.index >= state.representatives.length) return state;
+      const list = state.representatives.slice();
+      list.splice(action.index, 1);
+      return { ...state, representatives: list };
+    }
+
+    case "HYDRATE":
+      return { ...action.draft };
+
+    case "RESET":
+      return createEmptyDraft();
+
+    default:
+      return state;
+  }
+}
+
+export type RegistrationDraftActions = {
+  patchFields: (patch: Partial<RegistrationDraft>) => void;
+  setAdherentRole: (role: RegistrationDraft["adherentRole"]) => void;
+  setSex: (sex: RegistrationDraft["sex"]) => void;
+  addRepresentative: (rep?: Representative) => void;
+  updateRepresentative: (index: number, patch: Partial<Representative>) => void;
+  removeRepresentative: (index: number) => void;
+  hydrate: (draft: RegistrationDraft) => void;
+  reset: () => void;
+};
+
+export function useRegistrationDraft(initial?: RegistrationDraft): {
+  draft: RegistrationDraft;
+  actions: RegistrationDraftActions;
+} {
+  const [draft, dispatch] = useReducer(
+    registrationDraftReducer,
+    initial ?? createEmptyDraft()
+  );
+
+  const patchFields = useCallback(
+    (patch: Partial<RegistrationDraft>) => dispatch({ type: "PATCH_FIELDS", patch }),
+    []
+  );
+  const setAdherentRole = useCallback(
+    (role: RegistrationDraft["adherentRole"]) =>
+      dispatch({ type: "SET_ADHERENT_ROLE", role }),
+    []
+  );
+  const setSex = useCallback(
+    (sex: RegistrationDraft["sex"]) => dispatch({ type: "SET_SEX", sex }),
+    []
+  );
+  const addRepresentative = useCallback(
+    (rep?: Representative) =>
+      dispatch(
+        rep
+          ? { type: "ADD_REPRESENTATIVE", representative: rep }
+          : { type: "ADD_REPRESENTATIVE" }
+      ),
+    []
+  );
+  const updateRepresentative = useCallback(
+    (index: number, patch: Partial<Representative>) =>
+      dispatch({ type: "UPDATE_REPRESENTATIVE", index, patch }),
+    []
+  );
+  const removeRepresentative = useCallback(
+    (index: number) => dispatch({ type: "REMOVE_REPRESENTATIVE", index }),
+    []
+  );
+  const hydrate = useCallback(
+    (next: RegistrationDraft) => dispatch({ type: "HYDRATE", draft: next }),
+    []
+  );
+  const reset = useCallback(() => dispatch({ type: "RESET" }), []);
+
+  return {
+    draft,
+    actions: {
+      patchFields,
+      setAdherentRole,
+      setSex,
+      addRepresentative,
+      updateRepresentative,
+      removeRepresentative,
+      hydrate,
+      reset,
+    },
+  };
+}

--- a/src/components/club-registration/useRegistrationDraftStorage.test.ts
+++ b/src/components/club-registration/useRegistrationDraftStorage.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { useRegistrationDraftStorage } from "./useRegistrationDraftStorage";
+import { createEmptyDraft } from "./registration-defaults";
+
+const STORAGE_KEY = "teamup:club-registration:v1";
+const DISABLED_KEY = "teamup:club-registration:storage-disabled";
+
+describe("useRegistrationDraftStorage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("save écrit en localStorage après debounce, load relit", () => {
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    const draft = { ...createEmptyDraft(), firstName: "Olivier" };
+    act(() => {
+      result.current.save(draft);
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const reloaded = result.current.load();
+    expect(reloaded?.firstName).toBe("Olivier");
+  });
+
+  it("saveNow écrit immédiatement", () => {
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    const draft = { ...createEmptyDraft(), firstName: "Marie" };
+    act(() => {
+      result.current.saveNow(draft);
+    });
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).draft.firstName).toBe("Marie");
+  });
+
+  it("clear supprime le brouillon stocké", () => {
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    act(() => {
+      result.current.saveNow({ ...createEmptyDraft(), firstName: "X" });
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    act(() => {
+      result.current.clear();
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("disable empêche la sauvegarde et efface l'existant", () => {
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    act(() => {
+      result.current.saveNow({ ...createEmptyDraft(), firstName: "Camille" });
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    act(() => {
+      result.current.disable();
+    });
+    expect(result.current.isDisabled).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(DISABLED_KEY)).toBe("1");
+
+    act(() => {
+      result.current.saveNow({ ...createEmptyDraft(), firstName: "Y" });
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("enable réactive la sauvegarde", () => {
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    act(() => {
+      result.current.disable();
+    });
+    expect(result.current.isDisabled).toBe(true);
+
+    act(() => {
+      result.current.enable();
+    });
+    expect(result.current.isDisabled).toBe(false);
+
+    act(() => {
+      result.current.saveNow({ ...createEmptyDraft(), firstName: "Z" });
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("load retourne null si la version stockée diffère et nettoie l'entrée", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ schemaVersion: 99, draft: { firstName: "Old" }, updatedAt: "now" })
+    );
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    const reloaded = result.current.load();
+    expect(reloaded).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("load retourne null si désactivé même avec une entrée présente", () => {
+    window.localStorage.setItem(DISABLED_KEY, "1");
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        draft: createEmptyDraft(),
+        updatedAt: "now",
+      })
+    );
+    const { result } = renderHook(() => useRegistrationDraftStorage());
+
+    expect(result.current.load()).toBeNull();
+  });
+});

--- a/src/components/club-registration/useRegistrationDraftStorage.ts
+++ b/src/components/club-registration/useRegistrationDraftStorage.ts
@@ -1,0 +1,170 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RegistrationDraft } from "./registration-defaults";
+
+const STORAGE_KEY = "teamup:club-registration:v1";
+const DISABLED_KEY = "teamup:club-registration:storage-disabled";
+const SCHEMA_VERSION = 1;
+const SAVE_DEBOUNCE_MS = 500;
+
+type StoragePayload = {
+  schemaVersion: number;
+  draft: RegistrationDraft;
+  updatedAt: string;
+};
+
+export type DraftStorageStatus = "idle" | "saving" | "saved" | "disabled";
+
+export type UseRegistrationDraftStorage = {
+  status: DraftStorageStatus;
+  lastSavedAt: Date | null;
+  isDisabled: boolean;
+  load: () => RegistrationDraft | null;
+  save: (draft: RegistrationDraft) => void;
+  saveNow: (draft: RegistrationDraft) => void;
+  clear: () => void;
+  disable: () => void;
+  enable: () => void;
+};
+
+function readDisabledFlag(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(DISABLED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function readStoredDraft(): RegistrationDraft | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as StoragePayload).schemaVersion !== SCHEMA_VERSION
+    ) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return (parsed as StoragePayload).draft;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sauvegarde locale du brouillon d'inscription (RGPD : transparence via DraftStorageDisclosure).
+ * Stocke en JSON avec versioning pour migration future.
+ * Sauvegarde activée par défaut, l'utilisateur peut désactiver/effacer à tout moment.
+ */
+export function useRegistrationDraftStorage(): UseRegistrationDraftStorage {
+  const [isDisabled, setIsDisabled] = useState<boolean>(false);
+  const [status, setStatus] = useState<DraftStorageStatus>("idle");
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setIsDisabled(readDisabledFlag());
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const load = useCallback((): RegistrationDraft | null => {
+    if (readDisabledFlag()) return null;
+    return readStoredDraft();
+  }, []);
+
+  const writeNow = useCallback((draft: RegistrationDraft) => {
+    if (typeof window === "undefined") return;
+    if (readDisabledFlag()) return;
+    try {
+      const payload: StoragePayload = {
+        schemaVersion: SCHEMA_VERSION,
+        draft,
+        updatedAt: new Date().toISOString(),
+      };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      setLastSavedAt(new Date());
+      setStatus("saved");
+    } catch {
+      // Quota exceeded ou storage indisponible : on ignore silencieusement.
+      setStatus("idle");
+    }
+  }, []);
+
+  const save = useCallback(
+    (draft: RegistrationDraft) => {
+      if (readDisabledFlag()) return;
+      setStatus("saving");
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        writeNow(draft);
+      }, SAVE_DEBOUNCE_MS);
+    },
+    [writeNow]
+  );
+
+  const saveNow = useCallback(
+    (draft: RegistrationDraft) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      writeNow(draft);
+    },
+    [writeNow]
+  );
+
+  const clear = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+    setLastSavedAt(null);
+    setStatus(readDisabledFlag() ? "disabled" : "idle");
+  }, []);
+
+  const disable = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(DISABLED_KEY, "1");
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+    setIsDisabled(true);
+    setLastSavedAt(null);
+    setStatus("disabled");
+  }, []);
+
+  const enable = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(DISABLED_KEY);
+    } catch {
+      /* ignore */
+    }
+    setIsDisabled(false);
+    setStatus("idle");
+  }, []);
+
+  return {
+    status: isDisabled ? "disabled" : status,
+    lastSavedAt,
+    isDisabled,
+    load,
+    save,
+    saveNow,
+    clear,
+    disable,
+    enable,
+  };
+}

--- a/src/lib/auth/audit-logger.ts
+++ b/src/lib/auth/audit-logger.ts
@@ -85,6 +85,7 @@ export const AUDIT_ACTIONS = {
   COACH_REQUEST_SUBMITTED: "coach.request.submitted",
   COACH_REQUEST_APPROVED: "coach.request.approved",
   COACH_REQUEST_REJECTED: "coach.request.rejected",
+  CLUB_REGISTRATION_SUBMITTED: "club.registration.submitted",
   TEAM_CREATED: "team.created",
   TEAM_UPDATED: "team.updated",
   TEAM_DELETED: "team.deleted",

--- a/src/lib/club-registration/age.test.ts
+++ b/src/lib/club-registration/age.test.ts
@@ -1,0 +1,56 @@
+import { isAdultAt, isMinorAt } from "./age";
+
+/**
+ * On utilise `new Date(y, m, d)` (heure locale) pour éviter les pièges
+ * de fuseau horaire avec les littéraux "...Z".
+ */
+function localDate(y: number, m: number, d: number): Date {
+  return new Date(y, m - 1, d, 12, 0, 0);
+}
+
+describe("isAdultAt", () => {
+  it("retourne true le jour exact des 18 ans", () => {
+    expect(isAdultAt("2007-05-11", localDate(2025, 5, 11))).toBe(true);
+  });
+
+  it("retourne false la veille des 18 ans", () => {
+    expect(isAdultAt("2007-05-12", localDate(2025, 5, 11))).toBe(false);
+  });
+
+  it("retourne true bien après les 18 ans", () => {
+    expect(isAdultAt("1980-01-15", localDate(2025, 6, 1))).toBe(true);
+  });
+
+  it("retourne false pour un enfant de 5 ans", () => {
+    expect(isAdultAt("2020-01-01", localDate(2025, 6, 1))).toBe(false);
+  });
+
+  it("gère un anniversaire 29 février sur année non bissextile (28 fev = pas encore atteint)", () => {
+    expect(isAdultAt("2008-02-29", localDate(2026, 2, 28))).toBe(false);
+  });
+
+  it("gère un anniversaire 29 février sur année non bissextile (1er mars = atteint)", () => {
+    expect(isAdultAt("2008-02-29", localDate(2026, 3, 1))).toBe(true);
+  });
+
+  it("retourne false pour une date invalide", () => {
+    expect(isAdultAt("", localDate(2025, 1, 1))).toBe(false);
+    expect(isAdultAt("abcd-ef-gh", localDate(2025, 1, 1))).toBe(false);
+    expect(isAdultAt("2025-13-01", localDate(2025, 1, 1))).toBe(false);
+  });
+});
+
+describe("isMinorAt", () => {
+  it("retourne true pour un enfant", () => {
+    expect(isMinorAt("2015-06-01", localDate(2025, 6, 1))).toBe(true);
+  });
+
+  it("retourne false pour un adulte", () => {
+    expect(isMinorAt("1990-06-01", localDate(2025, 6, 1))).toBe(false);
+  });
+
+  it("retourne false pour une date vide ou invalide (pas de présomption)", () => {
+    expect(isMinorAt("", localDate(2025, 6, 1))).toBe(false);
+    expect(isMinorAt("not-a-date", localDate(2025, 6, 1))).toBe(false);
+  });
+});

--- a/src/lib/club-registration/age.ts
+++ b/src/lib/club-registration/age.ts
@@ -1,0 +1,47 @@
+/**
+ * Helpers d'âge pour le formulaire d'inscription club.
+ *
+ * - `isAdultAt` : retourne true si la personne née à `birthDate` (format ISO YYYY-MM-DD)
+ *   est majeure (>= 18 ans) à la date `at`. Anniversaire le jour J = majeur.
+ * - `isMinorAt` : inverse de `isAdultAt`, false si `birthDate` est invalide ou vide.
+ *
+ * La référence `at` est paramétrable pour faciliter les tests et garantir la stabilité
+ * (ne pas dépendre directement de `Date.now()`).
+ */
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseIsoDate(s: string): { y: number; m: number; d: number } | null {
+  if (!ISO_DATE.test(s)) return null;
+  const y = Number.parseInt(s.slice(0, 4), 10);
+  const m = Number.parseInt(s.slice(5, 7), 10);
+  const d = Number.parseInt(s.slice(8, 10), 10);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
+  if (m < 1 || m > 12) return null;
+  if (d < 1 || d > 31) return null;
+  return { y, m, d };
+}
+
+/** Renvoie true si `birthDate` (ISO) correspond à une personne majeure (>=18 ans) à la date `at`. */
+export function isAdultAt(birthDate: string, at: Date = new Date()): boolean {
+  const birth = parseIsoDate(birthDate);
+  if (!birth) return false;
+
+  const refY = at.getFullYear();
+  const refM = at.getMonth() + 1;
+  const refD = at.getDate();
+
+  let years = refY - birth.y;
+  if (refM < birth.m || (refM === birth.m && refD < birth.d)) {
+    years -= 1;
+  }
+  return years >= 18;
+}
+
+/** Inverse pratique : false si `birthDate` est vide / invalide (pas de présomption de minorité). */
+export function isMinorAt(birthDate: string, at: Date = new Date()): boolean {
+  if (!birthDate) return false;
+  const birth = parseIsoDate(birthDate);
+  if (!birth) return false;
+  return !isAdultAt(birthDate, at);
+}

--- a/src/lib/club-registration/constants.ts
+++ b/src/lib/club-registration/constants.ts
@@ -1,0 +1,165 @@
+/**
+ * Données de référence pour le formulaire d'inscription au club (aligné sur le formulaire public SQY PING).
+ * Les créneaux et sections peuvent être ajustés ici sans toucher à la logique métier.
+ */
+
+export type ClubRegistrationSiteSlot = {
+  id: string;
+  label: string;
+};
+
+export type ClubRegistrationSite = {
+  /**
+   * Identifiant du lieu / groupe de créneaux ; doit correspondre à l’id de section principale
+   * (`mainSectionId`) quand ce lieu représente la section (matching pour ouverture auto, refs Firebase).
+   */
+  id: string;
+  label: string;
+  slots: ClubRegistrationSiteSlot[];
+};
+
+/** Sections « principale / autres » (liste du formulaire papier / Webflow). */
+export const SECTION_PRINCIPALE_OPTIONS = [
+  { id: "voisins", label: "Voisins-le-Bretonneux" },
+  { id: "villepreux", label: "Villepreux" },
+  { id: "guyancourt", label: "Guyancourt" },
+  { id: "magny", label: "Magny-les-Hameaux" },
+  { id: "la-verriere", label: "La Verrière" },
+  { id: "trappes", label: "Trappes" },
+  { id: "handisport", label: "Section handisport" },
+  { id: "sport-adapte", label: "Section sport adapté" },
+] as const;
+
+/** Créneaux proposés par lieu (cases à cocher). */
+export const CLUB_REGISTRATION_SITES: ClubRegistrationSite[] = [
+  {
+    id: "voisins",
+    label: "Voisins-le-Bretonneux",
+    slots: [
+      { id: "voisins-lun-1730-jeunes-loisirs", label: "Lundi / 17h00 - 18h30 / Jeunes Loisirs" },
+      { id: "voisins-mar-1500-section-sportive", label: "Mardi / 15h00 - 17h00 / Section Sportive" },
+      { id: "voisins-mar-1830-handisport", label: "Mardi / 18h30 – 20h00 / Handisport" },
+      { id: "voisins-mar-1830-academie", label: "Mardi / 18h30 – 20h00 / Académie" },
+      { id: "voisins-mar-2030-adultes-compet", label: "Mardi / 20h30 – 22h30 / Adultes Compétiteurs" },
+      { id: "voisins-mar-2030-adultes-loisirs", label: "Mardi / 20h30 – 22h30 / Adultes Loisirs" },
+      { id: "voisins-mer-1300-individuel", label: "Mercredi / 13h00 – 14h00 / Individuel" },
+      { id: "voisins-mer-1400-jeunes-loisirs", label: "Mercredi / 14h00 – 15h30 / Jeunes Loisirs" },
+      { id: "voisins-mer-1530-jeunes-compet", label: "Mercredi / 15h30 – 17h00 / Jeunes Compétiteurs" },
+      { id: "voisins-mer-1700-jeunes-elites", label: "Mercredi / 17h00 – 19h00 / Jeunes Élites (sélection)" },
+      { id: "voisins-jeu-1700-jeunes", label: "Jeudi / 17h00 – 19h00 / Jeunes" },
+      { id: "voisins-jeu-1700-jeunes-elites", label: "Jeudi / 17h00 – 19h00 / Jeunes Élites (sélection)" },
+      { id: "voisins-jeu-1700-academie-handisport", label: "Jeudi / 17h00 – 19h00 / Académie Handisport" },
+      { id: "voisins-jeu-1900-adultes-elite", label: "Jeudi / 19h00 – 20h45 / Adultes Élite (sélection)" },
+      { id: "voisins-ven-1500-section-sportive", label: "Vendredi / 15h00 – 18h00 / Section Sportive" },
+      { id: "voisins-sam-1000-tous-publics", label: "Samedi / 10h00 – 12h00 / Tous publics" },
+    ],
+  },
+  {
+    id: "villepreux",
+    label: "Villepreux",
+    slots: [
+      { id: "villepreux-lun-1730-jeunes-loisirs", label: "Lundi / 17h00 - 18h30 / Jeunes Loisirs" },
+      { id: "villepreux-lun-1830-competiteurs", label: "Lundi / 18h30 - 20h00 / Compétiteurs" },
+      { id: "villepreux-lun-2030-adultes", label: "Lundi / 20h30 - 22h30 / Adultes" },
+      { id: "villepreux-mer-1400-jeunes-loisirs", label: "Mercredi / 14h00 – 15h30 / Jeunes Loisirs" },
+      { id: "villepreux-mer-1530-competiteurs", label: "Mercredi / 15h30 – 17h00 / Compétiteurs" },
+      { id: "villepreux-mer-1700-jeunes-elites", label: "Mercredi / 17h00 – 19h00 / Jeunes Élites (sélection)" },
+      { id: "villepreux-mer-2030-competiteurs", label: "Mercredi / 20h30 – 22h30 / Compétiteurs" },
+      { id: "villepreux-jeu-1030-sport-adapte", label: "Jeudi / 10h30 – 12h00 / Sport Adapté" },
+      { id: "villepreux-ven-1700-jeunes-loisirs", label: "Vendredi / 17h00 – 18h30 / Jeunes Loisirs" },
+      { id: "villepreux-ven-1830-jeunes-compet", label: "Vendredi / 18h30 – 20h00 / Jeunes Compétiteurs" },
+      { id: "villepreux-sam-1000-tous-publics", label: "Samedi / 10h00 – 12h00 / Tous publics" },
+    ],
+  },
+  {
+    id: "guyancourt",
+    label: "Guyancourt",
+    slots: [
+      { id: "guy-lun-1730-jeunes", label: "Lundi / 17h30 – 19h00 / Jeunes" },
+      { id: "guy-lun-1900-adultes-loisirs", label: "Lundi / 19h00 – 22h00 / Adultes Loisirs" },
+      { id: "guy-mar-1730-jeunes-loisirs-compet", label: "Mardi / 17h30 – 19h30 / Jeunes Loisirs et compétitions" },
+      { id: "guy-mar-2000-adultes-compet", label: "Mardi / 20h00 – 22h00 / Adultes Compétiteurs" },
+      { id: "guy-mer-1300-academie", label: "Mercredi / 13h00 – 17h00 / Académie" },
+      { id: "guy-mer-1600-jeunes-loisirs", label: "Mercredi / 16h00 – 17h30 / Jeunes Loisirs" },
+      { id: "guy-mer-1730-academie-handisport", label: "Mercredi / 17h30 – 19h30 / Académie Handisport" },
+      { id: "guy-ven-1800-jeunes-loisirs", label: "Vendredi / 18h00 – 20h00 / Jeunes Loisirs" },
+    ],
+  },
+  {
+    id: "la-verriere",
+    label: "La Verrière",
+    slots: [
+      { id: "lv-jeu-1800-jeunes-loisirs", label: "Jeudi / 18h00 – 19h30 / Jeunes Loisirs" },
+    ],
+  },
+  {
+    id: "vaucresson",
+    label: "Vaucresson",
+    slots: [
+      { id: "vau-lun-1900-handisport", label: "Lundi / 19h00 – 20h30 / Handisport" },
+      { id: "vau-jeu-1730-handisport", label: "Jeudi / 17h00 – 18h30 / Handisport" },
+    ],
+  },
+  {
+    id: "trappes",
+    label: "Trappes",
+    slots: [
+      { id: "trappes-mer-1730-jeunes-loisirs", label: "Mercredi / 17h30 – 19h30 / Jeunes Loisirs" },
+    ],
+  },
+  {
+    id: "magny",
+    label: "Magny-les-Hameaux",
+    slots: [
+      { id: "magny-mer-1800-jeunes", label: "Mercredi / 18h00 – 19h30 / Jeunes" },
+      { id: "magny-mer-2000-adultes", label: "Mercredi / 20h00 – 22h00 / Adultes" },
+      { id: "magny-jeu-1000-academie-handisport", label: "Jeudi / 10h00 – 12h00 / Académie handisport" },
+      { id: "magny-jeu-1300-academie-handisport", label: "Jeudi / 13h00 – 15h00 / Académie handisport" },
+      { id: "magny-ven-1830-tous-publics", label: "Vendredi / 18h30 – 20h00 / Tous publics" },
+    ],
+  },
+];
+
+/** Identifiants valides pour les créneaux (pour validation côté serveur). */
+export const ALL_SLOT_IDS: ReadonlySet<string> = new Set(
+  CLUB_REGISTRATION_SITES.flatMap((s) => s.slots.map((sl) => sl.id))
+);
+
+/** Compétitions optionnelles (bloc compétiteur). */
+export const COMPETITION_OPTIONS = [
+  {
+    id: "championnat_jeunes",
+    label: "Championnat des jeunes (25 € pouvant comprendre le critérium fédéral jeunes)",
+  },
+  {
+    id: "criterium_federal_jeunes",
+    label: "Critérium fédéral Jeunes (25 € pouvant comprendre le championnat des jeunes)",
+  },
+  { id: "championnat_equipe", label: "Championnat par équipe (25 €)" },
+  { id: "criterium_federal_seniors", label: "Critérium fédéral Seniors (42 €)" },
+  { id: "championnat_paris", label: "Championnat de Paris (15 €)" },
+  {
+    id: "competition_handisport",
+    label: "Compétition handisport (0 € — paiement à chaque compétition)",
+  },
+] as const;
+
+export const JERSEY_SIZES = ["XXS", "XS", "S", "M", "L", "XL", "XXL", "3XL", "4XL"] as const;
+
+export const REDUCTION_OPTIONS = [
+  { id: "pass_plus", label: "Pass Plus" },
+  { id: "pass_sport", label: "Pass Sport" },
+  { id: "labaz", label: "Labaz" },
+  { id: "aide_municipale", label: "Aide municipale" },
+] as const;
+
+/** Liens officiels (questionnaires, communication club). */
+export const CLUB_REGISTRATION_EXTERNAL_LINKS = {
+  questionnaireMajeur:
+    "https://cdn.prod.website-files.com/66e06edc471d4cd7cfe7d477/683f5edfa870f40a5e55c621_25-10-1-autoquestionnaire-medical-majeur.pdf",
+  questionnaireMineur:
+    "https://cdn.prod.website-files.com/66e06edc471d4cd7cfe7d477/683f5e0a8729cf962d616d7f_25-10-2-autoquestionnaire-medical-mineur.pdf",
+  siteClub: "https://www.sqyping.fr",
+  reglementInterieur:
+    "https://sqyping-my.sharepoint.com/:b:/r/personal/salome_nizan_sqyping_onmicrosoft_com/Documents/Voisins%20TT/Bureau%20-%20Administratif/Docs%20officiels%20club/R%C3%A8glement%20Int%C3%A9rieur/R%C3%A8glement%20Int%C3%A9rieur%20SQY%20PING%202019.pdf?csf=1&web=1&e=dbwOno",
+} as const;

--- a/src/lib/club-registration/phone-fr.ts
+++ b/src/lib/club-registration/phone-fr.ts
@@ -1,0 +1,57 @@
+/**
+ * Contrôle de surface pour numéros de téléphone français :
+ * - national : 10 chiffres, commence par 0 puis 1–9 (fixe 01–05 / 09, mobile 06–07, etc.)
+ * - international : +33 ou 0033 suivi de 9 chiffres sans le 0 initial
+ */
+
+const FR_NATIONAL = /^0[1-9]\d{8}$/;
+const FR_INTL_REST = /^[1-9]\d{8}$/;
+
+export function normalizeFrenchPhoneInput(raw: string): string | null {
+  const trimmed = raw.trim().replace(/[\s.\-\u00A0]/g, "");
+  if (trimmed === "") return null;
+  if (trimmed.startsWith("+33")) {
+    const rest = trimmed.slice(3);
+    return FR_INTL_REST.test(rest) ? `0${rest}` : null;
+  }
+  if (trimmed.startsWith("0033")) {
+    const rest = trimmed.slice(4);
+    return FR_INTL_REST.test(rest) ? `0${rest}` : null;
+  }
+  if (FR_NATIONAL.test(trimmed)) return trimmed;
+  return null;
+}
+
+export function isValidFrenchPhoneSurface(raw: string): boolean {
+  return normalizeFrenchPhoneInput(raw) !== null;
+}
+
+/** Masque d’affichage / saisie : groupes de 2 chiffres (ex. 06 34 44 55 33). */
+export function formatFrenchPhoneMask(digits: string): string {
+  const d = digits.replace(/\D/g, "").slice(0, 10);
+  if (d.length === 0) return "";
+  const parts: string[] = [];
+  for (let i = 0; i < d.length; i += 2) {
+    parts.push(d.slice(i, i + 2));
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Interprète la saisie ou un collage : renvoie uniquement les chiffres nationaux (max 10).
+ * Reconnait +33 / 0033 ; sinon ne garde que les chiffres.
+ */
+export function extractNationalDigitsForMask(raw: string): string {
+  const t = raw.trim();
+  if (t === "") return "";
+  if (t.startsWith("+") || t.startsWith("00")) {
+    const n = normalizeFrenchPhoneInput(t);
+    return n ?? "";
+  }
+  return t.replace(/\D/g, "").slice(0, 10);
+}
+
+/** Valeur stockée → affichage masqué (rechargement API, valeurs sans espaces). */
+export function toFrenchPhoneMaskedDisplay(stored: string): string {
+  return formatFrenchPhoneMask(extractNationalDigitsForMask(stored));
+}

--- a/src/lib/club-registration/schema.test.ts
+++ b/src/lib/club-registration/schema.test.ts
@@ -1,0 +1,226 @@
+import { clubRegistrationPayloadSchema } from "./schema";
+
+/**
+ * Helper qui construit un payload valide minimal pour un adulte qui s'inscrit lui-même,
+ * et permet d'écraser des champs spécifiques pour cibler chaque cas de test.
+ */
+function buildPayload(
+  overrides: Partial<Parameters<typeof clubRegistrationPayloadSchema.safeParse>[0]> = {}
+) {
+  const base = {
+    adherentRole: "self" as const,
+    firstName: "Olivier",
+    lastName: "Dupont",
+    sex: "male" as const,
+    birthCity: "Paris",
+    birthDate: "1985-04-12",
+    adherentEmail: "olivier@example.com",
+    adherentPhonePrimary: "0612345678",
+    adherentPhoneSecondary: "",
+    addressLine1: "12 rue Victor Hugo",
+    addressLine2: "",
+    postalCode: "78280",
+    city: "Guyancourt",
+    representatives: [],
+    mainSectionId: "voisins",
+    additionalSectionIds: [],
+    slotIds: ["voisins-mar-2030-adultes-loisirs"],
+    medicalCertificateDeclaration: "under_40_all_no",
+    wantsRegistrationCertificate: false,
+    familyRegistrationOrder: "none",
+    reductionTypes: [],
+    passSportCode: "",
+    photoConsent: "accept",
+    emergencyMedicalAuthorization: "not_applicable_adult",
+    supervisionAcknowledgement: "not_applicable_adult",
+    internalRulesAccepted: true,
+    wantsCompetitorExtras: false,
+    competitionIds: [],
+  };
+  return { ...base, ...overrides };
+}
+
+describe("clubRegistrationPayloadSchema", () => {
+  it("accepte un payload minimal valide pour un adulte qui s'inscrit lui-même", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(buildPayload());
+    expect(r.success).toBe(true);
+  });
+
+  it("refuse un mineur qui s'inscrit en mode self", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ birthDate: "2015-04-12", adherentRole: "self" })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes("adherentRole"))).toBe(true);
+    }
+  });
+
+  it("refuse un mineur en mode minor_dependent sans représentant", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "2015-04-12",
+        adherentRole: "minor_dependent",
+        representatives: [],
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path[0] === "representatives")).toBe(true);
+    }
+  });
+
+  it("accepte un mineur avec un représentant légal", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "2015-04-12",
+        adherentRole: "minor_dependent",
+        emergencyMedicalAuthorization: "yes",
+        supervisionAcknowledgement: "yes",
+        representatives: [
+          {
+            role: "mother",
+            firstName: "Marie",
+            lastName: "Dupont",
+            email: "marie@example.com",
+            phone: "0612345670",
+          },
+        ],
+      })
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("refuse 2 représentants avec le même email", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "2015-04-12",
+        adherentRole: "minor_dependent",
+        emergencyMedicalAuthorization: "yes",
+        supervisionAcknowledgement: "yes",
+        representatives: [
+          {
+            role: "mother",
+            firstName: "Marie",
+            lastName: "Dupont",
+            email: "duplicate@example.com",
+            phone: "0612345670",
+          },
+          {
+            role: "father",
+            firstName: "Pierre",
+            lastName: "Dupont",
+            email: "duplicate@example.com",
+            phone: "0612345671",
+          },
+        ],
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path[0] === "representatives")).toBe(true);
+    }
+  });
+
+  it("refuse 3 représentants (max 2)", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "2015-04-12",
+        adherentRole: "minor_dependent",
+        emergencyMedicalAuthorization: "yes",
+        supervisionAcknowledgement: "yes",
+        representatives: [
+          { role: "mother", firstName: "A", lastName: "A", email: "a@a.fr", phone: "0612345670" },
+          { role: "father", firstName: "B", lastName: "B", email: "b@b.fr", phone: "0612345671" },
+          { role: "guardian", firstName: "C", lastName: "C", email: "c@c.fr", phone: "0612345672" },
+        ],
+      })
+    );
+    expect(r.success).toBe(false);
+  });
+
+  it("refuse un adulte (self) avec un représentant légal", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        adherentRole: "self",
+        representatives: [
+          {
+            role: "mother",
+            firstName: "Marie",
+            lastName: "Dupont",
+            email: "marie@example.com",
+            phone: "0612345670",
+          },
+        ],
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path[0] === "representatives")).toBe(true);
+    }
+  });
+
+  it("refuse un autre adulte (other_adult) avec un représentant légal", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        adherentRole: "other_adult",
+        representatives: [
+          {
+            role: "guardian",
+            firstName: "Tuteur",
+            lastName: "Légal",
+            email: "tuteur@example.com",
+            phone: "0612345670",
+          },
+        ],
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path[0] === "representatives")).toBe(true);
+    }
+  });
+
+  it("refuse une femme sans firstFemaleRegistrationSqy", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ sex: "female", firstFemaleRegistrationSqy: undefined })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("firstFemaleRegistrationSqy"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse un compétiteur sans taille de maillot", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ wantsCompetitorExtras: true, competitionJerseySize: undefined })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("competitionJerseySize"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse un téléphone principal invalide", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ adherentPhonePrimary: "01234" })
+    );
+    expect(r.success).toBe(false);
+  });
+
+  it("refuse un payload sans créneau", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(buildPayload({ slotIds: [] }));
+    expect(r.success).toBe(false);
+  });
+
+  it("refuse une section additionnelle qui reprend la principale", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ mainSectionId: "voisins", additionalSectionIds: ["voisins"] })
+    );
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/lib/club-registration/schema.ts
+++ b/src/lib/club-registration/schema.ts
@@ -1,0 +1,212 @@
+import { z } from "zod";
+import {
+  ALL_SLOT_IDS,
+  COMPETITION_OPTIONS,
+  JERSEY_SIZES,
+  REDUCTION_OPTIONS,
+  SECTION_PRINCIPALE_OPTIONS,
+} from "./constants";
+import { isValidFrenchPhoneSurface, normalizeFrenchPhoneInput } from "./phone-fr";
+import { isMinorAt } from "./age";
+
+const sectionIds = SECTION_PRINCIPALE_OPTIONS.map((s) => s.id) as [
+  string,
+  ...string[],
+];
+
+const competitionIds = COMPETITION_OPTIONS.map((c) => c.id) as [
+  string,
+  ...string[],
+];
+
+const reductionIds = REDUCTION_OPTIONS.map((r) => r.id) as [string, ...string[]];
+
+/**
+ * Sous-schéma téléphone FR : surface acceptée puis normalisée (10 chiffres commençant par 0).
+ */
+const frenchPhoneRequired = z
+  .string()
+  .trim()
+  .min(1)
+  .max(40)
+  .refine(isValidFrenchPhoneSurface, {
+    message:
+      "Numéro de téléphone français invalide (10 chiffres commençant par 0, ou format +33).",
+  })
+  .transform((s) => normalizeFrenchPhoneInput(s)!);
+
+const frenchPhoneOptional = z
+  .union([z.literal(""), z.string().trim().max(40)])
+  .optional()
+  .refine((v) => v === undefined || v === "" || isValidFrenchPhoneSurface(v), {
+    message:
+      "Numéro de téléphone français invalide (10 chiffres commençant par 0, ou format +33).",
+  })
+  .transform((v) => {
+    if (v === undefined || v === "") return undefined;
+    return normalizeFrenchPhoneInput(v)!;
+  });
+
+/** Représentant légal (mère, père, tuteur, autre). 0 à 2 par dossier. */
+export const representativeSchema = z.object({
+  role: z.enum(["mother", "father", "guardian", "self", "other"]),
+  firstName: z.string().trim().min(1, "Le prénom est obligatoire").max(120),
+  lastName: z.string().trim().min(1, "Le nom est obligatoire").max(120),
+  email: z.string().trim().email("Adresse e-mail invalide"),
+  phone: frenchPhoneRequired,
+});
+
+export type Representative = z.infer<typeof representativeSchema>;
+
+/** Rôle du soumettant vis-à-vis de l'adhérent (qui remplit le formulaire et pour qui). */
+export const adherentRoleSchema = z.enum([
+  "self",
+  "minor_dependent",
+  "other_adult",
+]);
+export type AdherentRole = z.infer<typeof adherentRoleSchema>;
+
+export const clubRegistrationPayloadSchema = z
+  .object({
+    /* Bloc adhérent ----------------------------------------------------- */
+    adherentRole: adherentRoleSchema,
+    firstName: z.string().trim().min(1, "Le prénom est obligatoire").max(120),
+    lastName: z.string().trim().min(1, "Le nom est obligatoire").max(120),
+    sex: z.enum(["female", "male", "other"]),
+    birthCity: z.string().trim().min(1, "La ville de naissance est obligatoire").max(120),
+    birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date invalide (AAAA-MM-JJ)"),
+    adherentEmail: z
+      .union([z.literal(""), z.string().trim().email("Adresse e-mail invalide")])
+      .optional(),
+    adherentPhonePrimary: frenchPhoneRequired,
+    adherentPhoneSecondary: frenchPhoneOptional,
+
+    /* Adresse postale --------------------------------------------------- */
+    addressLine1: z.string().trim().min(1, "L’adresse est obligatoire").max(200),
+    addressLine2: z.union([z.literal(""), z.string().trim().max(200)]).optional(),
+    postalCode: z
+      .string()
+      .trim()
+      .regex(/^[0-9]{5}$/, "Code postal français attendu (5 chiffres)"),
+    city: z.string().trim().min(1, "La ville est obligatoire").max(120),
+
+    /* Représentants légaux (0..2) -------------------------------------- */
+    representatives: z.array(representativeSchema).max(2, "Maximum 2 représentants légaux").default([]),
+
+    /* Sections / créneaux ---------------------------------------------- */
+    mainSectionId: z.enum(sectionIds),
+    additionalSectionIds: z.array(z.enum(sectionIds)).default([]),
+    slotIds: z.array(z.string()).min(1, "Sélectionnez au moins un créneau"),
+
+    /* Médical / aides -------------------------------------------------- */
+    medicalCertificateDeclaration: z.enum([
+      "under_40_all_no",
+      "over_40_cert_unchanged_all_no",
+      "questionnaire_yes_certificate_required",
+    ]),
+    wantsRegistrationCertificate: z.boolean(),
+    familyRegistrationOrder: z.enum(["none", "second", "third_or_more"]),
+    reductionTypes: z.array(z.enum(reductionIds)).default([]),
+    passSportCode: z.union([z.literal(""), z.string().trim().max(80)]).optional(),
+    firstFemaleRegistrationSqy: z.boolean().optional(),
+
+    /* Autorisations ---------------------------------------------------- */
+    photoConsent: z.enum(["accept", "refuse"]),
+    emergencyMedicalAuthorization: z.enum(["yes", "not_applicable_adult"]),
+    supervisionAcknowledgement: z.enum(["yes", "not_applicable_adult"]),
+    internalRulesAccepted: z.literal(true),
+
+    /* Section compétiteur --------------------------------------------- */
+    wantsCompetitorExtras: z.boolean(),
+    competitionJerseySize: z.enum(JERSEY_SIZES).optional(),
+    competitionIds: z.array(z.enum(competitionIds)).default([]),
+  })
+  .superRefine((data, ctx) => {
+    /* Créneaux connus */
+    for (const id of data.slotIds) {
+      if (!ALL_SLOT_IDS.has(id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Créneau inconnu",
+          path: ["slotIds"],
+        });
+        return;
+      }
+    }
+
+    /* Sections additionnelles ne reprennent pas la principale */
+    const uniqueAdditional = new Set(data.additionalSectionIds);
+    if (uniqueAdditional.has(data.mainSectionId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Les autres sections ne peuvent pas reprendre la section principale",
+        path: ["additionalSectionIds"],
+      });
+    }
+
+    /* Femme : préciser si première inscription féminine au club */
+    if (data.sex === "female" && data.firstFemaleRegistrationSqy === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Indiquez s’il s’agit de votre première inscription au club",
+        path: ["firstFemaleRegistrationSqy"],
+      });
+    }
+
+    /* Compétiteur : taille de maillot obligatoire */
+    if (data.wantsCompetitorExtras && !data.competitionJerseySize) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Taille de maillot obligatoire pour la section compétiteur",
+        path: ["competitionJerseySize"],
+      });
+    }
+
+    /* Mineur dépendant : au moins un représentant légal */
+    if (data.adherentRole === "minor_dependent" && data.representatives.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Au moins un représentant légal est requis pour l'inscription d'un mineur",
+        path: ["representatives"],
+      });
+    }
+
+    /* Adulte (self / other_adult) : pas de représentants légaux */
+    if (data.adherentRole !== "minor_dependent" && data.representatives.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Les représentants légaux ne s'appliquent qu'à l'inscription d'un mineur",
+        path: ["representatives"],
+      });
+    }
+
+    /* Cohérence âge / rôle */
+    const minor = isMinorAt(data.birthDate);
+    if (minor && data.adherentRole === "self") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "La date de naissance correspond à un mineur : indiquez un représentant légal et passez en mode \"mineur\".",
+        path: ["adherentRole"],
+      });
+    }
+    if (minor && data.adherentRole === "minor_dependent" && data.representatives.length === 0) {
+      // déjà couvert plus haut, pas de doublon ici
+    }
+
+    /* Emails distincts entre les représentants */
+    if (data.representatives.length === 2) {
+      const a = data.representatives[0].email.trim().toLowerCase();
+      const b = data.representatives[1].email.trim().toLowerCase();
+      if (a && b && a === b) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Les deux représentants doivent avoir des emails distincts",
+          path: ["representatives"],
+        });
+      }
+    }
+  });
+
+export type ClubRegistrationPayload = z.infer<typeof clubRegistrationPayloadSchema>;

--- a/src/lib/geocoding/ban-query-filter.test.ts
+++ b/src/lib/geocoding/ban-query-filter.test.ts
@@ -1,0 +1,44 @@
+import { filterBanFeaturesByQuery, meaningfulQueryTokens } from "./ban-query-filter";
+import type { BanFeature } from "./ban";
+
+function feat(label: string, score: number): BanFeature {
+  return {
+    type: "Feature",
+    properties: {
+      label,
+      score,
+      postcode: "75000",
+      city: "Paris",
+    },
+  };
+}
+
+describe("meaningfulQueryTokens", () => {
+  it("extrait mail et the depuis thé", () => {
+    expect(meaningfulQueryTokens("1 mail thé").sort()).toEqual(["mail", "the"].sort());
+  });
+});
+
+describe("filterBanFeaturesByQuery", () => {
+  it("priorise une voie dont un mot commence par le segment (Thérèse avant Barthelemy)", () => {
+    const q = "1 mail the";
+    const features: BanFeature[] = [
+      feat("1 Mail Barthelemy Thimonnier 77185 Lognes", 0.95),
+      feat("1 Mail Thérèse Desqueyroux 78280 Guyancourt", 0.88),
+    ];
+    const out = filterBanFeaturesByQuery(q, features);
+    expect(out.length).toBeGreaterThanOrEqual(2);
+    expect(out[0]?.properties.label).toContain("Thérèse");
+  });
+
+  it("exclut une rue qui ne contient pas tous les segments", () => {
+    const q = "1 mail thér";
+    const features: BanFeature[] = [
+      feat("1 Mail Thérèse Desqueyroux 78280 Guyancourt", 0.9),
+      feat("1 Mail des Tertres 92220 Bagneux", 0.85),
+    ];
+    const out = filterBanFeaturesByQuery(q, features);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.properties.label).toContain("Thérèse");
+  });
+});

--- a/src/lib/geocoding/ban-query-filter.ts
+++ b/src/lib/geocoding/ban-query-filter.ts
@@ -1,0 +1,106 @@
+/**
+ * Filtre les résultats BAN : l’API renvoie souvent des correspondances « floues » peu pertinentes.
+ * On garde les entrées dont le libellé contient tous les segments utiles de la requête
+ * (insensible à la casse et aux accents).
+ */
+
+import type { BanFeature } from "./ban";
+
+function stripDiacritics(s: string): string {
+  return s.normalize("NFD").replace(/\p{M}/gu, "");
+}
+
+function foldLatinLigatures(s: string): string {
+  return s.replace(/œ/g, "oe").replace(/Œ/g, "oe").replace(/æ/g, "ae").replace(/Æ/g, "ae");
+}
+
+function normalizeForMatch(s: string): string {
+  const d = foldLatinLigatures(stripDiacritics(s.toLowerCase()));
+  return d.replace(/[-']/g, " ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Segments à croiser avec le libellé : mots d’au moins 3 lettres (hors pur numérique).
+ * Ex. « 1 mail thé » → [« mail », « the »].
+ */
+export function meaningfulQueryTokens(query: string): string[] {
+  const parts = query.trim().split(/\s+/).filter(Boolean);
+  const out: string[] = [];
+  for (const part of parts) {
+    const alnum = foldLatinLigatures(stripDiacritics(part.toLowerCase())).replace(
+      /[^a-z0-9]/gi,
+      ""
+    );
+    if (alnum.length >= 3 && !/^\d+$/.test(alnum)) {
+      out.push(alnum);
+    }
+  }
+  return out;
+}
+
+function normalizedWords(label: string): string[] {
+  return normalizeForMatch(label)
+    .split(/\s+/)
+    .map((w) => stripDiacritics(w.toLowerCase()).replace(/[^a-z0-9]/gi, ""))
+    .filter(Boolean);
+}
+
+/** Le segment matche si sous-chaîne OU début d’un mot (ex. « the » → « Thérèse »). */
+export function tokenMatchesLabel(label: string, token: string): boolean {
+  const compact = normalizeForMatch(label).replace(/\s+/g, "").replace(/[^a-z0-9]/gi, "");
+  if (compact.includes(token)) return true;
+  const words = normalizedWords(label);
+  return words.some((w) => w.startsWith(token));
+}
+
+function labelMatchesAllTokens(label: string, tokens: string[]): boolean {
+  return tokens.every((t) => tokenMatchesLabel(label, t));
+}
+
+/**
+ * Score de pertinence : fort bonus si le segment est préfixe d’un mot du libellé
+ * (évite qu’un « Barthelemy » passe avant « Thérèse » pour la saisie « the »).
+ */
+function matchRankLabel(label: string, tokens: string[]): number {
+  const words = normalizedWords(label);
+  const compact = normalizeForMatch(label).replace(/\s+/g, "").replace(/[^a-z0-9]/gi, "");
+  let rank = 0;
+  for (const t of tokens) {
+    const prefix = words.some((w) => w.startsWith(t));
+    const sub = compact.includes(t);
+    if (prefix) rank += 100;
+    else if (sub) rank += 15;
+  }
+  return rank;
+}
+
+/**
+ * Trie d’abord par pertinence des segments, puis par score BAN.
+ * Demande un peu plus de résultats bruts (voir route API) pour que la BAN renvoie
+ * aussi les voies correctes mal classées dans les premiers rangs.
+ */
+export function filterBanFeaturesByQuery(query: string, features: BanFeature[]): BanFeature[] {
+  const sortedByBan = [...features].sort(
+    (a, b) => (b.properties.score ?? 0) - (a.properties.score ?? 0)
+  );
+  const tokens = meaningfulQueryTokens(query);
+  if (tokens.length === 0) {
+    return sortedByBan.slice(0, 8);
+  }
+  const filtered = sortedByBan.filter((f) =>
+    labelMatchesAllTokens(f.properties.label ?? "", tokens)
+  );
+  /* Évite liste vide si la saisie est trop atypique ou si la BAN classe mal : on montre les meilleurs scores bruts. */
+  if (filtered.length === 0 && sortedByBan.length > 0) {
+    return sortedByBan.slice(0, 8);
+  }
+  const ranked = [...filtered].sort((a, b) => {
+    const la = a.properties.label ?? "";
+    const lb = b.properties.label ?? "";
+    const ra = matchRankLabel(la, tokens);
+    const rb = matchRankLabel(lb, tokens);
+    if (rb !== ra) return rb - ra;
+    return (b.properties.score ?? 0) - (a.properties.score ?? 0);
+  });
+  return ranked.slice(0, 8);
+}

--- a/src/lib/geocoding/ban-supplemental-query.test.ts
+++ b/src/lib/geocoding/ban-supplemental-query.test.ts
@@ -1,0 +1,43 @@
+import {
+  buildSupplementalBanQuery,
+  mergeBanFeaturesPreferHigherScore,
+} from "./ban-supplemental-query";
+import type { BanFeature } from "./ban";
+
+describe("buildSupplementalBanQuery", () => {
+  it("étend « the » final en « ther »", () => {
+    expect(buildSupplementalBanQuery("1 mail the")).toBe("1 mail ther");
+    expect(buildSupplementalBanQuery("  1 mail the  ")).toBe("1 mail ther");
+  });
+
+  it("étend « thé » final en « ther »", () => {
+    expect(buildSupplementalBanQuery("1 mail thé")).toBe("1 mail ther");
+  });
+
+  it("ne change pas si pas de motif", () => {
+    expect(buildSupplementalBanQuery("1 mail ther")).toBeNull();
+    expect(buildSupplementalBanQuery("rue de paris")).toBeNull();
+  });
+});
+
+describe("mergeBanFeaturesPreferHigherScore", () => {
+  const f = (id: string, label: string, score: number): BanFeature => ({
+    type: "Feature",
+    properties: { id, label, score },
+  });
+
+  it("dédoublonne par id et garde le meilleur score", () => {
+    const a = [f("a", "x", 0.5)];
+    const b = [f("a", "x", 0.9)];
+    const m = mergeBanFeaturesPreferHigherScore(a, b);
+    expect(m).toHaveLength(1);
+    expect(m[0]?.properties.score).toBe(0.9);
+  });
+
+  it("fusionne deux listes distinctes", () => {
+    const a = [f("1", "a", 1)];
+    const b = [f("2", "b", 0.5)];
+    const m = mergeBanFeaturesPreferHigherScore(a, b);
+    expect(m.map((x) => x.properties.id).sort()).toEqual(["1", "2"]);
+  });
+});

--- a/src/lib/geocoding/ban-supplemental-query.ts
+++ b/src/lib/geocoding/ban-supplemental-query.ts
@@ -1,0 +1,34 @@
+/**
+ * La BAN classe souvent mal les voies dont le nom commence comme « Thérèse » quand l’utilisateur
+ * n’a encore tapé que « the » / « thé » : les 20 premiers résultats ne contiennent pas la bonne ligne.
+ * Une 2ᵉ requête avec « … ther » ramène typiquement « Mail Thérèse Desqueyroux ».
+ */
+
+import type { BanFeature } from "./ban";
+
+export function buildSupplementalBanQuery(q: string): string | null {
+  const trimmed = q.trimEnd();
+  if (/\bthe\s*$/i.test(trimmed)) {
+    return trimmed.replace(/\bthe\s*$/i, "ther").trim();
+  }
+  if (/\bth[eé]\s*$/i.test(trimmed)) {
+    return trimmed.replace(/\bth[eé]\s*$/i, "ther").trim();
+  }
+  return null;
+}
+
+/** Dédouble les features par id (sinon label), en gardant le meilleur score BAN. */
+export function mergeBanFeaturesPreferHigherScore(a: BanFeature[], b: BanFeature[]): BanFeature[] {
+  const keyOf = (f: BanFeature) => String(f.properties.id ?? f.properties.label);
+  const map = new Map<string, BanFeature>();
+  const mergeOne = (f: BanFeature) => {
+    const k = keyOf(f);
+    const existing = map.get(k);
+    const s = f.properties.score ?? 0;
+    const es = existing?.properties.score ?? 0;
+    if (!existing || s > es) map.set(k, f);
+  };
+  a.forEach(mergeOne);
+  b.forEach(mergeOne);
+  return [...map.values()].sort((x, y) => (y.properties.score ?? 0) - (x.properties.score ?? 0));
+}

--- a/src/lib/geocoding/ban.test.ts
+++ b/src/lib/geocoding/ban.test.ts
@@ -1,0 +1,10 @@
+import { extractPostcodeCityFromLabel } from "./ban";
+
+describe("extractPostcodeCityFromLabel", () => {
+  it("extrait CP et commune en fin de libellé BAN", () => {
+    expect(extractPostcodeCityFromLabel("1 Mail Thérèse Desqueyroux 78280 Guyancourt")).toEqual({
+      postcode: "78280",
+      city: "Guyancourt",
+    });
+  });
+});

--- a/src/lib/geocoding/ban.ts
+++ b/src/lib/geocoding/ban.ts
@@ -1,0 +1,100 @@
+/**
+ * Types et extraction pour l’API Adresse (Base Adresse Nationale / data.gouv).
+ * https://adresse.data.gouv.fr/outils/doc/api/adresse/
+ */
+
+export type BanFeatureProperties = {
+  label: string;
+  score?: number;
+  housenumber?: string;
+  id?: string;
+  name?: string;
+  postcode?: string;
+  citycode?: string;
+  city?: string;
+  street?: string;
+  context?: string;
+  type?: string;
+};
+
+export type BanFeature = {
+  type: "Feature";
+  properties: BanFeatureProperties;
+};
+
+export type BanSearchResponse = {
+  type: "FeatureCollection";
+  features: BanFeature[];
+};
+
+export type ParsedBanAddress = {
+  /** Identifiant stable pour les options Autocomplete */
+  optionId: string;
+  /** Libellé affiché (properties.label) */
+  label: string;
+  addressLine1: string;
+  postalCode: string;
+  city: string;
+};
+
+function buildAddressLine1(props: BanFeatureProperties): string {
+  const postcode = props.postcode?.trim() ?? "";
+  const city = props.city?.trim() ?? "";
+  const fromParts = [props.housenumber, props.street || props.name]
+    .filter((x): x is string => Boolean(x && x.trim()))
+    .join(" ")
+    .trim();
+  if (fromParts) return fromParts;
+  if (props.label && postcode) {
+    const tail = new RegExp(`\\s*${escapeRegex(postcode)}\\s*${escapeRegex(city)}\\s*$`, "i");
+    const stripped = props.label.replace(tail, "").trim();
+    if (stripped) return stripped;
+  }
+  return props.label.trim();
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * La BAN n’alimente pas toujours postcode/city dans properties ; le libellé contient souvent « CP ville » en fin de chaîne.
+ */
+export function extractPostcodeCityFromLabel(label: string): { postcode: string; city: string } | null {
+  const trimmed = label.trim();
+  const m = trimmed.match(/(\d{5})\s+([^,]+?)\s*$/u);
+  if (!m?.[1] || !m[2]) return null;
+  const city = m[2].trim();
+  if (city.length < 2) return null;
+  return { postcode: m[1], city };
+}
+
+export function banFeatureToParsedAddress(feature: BanFeature, index: number): ParsedBanAddress | null {
+  const props = feature.properties;
+  let postalCode = props.postcode?.trim() ?? "";
+  let city = props.city?.trim() ?? "";
+  if (!postalCode || !city) {
+    const fromLabel = extractPostcodeCityFromLabel(props.label?.trim() ?? "");
+    if (fromLabel) {
+      if (!postalCode) postalCode = fromLabel.postcode;
+      if (!city) city = fromLabel.city;
+    }
+  }
+  if (!postalCode || !city) {
+    return null;
+  }
+  let addressLine1 = buildAddressLine1(props);
+  if (!addressLine1) {
+    addressLine1 = city;
+  }
+  const baseKey = props.id?.trim() ?? `${props.label}|${postalCode}`;
+  /* Index obligatoire : la BAN peut renvoyer plusieurs entrées au même libellé / même id. */
+  const optionId = `${baseKey}::__${index}`;
+  return {
+    optionId,
+    label: props.label.trim(),
+    addressLine1,
+    postalCode,
+    city,
+  };
+}


### PR DESCRIPTION
## Contexte

Refonte UX et technique du formulaire d'inscription au club pour permettre une **saisie en mode anonyme** ou connecté, avec passage à l'authentification uniquement au moment de l'envoi (livraison effective de la soumission prévue dans la PR suivante).

Cette PR pose toute l'infrastructure (UI, état, stockage local, schémas, API et règles Firestore) ; la soumission reste désactivée derrière le feature flag `NEXT_PUBLIC_HYBRID_SUBMIT_ENABLED`.

## Cas d'usage couverts

- Un visiteur **anonyme** peut remplir l'intégralité du formulaire et retrouver sa saisie au prochain passage (sauvegarde locale).
- Un compte unique peut soumettre **plusieurs dossiers** (ex. une mère qui inscrit ses deux enfants) → chaque dossier porte ses propres adresses (adhérent + représentants), distinctes de l'adresse du soumettant.
- Distinction claire des trois rôles : **soumettant** (compte connecté), **adhérent** (la personne inscrite) et **représentants légaux** (0..2, uniquement pour les mineurs).

## Changements principaux

### Domaine (`src/lib/club-registration/`)
- Nouveau `clubRegistrationPayloadSchema` (Zod) avec `adherentRole` (`self` / `minor_dependent` / `other_adult`) et `representatives` (0..2).
- Invariants : représentants **interdits pour les majeurs**, **requis pour les mineurs**, e-mails distincts entre représentants, cohérence date de naissance / rôle.
- Helpers `isAdultAt` / `isMinorAt` couverts par tests, validation FR du téléphone partagée, fixtures de dev.

### État (`src/components/club-registration/`)
- `useRegistrationDraft` (`useReducer`) : encapsule les invariants côté UI (vidage automatique des représentants quand l'utilisateur bascule vers un rôle adulte, reset cohérent de `firstFemaleRegistrationSqy`).
- `useRegistrationDraftStorage` : sauvegarde locale debouncée et versionnée, désactivable et effaçable.

### UI
- Wizard 5 étapes (Identité, Sections, Médical, Autorisations, **Récap**) avec navigation non linéaire.
- `IdentityStep` refondu : sélection du rôle d'inscription, contact adhérent distinct du soumettant, bloc Représentants visible uniquement pour les mineurs.
- `RecapStep` dédié : édition par section et bloc « Adresses e-mail enregistrées » qui rend explicite la distinction soumettant / adhérent / représentants.
- Pied de wizard discret pour la sauvegarde locale (information légale via Popover « En savoir plus »).

### Backend
- `POST /api/club/registration` (id auto, snapshot du soumettant, 503 tant que le flag est off).
- `GET /api/club/registration?id=` et `GET /api/club/registrations` (liste des dossiers du soumettant connecté).
- Règles Firestore et indexes composites pour `clubRegistrations` (lecture par propriétaire ou admin, mise à jour bloquée après approbation, listing par `submitterUid` + `submittedAt`).

### Divers
- Middleware : `/club/inscription` ouvert au public via `PUBLIC_ROUTES` et `PUBLIC_EXACT_ROUTES`.
- Layout : entrée « Inscription club » dans la navigation joueur.
- Audit logger : action dédiée à la création d'un dossier d'inscription.

## Cadrage RGPD

La sauvegarde locale du brouillon entre dans la catégorie **stockage strictement nécessaire au service explicitement demandé par l'utilisateur** (CNIL — lignes directrices cookies/traceurs, art. 82 LCEN). Information claire via un pied de page discret + Popover ; pas de consentement préalable obligatoire. L'utilisateur peut effacer ou désactiver la sauvegarde à tout tout moment.

## Tests

- 81 tests verts (Jest), dont :
  - `schema.test.ts` (15 tests) : couverture des invariants multi-rôle / représentants / âge.
  - `age.test.ts` : 18ᵉ anniversaire pile, années bissextiles, fuseaux.
  - `useRegistrationDraft.test.ts` : transitions de rôle, vidage des représentants, reset sex.
  - `useRegistrationDraftStorage.test.ts` : debounce, version mismatch, désactivation.
  - Tests BAN (`ban.test.ts`, `ban-query-filter.test.ts`, `ban-supplemental-query.test.ts`).
- `npm run check` (lint + type-check + build) ✅

## Test plan manuel

- [x] Accès à `/club/inscription` en mode anonyme (sans header de connexion redondant).
- [x] Saisie complète, fermeture de l'onglet, retour → brouillon retrouvé.
- [x] Bascule de rôle adulte → mineur → adulte : représentants ajoutés / vidés correctement.
- [x] Étape récap : bloc « Adresses e-mail » affiche « (à confirmer à la connexion) » en anonyme et l'e-mail du compte en connecté.
- [x] Effacer / Désactiver la sauvegarde locale fonctionnent.
- [x] `POST /api/club/registration` renvoie 503 (flag off).
- [x] `npm run check` ✅
- [ ] Revue UX par l'auteur des designs.

## Suivi (PR suivante)

- `AuthDialog` réutilisable (login + signup + reset + Google/Facebook prêts).
- Branchement de l'`AuthDialog` au moment de l'envoi (anonyme → flow login/signup → POST).
- Activation du `POST /api/club/registration` derrière le flag.
- Page « Mes dossiers » qui consomme `GET /api/club/registrations`.

Made with [Cursor](https://cursor.com)