### PR TITLE
PR3 — UX quick wins : RGPD defaults, a11y RadioGroup, garde-fous schema

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -239,16 +239,24 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
     if (sex === "" || photoConsent === "") {
       return null;
     }
+    /* La section compétiteur classique est incompatible avec handisport / sport-adapté
+       (cf. superRefine côté schema). Si l'utilisateur a basculé sa section principale
+       après avoir coché le switch, on force la cohérence au moment du build. */
+    const isAdaptedMainSection =
+      draft.mainSectionId === "handisport" || draft.mainSectionId === "sport-adapte";
+    const effectiveCompetitorExtras =
+      !isAdaptedMainSection && draft.wantsCompetitorExtras;
     return {
       ...rest,
       sex,
       photoConsent,
       internalRulesAccepted: true as const,
+      wantsCompetitorExtras: effectiveCompetitorExtras,
       competitionJerseySize:
-        draft.wantsCompetitorExtras && draft.competitionJerseySize
+        effectiveCompetitorExtras && draft.competitionJerseySize
           ? draft.competitionJerseySize
           : undefined,
-      competitionIds: draft.wantsCompetitorExtras ? draft.competitionIds : [],
+      competitionIds: effectiveCompetitorExtras ? draft.competitionIds : [],
     };
   };
 

--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -44,6 +44,7 @@ function validateStep(activeStep: number, draft: RegistrationDraft): string | nu
   if (activeStep === 0) {
     if (!draft.firstName.trim()) return "Indiquez le prénom de l’adhérent.";
     if (!draft.lastName.trim()) return "Indiquez le nom de l’adhérent.";
+    if (!draft.sex) return "Indiquez le sexe de l’adhérent.";
     if (!draft.birthCity.trim()) return "Indiquez la ville de naissance.";
     if (!draft.birthDate) return "Indiquez la date de naissance.";
 
@@ -127,6 +128,9 @@ function validateStep(activeStep: number, draft: RegistrationDraft): string | nu
     if (draft.slotIds.length === 0) return "Sélectionnez au moins un créneau.";
   }
   if (activeStep === 3) {
+    if (!draft.photoConsent) {
+      return "Indiquez votre choix sur la diffusion d’images (acte de consentement explicite).";
+    }
     if (!draft.rulesAccepted) return "Vous devez accepter le règlement intérieur pour continuer.";
     if (draft.wantsCompetitorExtras && !draft.competitionJerseySize) {
       return "Indiquez une taille de maillot pour la section compétiteur.";
@@ -223,12 +227,22 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
     [activeStep, draft]
   );
 
-  const buildPayload = (): ClubRegistrationPayload => {
-    /* Le toggle `rulesAccepted` est interne à l'UI ; côté schéma on attend `internalRulesAccepted = true`. */
+  /**
+   * Construit le payload final en filtrant les valeurs sentinelles `""` de `sex` et
+   * `photoConsent` (RGPD : consentement et identité ne peuvent pas être pré-cochés).
+   * Retourne `null` si l'utilisateur n'a pas choisi explicitement ; le composant
+   * remonte alors un message ciblé sur l'étape concernée.
+   */
+  const buildPayload = (): ClubRegistrationPayload | null => {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    const { rulesAccepted, ...rest } = draft;
-    const payload: ClubRegistrationPayload = {
+    const { rulesAccepted, sex, photoConsent, ...rest } = draft;
+    if (sex === "" || photoConsent === "") {
+      return null;
+    }
+    return {
       ...rest,
+      sex,
+      photoConsent,
       internalRulesAccepted: true as const,
       competitionJerseySize:
         draft.wantsCompetitorExtras && draft.competitionJerseySize
@@ -236,7 +250,6 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
           : undefined,
       competitionIds: draft.wantsCompetitorExtras ? draft.competitionIds : [],
     };
-    return payload;
   };
 
   /**
@@ -291,7 +304,23 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
       return;
     }
 
+    /* Garde-fou supplémentaire : on rejoue la validation de l'étape 1 au cas où
+       l'utilisateur aurait navigué via le stepper sans repasser par "Continuer". */
+    const err0 = validateStep(0, draft);
+    if (err0) {
+      setSubmitError(err0);
+      setActiveStep(0);
+      return;
+    }
+
     const payload = buildPayload();
+    if (!payload) {
+      /* `sex` ou `photoConsent` non choisis : impossible en pratique car validateStep
+         couvre le cas, mais on échoue gracieusement plutôt que de laisser passer un
+         payload incomplet. */
+      setSubmitError("Certaines informations obligatoires sont manquantes.");
+      return;
+    }
     const parsed = clubRegistrationPayloadSchema.safeParse(payload);
     if (!parsed.success) {
       setFieldErrors(

--- a/src/components/club-registration/IdentityStep.tsx
+++ b/src/components/club-registration/IdentityStep.tsx
@@ -156,7 +156,16 @@ export function IdentityStep({
 
       <FormControl fullWidth required>
         <InputLabel id="sex-label">Sexe</InputLabel>
-        <Select labelId="sex-label" label="Sexe" value={draft.sex} onChange={handleSex}>
+        <Select
+          labelId="sex-label"
+          label="Sexe"
+          value={draft.sex}
+          onChange={handleSex}
+          displayEmpty
+        >
+          <MenuItem value="" disabled>
+            <em>Sélectionner…</em>
+          </MenuItem>
           <MenuItem value="female">Femme</MenuItem>
           <MenuItem value="male">Homme</MenuItem>
           <MenuItem value="other">Autre / Ne pas préciser</MenuItem>

--- a/src/components/club-registration/LegalCompetitorStep.tsx
+++ b/src/components/club-registration/LegalCompetitorStep.tsx
@@ -68,11 +68,12 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
 
       <Typography variant="subtitle1">Mineurs — autorisations</Typography>
       <FormControl component="fieldset">
-        <Typography variant="subtitle2" gutterBottom>
+        <Typography variant="subtitle2" gutterBottom id="emergency-medical-label">
           Autorisation d&apos;actes médicaux ou chirurgicaux en urgence pour mon enfant mineur (à
           défaut : adhérent majeur non concerné).
         </Typography>
         <RadioGroup
+          aria-labelledby="emergency-medical-label"
           value={draft.emergencyMedicalAuthorization}
           onChange={(e) =>
             onChange({
@@ -91,11 +92,12 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
       </FormControl>
 
       <FormControl component="fieldset">
-        <Typography variant="subtitle2" gutterBottom>
+        <Typography variant="subtitle2" gutterBottom id="supervision-label">
           Je m&apos;engage à ce que mon enfant soit pris en charge par le responsable à l&apos;heure
           des cours (sinon : adhérent majeur non concerné).
         </Typography>
         <RadioGroup
+          aria-labelledby="supervision-label"
           value={draft.supervisionAcknowledgement}
           onChange={(e) =>
             onChange({

--- a/src/components/club-registration/LegalCompetitorStep.tsx
+++ b/src/components/club-registration/LegalCompetitorStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Alert,
   Checkbox,
   FormControl,
   FormControlLabel,
@@ -20,6 +21,8 @@ import {
   JERSEY_SIZES,
 } from "@/lib/club-registration/constants";
 import type { RegistrationDraft } from "./registration-defaults";
+
+const ADAPTED_SECTIONS = new Set(["handisport", "sport-adapte"]);
 
 type Props = {
   draft: RegistrationDraft;
@@ -139,17 +142,25 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
       />
 
       <Stack spacing={1}>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={draft.wantsCompetitorExtras}
-              onChange={(e) => onChange({ wantsCompetitorExtras: e.target.checked })}
-            />
-          }
-          label="Section compétiteur : taille de maillot et compétitions"
-        />
+        {ADAPTED_SECTIONS.has(draft.mainSectionId) ? (
+          <Alert severity="info">
+            La section compétiteur classique (maillot, championnats fédéraux) ne s’applique pas
+            aux sections handisport et sport adapté. L’option « Compétition handisport » reste
+            disponible dans les compétitions, sans extension compétiteur.
+          </Alert>
+        ) : (
+          <FormControlLabel
+            control={
+              <Switch
+                checked={draft.wantsCompetitorExtras}
+                onChange={(e) => onChange({ wantsCompetitorExtras: e.target.checked })}
+              />
+            }
+            label="Section compétiteur : taille de maillot et compétitions"
+          />
+        )}
 
-        {draft.wantsCompetitorExtras && (
+        {!ADAPTED_SECTIONS.has(draft.mainSectionId) && draft.wantsCompetitorExtras && (
           <>
             <FormControl fullWidth required={draft.wantsCompetitorExtras}>
               <InputLabel id="jersey-label">Taille de maillot de compétition</InputLabel>

--- a/src/components/club-registration/LegalCompetitorStep.tsx
+++ b/src/components/club-registration/LegalCompetitorStep.tsx
@@ -47,12 +47,13 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
         </a>{" "}
         et les réseaux sociaux.
       </Typography>
-      <FormControl component="fieldset">
-        <Typography variant="subtitle2" gutterBottom>
+      <FormControl component="fieldset" required>
+        <Typography variant="subtitle2" gutterBottom id="photo-consent-label">
           Acceptez-vous une diffusion d&apos;images à caractère sportif vous concernant (ou votre
           enfant mineur) ?
         </Typography>
         <RadioGroup
+          aria-labelledby="photo-consent-label"
           value={draft.photoConsent}
           onChange={(e) =>
             onChange({

--- a/src/components/club-registration/MedicalFamilyStep.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.tsx
@@ -39,7 +39,9 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
 
   return (
     <Stack spacing={2}>
-      <Typography variant="subtitle1">Certificat médical</Typography>
+      <Typography variant="subtitle1" id="medical-certificate-label">
+        Certificat médical
+      </Typography>
       <Typography variant="body2" color="text.secondary">
         Téléchargez le questionnaire adapté si besoin :{" "}
         <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMajeur} target="_blank" rel="noreferrer">
@@ -55,6 +57,7 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
 
       <FormControl component="fieldset">
         <RadioGroup
+          aria-labelledby="medical-certificate-label"
           value={draft.medicalCertificateDeclaration}
           onChange={(e) =>
             onChange({
@@ -97,10 +100,11 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
       </FormControl>
 
       <FormControl component="fieldset">
-        <Typography variant="subtitle2" gutterBottom>
+        <Typography variant="subtitle2" gutterBottom id="family-order-label">
           Deuxième ou troisième inscription (ou plus) dans la même famille ?
         </Typography>
         <RadioGroup
+          aria-labelledby="family-order-label"
           value={draft.familyRegistrationOrder}
           onChange={(e) =>
             onChange({
@@ -146,10 +150,11 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
 
       {draft.sex === "female" && (
         <FormControl component="fieldset" required>
-          <Typography variant="subtitle2" gutterBottom>
+          <Typography variant="subtitle2" gutterBottom id="first-female-label">
             Première inscription féminine au club SQY PING ?
           </Typography>
           <RadioGroup
+            aria-labelledby="first-female-label"
             value={draft.firstFemaleRegistrationSqy ? "yes" : "no"}
             onChange={(e) =>
               onChange({ firstFemaleRegistrationSqy: e.target.value === "yes" })

--- a/src/components/club-registration/PostalAddressSection.tsx
+++ b/src/components/club-registration/PostalAddressSection.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
-import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
@@ -63,42 +63,27 @@ export function PostalAddressSection({ draft, onChange }: Props) {
             placeholder="Ex. 12 rue Victor Hugo, Paris"
             helperText="Recherchez votre adresse dans la Base Adresse Nationale. Vous pourrez la compléter ensuite."
           />
-          <Link
-            component="button"
+          <Button
             type="button"
-            variant="body2"
+            variant="text"
+            size="small"
             onClick={handleSwitchToManual}
-            sx={{
-              alignSelf: "flex-start",
-              mt: 1,
-              cursor: "pointer",
-              border: 0,
-              background: "none",
-              font: "inherit",
-              textDecoration: "underline",
-            }}
+            sx={{ alignSelf: "flex-start", mt: 1, textTransform: "none" }}
           >
             Mon adresse n&apos;apparaît pas — saisir l&apos;adresse manuellement
-          </Link>
+          </Button>
         </Box>
       ) : (
         <Stack spacing={1}>
-          <Link
-            component="button"
+          <Button
             type="button"
-            variant="body2"
+            variant="text"
+            size="small"
             onClick={handleSwitchToSearch}
-            sx={{
-              alignSelf: "flex-start",
-              cursor: "pointer",
-              border: 0,
-              background: "none",
-              font: "inherit",
-              textDecoration: "underline",
-            }}
+            sx={{ alignSelf: "flex-start", textTransform: "none" }}
           >
             Rechercher une adresse officielle
-          </Link>
+          </Button>
         </Stack>
       )}
 

--- a/src/components/club-registration/RecapStep.tsx
+++ b/src/components/club-registration/RecapStep.tsx
@@ -41,6 +41,7 @@ const ROLE_LABELS: Record<Representative["role"], string> = {
 };
 
 const SEX_LABELS: Record<RegistrationDraft["sex"], string> = {
+  "": "—",
   female: "Femme",
   male: "Homme",
   other: "Autre / Ne pas préciser",
@@ -66,6 +67,7 @@ const FAMILY_ORDER_LABELS: Record<RegistrationDraft["familyRegistrationOrder"], 
 };
 
 const PHOTO_LABELS: Record<RegistrationDraft["photoConsent"], string> = {
+  "": "—",
   accept: "J’accepte la diffusion d’images",
   refuse: "Je refuse la diffusion d’images",
 };

--- a/src/components/club-registration/registration-defaults.ts
+++ b/src/components/club-registration/registration-defaults.ts
@@ -1,11 +1,23 @@
 import type { ClubRegistrationPayload, Representative } from "@/lib/club-registration/schema";
 
 /**
- * Forme du draft local. Conserve une bascule UI pour `internalRulesAccepted`
- * (case à cocher contrôlée par l'utilisateur, alors que côté schéma on attend `true`).
+ * Forme du draft local.
+ *
+ * Diffère du payload final sur trois points :
+ * - `internalRulesAccepted` côté schéma exige `true` ; on expose un `rulesAccepted: boolean`
+ *   pour rester contrôlable dans l'UI.
+ * - `sex` et `photoConsent` autorisent la chaîne vide tant que l'utilisateur n'a pas
+ *   activement choisi. RGPD oblige : le consentement à la diffusion d'images doit être
+ *   un acte positif (pas de pré-cochage), et le sexe ne doit pas être imposé par défaut.
+ *   `buildPayload()` côté wizard refuse la chaîne vide avant tout POST.
  */
-export type RegistrationDraft = Omit<ClubRegistrationPayload, "internalRulesAccepted"> & {
+export type RegistrationDraft = Omit<
+  ClubRegistrationPayload,
+  "internalRulesAccepted" | "sex" | "photoConsent"
+> & {
   rulesAccepted: boolean;
+  sex: ClubRegistrationPayload["sex"] | "";
+  photoConsent: ClubRegistrationPayload["photoConsent"] | "";
 };
 
 export type { Representative };
@@ -26,7 +38,7 @@ export function createEmptyDraft(): RegistrationDraft {
     adherentRole: "self",
     firstName: "",
     lastName: "",
-    sex: "male",
+    sex: "",
     birthCity: "",
     birthDate: "",
     adherentEmail: "",
@@ -46,7 +58,7 @@ export function createEmptyDraft(): RegistrationDraft {
     reductionTypes: [],
     passSportCode: "",
     firstFemaleRegistrationSqy: undefined,
-    photoConsent: "accept",
+    photoConsent: "",
     emergencyMedicalAuthorization: "not_applicable_adult",
     supervisionAcknowledgement: "not_applicable_adult",
     rulesAccepted: false,

--- a/src/lib/club-registration/schema.test.ts
+++ b/src/lib/club-registration/schema.test.ts
@@ -193,6 +193,75 @@ describe("clubRegistrationPayloadSchema", () => {
     }
   });
 
+  it("refuse firstFemaleRegistrationSqy orphelin (sex !== female)", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ sex: "male", firstFemaleRegistrationSqy: true })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(
+          (i) =>
+            i.path.includes("firstFemaleRegistrationSqy") &&
+            typeof i.message === "string" &&
+            /sexe féminin/i.test(i.message)
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("accepte un homme avec firstFemaleRegistrationSqy non renseigné (undefined)", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({ sex: "male", firstFemaleRegistrationSqy: undefined })
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("refuse wantsCompetitorExtras=true avec section handisport", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        mainSectionId: "handisport",
+        slotIds: ["voisins-mar-1830-handisport"],
+        wantsCompetitorExtras: true,
+        competitionJerseySize: "M",
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("wantsCompetitorExtras"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse wantsCompetitorExtras=true avec section sport-adapté", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        mainSectionId: "sport-adapte",
+        slotIds: ["villepreux-jeu-1030-sport-adapte"],
+        wantsCompetitorExtras: true,
+        competitionJerseySize: "M",
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("wantsCompetitorExtras"))
+      ).toBe(true);
+    }
+  });
+
+  it("accepte une section handisport sans extension compétiteur", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        mainSectionId: "handisport",
+        slotIds: ["voisins-mar-1830-handisport"],
+        wantsCompetitorExtras: false,
+      })
+    );
+    expect(r.success).toBe(true);
+  });
+
   it("refuse un compétiteur sans taille de maillot", () => {
     const r = clubRegistrationPayloadSchema.safeParse(
       buildPayload({ wantsCompetitorExtras: true, competitionJerseySize: undefined })

--- a/src/lib/club-registration/schema.ts
+++ b/src/lib/club-registration/schema.ts
@@ -153,12 +153,39 @@ export const clubRegistrationPayloadSchema = z
       });
     }
 
+    /* Valeur orpheline : firstFemaleRegistrationSqy n'a de sens que si sex==="female".
+       Côté UI le reducer remet déjà undefined quand on change de sexe, mais on
+       refuse défensivement les payloads incohérents reçus par l'API. */
+    if (data.sex !== "female" && data.firstFemaleRegistrationSqy !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Le champ « première inscription féminine » n’est applicable qu’au sexe féminin",
+        path: ["firstFemaleRegistrationSqy"],
+      });
+    }
+
     /* Compétiteur : taille de maillot obligatoire */
     if (data.wantsCompetitorExtras && !data.competitionJerseySize) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Taille de maillot obligatoire pour la section compétiteur",
         path: ["competitionJerseySize"],
+      });
+    }
+
+    /* Cohérence section / extension compétiteur : la section compétiteur classique
+       (taille de maillot, championnats fédéraux) n'a pas de sens pour handisport
+       et sport adapté qui ont leur propre option dédiée dans `competitionIds`. */
+    if (
+      data.wantsCompetitorExtras &&
+      (data.mainSectionId === "handisport" || data.mainSectionId === "sport-adapte")
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "La section compétiteur ne s'applique pas aux sections handisport et sport adapté",
+        path: ["wantsCompetitorExtras"],
       });
     }
 


### PR DESCRIPTION
## Contexte

Suite à la passe UX initiale sur le formulaire d'inscription au club, cette PR adresse les **quick wins** identifiés en priorité haute et moyenne sur les axes RGPD, accessibilité et cohérence métier — sans toucher au cœur du parcours.

Stackée sur la PR2 (#279 \`feature/club-registration-auth-submit\`).

## Préconisations UX adressées

| # | Sujet | Statut |
|---|---|---|
| 6 | RGPD : photoConsent et sex sans valeur par défaut | ✅ |
| 9 | sex sans valeur par défaut (doublon du #6) | ✅ |
| 13 | a11y : aria-labelledby sur les RadioGroup + Button au lieu de Link pour les toggles d'adresse | ✅ |
| 16 | Dette schema : firstFemaleRegistrationSqy orphelin et wantsCompetitorExtras avec section handisport / sport adapté | ✅ |

## Détail des 3 commits

### 1. \`feat: RGPD — sex et photoConsent sans valeur par défaut\`
- \`RegistrationDraft\` autorise \`\"\"\` pour \`sex\` et \`photoConsent\`.
- \`createEmptyDraft\` initialise ces deux champs à \`\"\"\` (au lieu de \`\"male\"\` et \`\"accept\"\`).
- \`validateStep(0)\` exige un sexe choisi ; \`validateStep(3)\` exige un consentement photo explicite (RGPD : acte positif et libre).
- \`buildPayload\` devient \`() => ClubRegistrationPayload | null\` ; refuse tant que \`sex\` ou \`photoConsent\` est vide. \`handleSubmit\` rejoue la validation de l'étape 1 par sécurité avant POST.
- UI : \`Select\` avec \`MenuItem\` placeholder « Sélectionner… » (\`displayEmpty\`) ; \`RadioGroup\` \`photoConsent\` sans pré-cochage, FormControl \`required\`.

### 2. \`feat: a11y — aria-labelledby sur RadioGroup + Button au lieu de Link\`
- 5 RadioGroup gagnent un \`aria-labelledby\` sur le Typography de leur question (médical, famille, première femme, médical urgence mineur, prise en charge). \`photoConsent\` traité dans le commit précédent.
- \`PostalAddressSection\` : les toggles « Mon adresse n'apparaît pas / Rechercher une adresse officielle » passent de \`Link component=\"button\"\` (avec re-styling souligné) à \`Button variant=\"text\"\` — sémantique native, focus visible, code plus court.

### 3. \`feat: garde-fous schema — femme orpheline et compétiteur sur sections adaptées\`
- \`superRefine\` : refuse \`firstFemaleRegistrationSqy\` défini si \`sex !== \"female\"\` (valeur orpheline).
- \`superRefine\` : refuse \`wantsCompetitorExtras=true\` quand \`mainSectionId ∈ {handisport, sport-adapte}\` (l'option compétiteur classique n'a pas de sens, l'option \`competition_handisport\` reste disponible séparément).
- UI : \`LegalCompetitorStep\` masque le switch compétiteur sur ces sections, avec une \`Alert\` explicative.
- \`buildPayload\` force \`wantsCompetitorExtras=false\` + vide les champs liés si l'utilisateur a basculé sa section principale après avoir coché le switch.

## Hors scope

Les préconisations qui demandent un effort plus important sont conservées pour les PR suivantes :
- PR4 : conditionnels mineur/majeur sur autorisations + médical (#5)
- PR5 : validation onBlur + saut sur étape en erreur + scroll-to-field (#2, #10, #11)
- PR6 : refonte étape 2 (créneaux groupés par public) + trichotomie étape 1 (#7, #8)
- PR7 : statut dossier dans le wizard (#4)
- PR8 : polish mobile + wording (#14, #15)

## Test plan

- [x] \`npm run check\` (lint + type-check + build) ✅
- [x] \`npx jest\` (117/117 verts, +5 nouveaux tests Zod) ✅
- [ ] Smoke test manuel : étape 1 doit refuser de passer sans sexe choisi
- [ ] Smoke test manuel : étape 4 doit refuser sans consentement photo explicite
- [ ] Smoke test manuel : sélectionner section principale « Section handisport » → le switch compétiteur disparaît, message d'info affiché
- [ ] Smoke test manuel : RadioGroup correctement annoncés par un lecteur d'écran (VoiceOver / NVDA)

Made with [Cursor](https://cursor.com)