### PR TITLE
🛡️ Sentinel: Harden API routes with standardized auth and RBAC

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,32 +1,14 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
 import type { DocumentData, QueryDocumentSnapshot, Query } from "firebase-admin/firestore";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
+import { USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
 import type { User } from "@/types";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        { success: false, error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
     const firestore = getFirestoreAdmin();
 
     // Récupérer tous les utilisateurs avec pagination
@@ -173,6 +155,4 @@ export async function GET() {
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN]);

--- a/src/app/api/teams/[teamId]/matches/route.ts
+++ b/src/app/api/teams/[teamId]/matches/route.ts
@@ -1,43 +1,17 @@
-import type { NextRequest } from "next/server";
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
 import { getTeamMatches } from "@/lib/server/team-matches";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 export const runtime = "nodejs";
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ teamId: string }> }
-) {
-  // Vérification d'authentification
-  const cookieStore = await cookies();
-  const sessionCookie = cookieStore.get("__session")?.value;
-  
-  if (!sessionCookie) {
-    return jsonNoStore(
-      { error: "Authentification requise" },
-      { status: 401 }
-    );
-  }
-
-  try {
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    if (!decoded.email_verified) {
-      return jsonNoStore(
-        { error: "Email non vérifié" },
-        { status: 403 }
-      );
-    }
-  } catch {
-    return jsonNoStore(
-      { error: "Session invalide" },
-      { status: 401 }
-    );
-  }
-
+export const GET = withAuth(async (
+  _request: Request,
+  context: any
+) => {
   // Récupérer teamId depuis les paramètres de route
-  const { teamId } = await params;
+  const { teamId } = await (context.params as Promise<{ teamId: string }>);
 
   if (!teamId || typeof teamId !== "string") {
     return jsonNoStore(
@@ -68,11 +42,8 @@ export async function GET(
     return jsonNoStore(
       {
         error: "Failed to fetch team matches",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/teams/[teamId]/matches/route.ts
+++ b/src/app/api/teams/[teamId]/matches/route.ts
@@ -8,10 +8,12 @@ export const runtime = "nodejs";
 
 export const GET = withAuth(async (
   _request: Request,
-  context: any
+  context: unknown
 ) => {
   // Récupérer teamId depuis les paramètres de route
-  const { teamId } = await (context.params as Promise<{ teamId: string }>);
+  const { teamId } = await (
+    (context as { params: Promise<{ teamId: string }> }).params
+  );
 
   if (!teamId || typeof teamId !== "string") {
     return jsonNoStore(


### PR DESCRIPTION
This PR hardens the security of two key API endpoints by migrating them to the standardized `withAuth` higher-order component. 

### 🛡️ Security Improvements:
1. **Standardized Authentication**: Replaced manual session verification with the `withAuth` HOC, ensuring consistent session handling.
2. **Email Verification Enforcement**: Added missing `email_verified` checks to the administrative and team match routes, aligning them with the project's security standard.
3. **RBAC Implementation**: Added explicit role-based access control to the team matches endpoint (restricted to `ADMIN` and `COACH`), following the principle of least privilege.
4. **Information Leakage Prevention**: Removed raw error message leakage in the `matches` route, replacing it with generic error messages to avoid exposing internal implementation details.
5. **Anti-Caching Headers**: The `withAuth` HOC automatically applies `Cache-Control: no-store`, preventing sensitive player and match data from being cached.

### ✅ Verification:
- Ran `npm test`: All 6 test suites (30 tests) passed.
- Ran `npm run type-check`: All TypeScript checks passed, including the `withAuth` context handling for dynamic routes.
- Ran `npm run lint`: No linting errors.

These changes address high-priority security gaps related to inconsistent authorization and potential information leakage.

---
*PR created automatically by Jules for task [1636804009188669474](https://jules.google.com/task/1636804009188669474) started by @omichalo*