### PR TITLE
PR4 — Logique mineur / majeur dérivée de la date de naissance

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -16,7 +16,7 @@ import {
 import { isValidFrenchPhoneSurface } from "@/lib/club-registration/phone-fr";
 import type { ClubRegistrationPayload } from "@/lib/club-registration/schema";
 import { clubRegistrationPayloadSchema } from "@/lib/club-registration/schema";
-import { isMinorAt } from "@/lib/club-registration/age";
+import { isAtLeast40At, isMinorAt } from "@/lib/club-registration/age";
 import { submitRegistration } from "@/lib/club-registration/submit";
 import type { RegistrationDraft } from "./registration-defaults";
 import { IdentityStep } from "./IdentityStep";
@@ -126,6 +126,25 @@ function validateStep(activeStep: number, draft: RegistrationDraft): string | nu
   }
   if (activeStep === 1) {
     if (draft.slotIds.length === 0) return "Sélectionnez au moins un créneau.";
+  }
+  if (activeStep === 2) {
+    /* Cohérence âge ↔ déclaration médicale : on guide le choix dès l'UI mais on
+       garde un filet ici si l'utilisateur change sa date de naissance après coup. */
+    const atLeast40 = isAtLeast40At(draft.birthDate);
+    const decl = draft.medicalCertificateDeclaration;
+    if (!decl) {
+      return "Choisissez une déclaration sur le questionnaire médical.";
+    }
+    if (
+      !atLeast40 &&
+      (decl === "over_40_cert_unchanged_all_no" ||
+        decl === "over_40_first_or_changed_certificate_required")
+    ) {
+      return "La déclaration médicale sélectionnée est réservée aux 40 ans et plus.";
+    }
+    if (atLeast40 && decl === "under_40_all_no") {
+      return "La déclaration médicale « moins de 40 ans » n’est pas applicable à votre date de naissance.";
+    }
   }
   if (activeStep === 3) {
     if (!draft.photoConsent) {

--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -150,6 +150,14 @@ function validateStep(activeStep: number, draft: RegistrationDraft): string | nu
     if (!draft.photoConsent) {
       return "Indiquez votre choix sur la diffusion d’images (acte de consentement explicite).";
     }
+    if (isMinorAt(draft.birthDate)) {
+      if (draft.emergencyMedicalAuthorization !== "yes") {
+        return "Cochez l’autorisation d’actes médicaux d’urgence (obligatoire pour un mineur).";
+      }
+      if (draft.supervisionAcknowledgement !== "yes") {
+        return "Cochez l’engagement de prise en charge à l’heure des cours (obligatoire pour un mineur).";
+      }
+    }
     if (!draft.rulesAccepted) return "Vous devez accepter le règlement intérieur pour continuer.";
     if (draft.wantsCompetitorExtras && !draft.competitionJerseySize) {
       return "Indiquez une taille de maillot pour la section compétiteur.";
@@ -265,10 +273,22 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
       draft.mainSectionId === "handisport" || draft.mainSectionId === "sport-adapte";
     const effectiveCompetitorExtras =
       !isAdaptedMainSection && draft.wantsCompetitorExtras;
+    /* Les autorisations légales mineurs sont forcées à `not_applicable_adult` côté
+       majeur (l'UI les masque). Côté mineur l'UI exige la case cochée donc la valeur
+       est déjà `yes` dans le draft. On garde une cohérence ceinture/bretelles. */
+    const minor = isMinorAt(draft.birthDate);
+    const emergencyMedicalAuthorization = minor
+      ? draft.emergencyMedicalAuthorization
+      : ("not_applicable_adult" as const);
+    const supervisionAcknowledgement = minor
+      ? draft.supervisionAcknowledgement
+      : ("not_applicable_adult" as const);
     return {
       ...rest,
       sex,
       photoConsent,
+      emergencyMedicalAuthorization,
+      supervisionAcknowledgement,
       internalRulesAccepted: true as const,
       wantsCompetitorExtras: effectiveCompetitorExtras,
       competitionJerseySize:

--- a/src/components/club-registration/IdentityStep.tsx
+++ b/src/components/club-registration/IdentityStep.tsx
@@ -172,6 +172,24 @@ export function IdentityStep({
         </Select>
       </FormControl>
 
+      {draft.sex === "female" ? (
+        <FormControl component="fieldset" required>
+          <Typography variant="subtitle2" gutterBottom id="first-female-label">
+            Première inscription féminine au club SQY PING ?
+          </Typography>
+          <RadioGroup
+            aria-labelledby="first-female-label"
+            value={draft.firstFemaleRegistrationSqy ? "yes" : "no"}
+            onChange={(e) =>
+              onPatch({ firstFemaleRegistrationSqy: e.target.value === "yes" })
+            }
+          >
+            <FormControlLabel value="yes" control={<Radio />} label="Oui" />
+            <FormControlLabel value="no" control={<Radio />} label="Non" />
+          </RadioGroup>
+        </FormControl>
+      ) : null}
+
       <TextField
         required
         label="Ville de naissance"

--- a/src/components/club-registration/LegalCompetitorStep.tsx
+++ b/src/components/club-registration/LegalCompetitorStep.tsx
@@ -20,6 +20,7 @@ import {
   CLUB_REGISTRATION_EXTERNAL_LINKS,
   JERSEY_SIZES,
 } from "@/lib/club-registration/constants";
+import { isMinorAt } from "@/lib/club-registration/age";
 import type { RegistrationDraft } from "./registration-defaults";
 
 const ADAPTED_SECTIONS = new Set(["handisport", "sport-adapte"]);
@@ -39,6 +40,12 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
     }
     onChange({ competitionIds: Array.from(set) });
   };
+
+  /* Les autorisations « actes médicaux d'urgence » et « prise en charge à l'heure
+     des cours » sont strictement pertinentes pour un mineur : un majeur n'a pas
+     à se prononcer dessus. On les masque et on délègue au wizard la responsabilité
+     de poser `not_applicable_adult` au moment du build du payload. */
+  const isMinor = isMinorAt(draft.birthDate);
 
   return (
     <Stack spacing={2}>
@@ -69,54 +76,55 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
         </RadioGroup>
       </FormControl>
 
-      <Typography variant="subtitle1">Mineurs — autorisations</Typography>
-      <FormControl component="fieldset">
-        <Typography variant="subtitle2" gutterBottom id="emergency-medical-label">
-          Autorisation d&apos;actes médicaux ou chirurgicaux en urgence pour mon enfant mineur (à
-          défaut : adhérent majeur non concerné).
-        </Typography>
-        <RadioGroup
-          aria-labelledby="emergency-medical-label"
-          value={draft.emergencyMedicalAuthorization}
-          onChange={(e) =>
-            onChange({
-              emergencyMedicalAuthorization: e.target
-                .value as RegistrationDraft["emergencyMedicalAuthorization"],
-            })
-          }
-        >
-          <FormControlLabel value="yes" control={<Radio />} label="Oui" />
+      {isMinor ? (
+        <>
+          <Typography variant="subtitle1">Autorisations pour l’adhérent mineur</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Ces deux autorisations sont obligatoires pour l’inscription d’un mineur. Elles ne
+            sont pas affichées si l’adhérent est majeur.
+          </Typography>
           <FormControlLabel
-            value="not_applicable_adult"
-            control={<Radio />}
-            label="Adhérent majeur — non concerné"
+            control={
+              <Checkbox
+                checked={draft.emergencyMedicalAuthorization === "yes"}
+                onChange={(e) =>
+                  onChange({
+                    emergencyMedicalAuthorization: e.target.checked
+                      ? "yes"
+                      : "not_applicable_adult",
+                  })
+                }
+              />
+            }
+            label={
+              <Typography variant="body2" component="span">
+                J’autorise les actes médicaux ou chirurgicaux en urgence pour mon enfant
+                mineur.
+              </Typography>
+            }
           />
-        </RadioGroup>
-      </FormControl>
-
-      <FormControl component="fieldset">
-        <Typography variant="subtitle2" gutterBottom id="supervision-label">
-          Je m&apos;engage à ce que mon enfant soit pris en charge par le responsable à l&apos;heure
-          des cours (sinon : adhérent majeur non concerné).
-        </Typography>
-        <RadioGroup
-          aria-labelledby="supervision-label"
-          value={draft.supervisionAcknowledgement}
-          onChange={(e) =>
-            onChange({
-              supervisionAcknowledgement: e.target
-                .value as RegistrationDraft["supervisionAcknowledgement"],
-            })
-          }
-        >
-          <FormControlLabel value="yes" control={<Radio />} label="Oui" />
           <FormControlLabel
-            value="not_applicable_adult"
-            control={<Radio />}
-            label="Adhérent majeur — non concerné"
+            control={
+              <Checkbox
+                checked={draft.supervisionAcknowledgement === "yes"}
+                onChange={(e) =>
+                  onChange({
+                    supervisionAcknowledgement: e.target.checked
+                      ? "yes"
+                      : "not_applicable_adult",
+                  })
+                }
+              />
+            }
+            label={
+              <Typography variant="body2" component="span">
+                Je m’engage à ce que mon enfant soit pris en charge par le responsable à
+                l’heure des cours.
+              </Typography>
+            }
           />
-        </RadioGroup>
-      </FormControl>
+        </>
+      ) : null}
 
       <FormControlLabel
         control={

--- a/src/components/club-registration/MedicalFamilyStep.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.tsx
@@ -189,24 +189,6 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
         fullWidth
       />
 
-      {draft.sex === "female" && (
-        <FormControl component="fieldset" required>
-          <Typography variant="subtitle2" gutterBottom id="first-female-label">
-            Première inscription féminine au club SQY PING ?
-          </Typography>
-          <RadioGroup
-            aria-labelledby="first-female-label"
-            value={draft.firstFemaleRegistrationSqy ? "yes" : "no"}
-            onChange={(e) =>
-              onChange({ firstFemaleRegistrationSqy: e.target.value === "yes" })
-            }
-          >
-            <FormControlLabel value="yes" control={<Radio />} label="Oui" />
-            <FormControlLabel value="no" control={<Radio />} label="Non" />
-          </RadioGroup>
-        </FormControl>
-      )}
-
       <Alert severity="info">
         Site du club :{" "}
         <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.siteClub} target="_blank" rel="noreferrer">

--- a/src/components/club-registration/MedicalFamilyStep.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.tsx
@@ -19,7 +19,38 @@ import {
   CLUB_REGISTRATION_EXTERNAL_LINKS,
   REDUCTION_OPTIONS,
 } from "@/lib/club-registration/constants";
+import { isAtLeast40At } from "@/lib/club-registration/age";
 import type { RegistrationDraft } from "./registration-defaults";
+
+type MedicalOptionId = RegistrationDraft["medicalCertificateDeclaration"];
+
+const MEDICAL_OPTIONS_UNDER_40: ReadonlyArray<{ id: MedicalOptionId; label: string }> = [
+  {
+    id: "under_40_all_no",
+    label: "Moins de 40 ans : j’atteste avoir répondu « Non » à tout le questionnaire médical.",
+  },
+  {
+    id: "questionnaire_yes_certificate_required",
+    label: "J’ai répondu « Oui » à au moins une question : certificat médical requis.",
+  },
+];
+
+const MEDICAL_OPTIONS_AT_LEAST_40: ReadonlyArray<{ id: MedicalOptionId; label: string }> = [
+  {
+    id: "over_40_cert_unchanged_all_no",
+    label:
+      "40 ans et plus, certificat déjà fourni dans la même catégorie : j’atteste avoir répondu « Non » au questionnaire.",
+  },
+  {
+    id: "over_40_first_or_changed_certificate_required",
+    label:
+      "40 ans et plus, première inscription ou changement de catégorie : certificat médical requis.",
+  },
+  {
+    id: "questionnaire_yes_certificate_required",
+    label: "J’ai répondu « Oui » à au moins une question : certificat médical requis.",
+  },
+];
 
 type Props = {
   draft: RegistrationDraft;
@@ -36,6 +67,17 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
     }
     onChange({ reductionTypes: Array.from(set) });
   };
+
+  /* L'âge dérive de la date de naissance saisie à l'étape 1. Le wizard interdit déjà
+     de passer à l'étape 3 sans `birthDate`. */
+  const atLeast40 = isAtLeast40At(draft.birthDate);
+  const medicalOptions = atLeast40
+    ? MEDICAL_OPTIONS_AT_LEAST_40
+    : MEDICAL_OPTIONS_UNDER_40;
+  const allowedIds = new Set<MedicalOptionId>(medicalOptions.map((o) => o.id));
+  const declarationIsIncompatible =
+    Boolean(draft.medicalCertificateDeclaration) &&
+    !allowedIds.has(draft.medicalCertificateDeclaration);
 
   return (
     <Stack spacing={2}>
@@ -55,32 +97,31 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
         modalités du club.
       </Typography>
 
-      <FormControl component="fieldset">
+      {declarationIsIncompatible ? (
+        <Alert severity="warning">
+          La déclaration médicale précédemment sélectionnée n’est plus compatible avec la date
+          de naissance saisie. Choisissez une nouvelle option ci-dessous.
+        </Alert>
+      ) : null}
+
+      <FormControl component="fieldset" required>
         <RadioGroup
           aria-labelledby="medical-certificate-label"
-          value={draft.medicalCertificateDeclaration}
+          value={declarationIsIncompatible ? "" : draft.medicalCertificateDeclaration}
           onChange={(e) =>
             onChange({
-              medicalCertificateDeclaration: e.target
-                .value as RegistrationDraft["medicalCertificateDeclaration"],
+              medicalCertificateDeclaration: e.target.value as MedicalOptionId,
             })
           }
         >
-          <FormControlLabel
-            value="under_40_all_no"
-            control={<Radio />}
-            label='Moins de 40 ans : j’atteste avoir répondu « Non » à tout le questionnaire médical.'
-          />
-          <FormControlLabel
-            value="over_40_cert_unchanged_all_no"
-            control={<Radio />}
-            label="Plus de 40 ans, certificat dans la même catégorie : j’atteste avoir répondu « Non » au questionnaire."
-          />
-          <FormControlLabel
-            value="questionnaire_yes_certificate_required"
-            control={<Radio />}
-            label='J’ai répondu « Oui » à au moins une question : certificat médical requis.'
-          />
+          {medicalOptions.map((option) => (
+            <FormControlLabel
+              key={option.id}
+              value={option.id}
+              control={<Radio />}
+              label={option.label}
+            />
+          ))}
         </RadioGroup>
       </FormControl>
 

--- a/src/components/club-registration/RecapStep.tsx
+++ b/src/components/club-registration/RecapStep.tsx
@@ -56,7 +56,9 @@ const ADHERENT_ROLE_LABELS: Record<RegistrationDraft["adherentRole"], string> = 
 const MEDICAL_LABELS: Record<RegistrationDraft["medicalCertificateDeclaration"], string> = {
   under_40_all_no: "Moins de 40 ans : aucune réponse « Oui »",
   over_40_cert_unchanged_all_no:
-    "Plus de 40 ans, certificat existant valide : aucune réponse « Oui »",
+    "40 ans et plus, certificat déjà fourni : aucune réponse « Oui »",
+  over_40_first_or_changed_certificate_required:
+    "40 ans et plus, première inscription ou changement de catégorie : certificat requis",
   questionnaire_yes_certificate_required: "Au moins une réponse « Oui » : certificat requis",
 };
 

--- a/src/components/club-registration/RecapStep.tsx
+++ b/src/components/club-registration/RecapStep.tsx
@@ -17,6 +17,7 @@ import {
   SECTION_PRINCIPALE_OPTIONS,
 } from "@/lib/club-registration/constants";
 import { toFrenchPhoneMaskedDisplay } from "@/lib/club-registration/phone-fr";
+import { isMinorAt } from "@/lib/club-registration/age";
 import type { RegistrationDraft, Representative } from "./registration-defaults";
 
 type Props = {
@@ -170,6 +171,7 @@ export function RecapStep({ draft, accountEmail, onEditStep }: Props) {
   const slotLabels = draft.slotIds.map(findSlotLabel);
   const reductions = draft.reductionTypes.map(findReductionLabel);
   const competitions = draft.competitionIds.map(findCompetitionLabel);
+  const isMinor = isMinorAt(draft.birthDate);
 
   const fullAddress = [
     draft.addressLine1,
@@ -201,6 +203,14 @@ export function RecapStep({ draft, accountEmail, onEditStep }: Props) {
           { label: "Prénom", value: draft.firstName },
           { label: "Nom", value: draft.lastName },
           { label: "Sexe", value: SEX_LABELS[draft.sex] },
+          ...(draft.sex === "female"
+            ? [
+                {
+                  label: "1ʳᵉ inscription féminine au club",
+                  value: draft.firstFemaleRegistrationSqy ? "Oui" : "Non",
+                } as Field,
+              ]
+            : []),
           { label: "Né(e) le", value: draft.birthDate },
           { label: "Ville de naissance", value: draft.birthCity },
         ]}
@@ -312,14 +322,6 @@ export function RecapStep({ draft, accountEmail, onEditStep }: Props) {
               ),
           },
           { label: "Code Pass Sport", value: draft.passSportCode || "—" },
-          ...(draft.sex === "female"
-            ? [
-                {
-                  label: "1ʳᵉ inscription féminine au club",
-                  value: draft.firstFemaleRegistrationSqy ? "Oui" : "Non",
-                } as Field,
-              ]
-            : []),
         ]}
       />
 
@@ -328,14 +330,18 @@ export function RecapStep({ draft, accountEmail, onEditStep }: Props) {
         onEdit={() => onEditStep(STEP_INDEX.consents)}
         fields={[
           { label: "Image et communication", value: PHOTO_LABELS[draft.photoConsent] },
-          {
-            label: "Acte médical d’urgence (mineur)",
-            value: CONSENT_LABELS[draft.emergencyMedicalAuthorization],
-          },
-          {
-            label: "Prise en charge à l’heure des cours (mineur)",
-            value: CONSENT_LABELS[draft.supervisionAcknowledgement],
-          },
+          ...(isMinor
+            ? ([
+                {
+                  label: "Acte médical d’urgence",
+                  value: CONSENT_LABELS[draft.emergencyMedicalAuthorization],
+                },
+                {
+                  label: "Prise en charge à l’heure des cours",
+                  value: CONSENT_LABELS[draft.supervisionAcknowledgement],
+                },
+              ] as Field[])
+            : []),
           {
             label: "Règlement intérieur",
             value: draft.rulesAccepted ? "Accepté" : "Non accepté",

--- a/src/lib/club-registration/age.test.ts
+++ b/src/lib/club-registration/age.test.ts
@@ -1,4 +1,4 @@
-import { isAdultAt, isMinorAt } from "./age";
+import { computeAgeAt, isAdultAt, isAtLeast40At, isMinorAt } from "./age";
 
 /**
  * On utilise `new Date(y, m, d)` (heure locale) pour éviter les pièges
@@ -52,5 +52,39 @@ describe("isMinorAt", () => {
   it("retourne false pour une date vide ou invalide (pas de présomption)", () => {
     expect(isMinorAt("", localDate(2025, 6, 1))).toBe(false);
     expect(isMinorAt("not-a-date", localDate(2025, 6, 1))).toBe(false);
+  });
+});
+
+describe("isAtLeast40At", () => {
+  it("retourne true le jour exact des 40 ans", () => {
+    expect(isAtLeast40At("1985-05-11", localDate(2025, 5, 11))).toBe(true);
+  });
+
+  it("retourne false la veille des 40 ans", () => {
+    expect(isAtLeast40At("1985-05-12", localDate(2025, 5, 11))).toBe(false);
+  });
+
+  it("retourne true bien après 40 ans", () => {
+    expect(isAtLeast40At("1960-01-01", localDate(2025, 6, 1))).toBe(true);
+  });
+
+  it("retourne false pour une date vide ou invalide", () => {
+    expect(isAtLeast40At("", localDate(2025, 6, 1))).toBe(false);
+    expect(isAtLeast40At("abcd-ef-gh", localDate(2025, 6, 1))).toBe(false);
+  });
+});
+
+describe("computeAgeAt", () => {
+  it("retourne l'âge entier le jour de l'anniversaire", () => {
+    expect(computeAgeAt("2000-01-15", localDate(2025, 1, 15))).toBe(25);
+  });
+
+  it("retourne l'âge - 1 la veille de l'anniversaire", () => {
+    expect(computeAgeAt("2000-01-15", localDate(2025, 1, 14))).toBe(24);
+  });
+
+  it("retourne null pour une date vide ou invalide", () => {
+    expect(computeAgeAt("", localDate(2025, 6, 1))).toBeNull();
+    expect(computeAgeAt("nope", localDate(2025, 6, 1))).toBeNull();
   });
 });

--- a/src/lib/club-registration/age.ts
+++ b/src/lib/club-registration/age.ts
@@ -1,9 +1,13 @@
 /**
  * Helpers d'âge pour le formulaire d'inscription club.
  *
- * - `isAdultAt` : retourne true si la personne née à `birthDate` (format ISO YYYY-MM-DD)
- *   est majeure (>= 18 ans) à la date `at`. Anniversaire le jour J = majeur.
- * - `isMinorAt` : inverse de `isAdultAt`, false si `birthDate` est invalide ou vide.
+ * - `computeAgeAt` : âge en années révolues à la date `at`, ou `null` si la date est
+ *   vide / invalide. Anniversaire le jour J = âge incrémenté.
+ * - `isAdultAt` : true si la personne est majeure (>= 18 ans) à la date `at`.
+ * - `isMinorAt` : inverse de `isAdultAt`. False si `birthDate` est vide ou invalide
+ *   (pas de présomption de minorité).
+ * - `isAtLeast40At` : true si la personne a 40 ans ou plus à la date `at`. Utilisé
+ *   pour orienter le choix du questionnaire médical.
  *
  * La référence `at` est paramétrable pour faciliter les tests et garantir la stabilité
  * (ne pas dépendre directement de `Date.now()`).
@@ -22,10 +26,10 @@ function parseIsoDate(s: string): { y: number; m: number; d: number } | null {
   return { y, m, d };
 }
 
-/** Renvoie true si `birthDate` (ISO) correspond à une personne majeure (>=18 ans) à la date `at`. */
-export function isAdultAt(birthDate: string, at: Date = new Date()): boolean {
+/** Âge en années révolues à la date `at`, ou null si `birthDate` est vide/invalide. */
+export function computeAgeAt(birthDate: string, at: Date = new Date()): number | null {
   const birth = parseIsoDate(birthDate);
-  if (!birth) return false;
+  if (!birth) return null;
 
   const refY = at.getFullYear();
   const refM = at.getMonth() + 1;
@@ -35,13 +39,23 @@ export function isAdultAt(birthDate: string, at: Date = new Date()): boolean {
   if (refM < birth.m || (refM === birth.m && refD < birth.d)) {
     years -= 1;
   }
-  return years >= 18;
+  return years;
+}
+
+/** Renvoie true si `birthDate` (ISO) correspond à une personne majeure (>=18 ans) à la date `at`. */
+export function isAdultAt(birthDate: string, at: Date = new Date()): boolean {
+  const years = computeAgeAt(birthDate, at);
+  return years !== null && years >= 18;
 }
 
 /** Inverse pratique : false si `birthDate` est vide / invalide (pas de présomption de minorité). */
 export function isMinorAt(birthDate: string, at: Date = new Date()): boolean {
-  if (!birthDate) return false;
-  const birth = parseIsoDate(birthDate);
-  if (!birth) return false;
-  return !isAdultAt(birthDate, at);
+  const years = computeAgeAt(birthDate, at);
+  return years !== null && years < 18;
+}
+
+/** True si la personne a 40 ans ou plus (questionnaire médical : seuil FFTT). */
+export function isAtLeast40At(birthDate: string, at: Date = new Date()): boolean {
+  const years = computeAgeAt(birthDate, at);
+  return years !== null && years >= 40;
 }

--- a/src/lib/club-registration/schema.test.ts
+++ b/src/lib/club-registration/schema.test.ts
@@ -335,6 +335,86 @@ describe("clubRegistrationPayloadSchema", () => {
     expect(r.success).toBe(true);
   });
 
+  it("refuse un mineur sans autorisation médicale d'urgence (yes)", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "2015-04-12",
+        adherentRole: "minor_dependent",
+        emergencyMedicalAuthorization: "not_applicable_adult",
+        supervisionAcknowledgement: "yes",
+        representatives: [
+          {
+            role: "mother",
+            firstName: "Marie",
+            lastName: "Dupont",
+            email: "marie@example.com",
+            phone: "0612345670",
+          },
+        ],
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("emergencyMedicalAuthorization"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse un mineur sans engagement de prise en charge (yes)", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "2015-04-12",
+        adherentRole: "minor_dependent",
+        emergencyMedicalAuthorization: "yes",
+        supervisionAcknowledgement: "not_applicable_adult",
+        representatives: [
+          {
+            role: "mother",
+            firstName: "Marie",
+            lastName: "Dupont",
+            email: "marie@example.com",
+            phone: "0612345670",
+          },
+        ],
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("supervisionAcknowledgement"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse un majeur qui aurait `yes` sur l'autorisation médicale d'urgence", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        emergencyMedicalAuthorization: "yes",
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("emergencyMedicalAuthorization"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse un majeur qui aurait `yes` sur l'engagement de prise en charge", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        supervisionAcknowledgement: "yes",
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("supervisionAcknowledgement"))
+      ).toBe(true);
+    }
+  });
+
   it("accepte `questionnaire_yes_certificate_required` quel que soit l'âge", () => {
     const young = clubRegistrationPayloadSchema.safeParse(
       buildPayload({

--- a/src/lib/club-registration/schema.test.ts
+++ b/src/lib/club-registration/schema.test.ts
@@ -13,7 +13,9 @@ function buildPayload(
     lastName: "Dupont",
     sex: "male" as const,
     birthCity: "Paris",
-    birthDate: "1985-04-12",
+    /* Date choisie pour rester un majeur < 40 ans quelle que soit l'année du run
+       du test (compatible avec la déclaration `under_40_all_no` par défaut). */
+    birthDate: "2000-04-12",
     adherentEmail: "olivier@example.com",
     adherentPhonePrimary: "0612345678",
     adherentPhoneSecondary: "",
@@ -291,5 +293,62 @@ describe("clubRegistrationPayloadSchema", () => {
       buildPayload({ mainSectionId: "voisins", additionalSectionIds: ["voisins"] })
     );
     expect(r.success).toBe(false);
+  });
+
+  it("refuse une déclaration médicale `over_40_*` pour un moins de 40 ans", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "1995-04-12",
+        medicalCertificateDeclaration: "over_40_cert_unchanged_all_no",
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("medicalCertificateDeclaration"))
+      ).toBe(true);
+    }
+  });
+
+  it("refuse une déclaration médicale `under_40_all_no` pour un ≥ 40 ans", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "1960-04-12",
+        medicalCertificateDeclaration: "under_40_all_no",
+      })
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes("medicalCertificateDeclaration"))
+      ).toBe(true);
+    }
+  });
+
+  it("accepte la nouvelle option `over_40_first_or_changed_certificate_required` pour un ≥ 40 ans", () => {
+    const r = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "1960-04-12",
+        medicalCertificateDeclaration: "over_40_first_or_changed_certificate_required",
+      })
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("accepte `questionnaire_yes_certificate_required` quel que soit l'âge", () => {
+    const young = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "1995-04-12",
+        medicalCertificateDeclaration: "questionnaire_yes_certificate_required",
+      })
+    );
+    const old = clubRegistrationPayloadSchema.safeParse(
+      buildPayload({
+        birthDate: "1960-04-12",
+        medicalCertificateDeclaration: "questionnaire_yes_certificate_required",
+      })
+    );
+    expect(young.success).toBe(true);
+    expect(old.success).toBe(true);
   });
 });

--- a/src/lib/club-registration/schema.ts
+++ b/src/lib/club-registration/schema.ts
@@ -7,7 +7,7 @@ import {
   SECTION_PRINCIPALE_OPTIONS,
 } from "./constants";
 import { isValidFrenchPhoneSurface, normalizeFrenchPhoneInput } from "./phone-fr";
-import { isMinorAt } from "./age";
+import { isAtLeast40At, isMinorAt } from "./age";
 
 const sectionIds = SECTION_PRINCIPALE_OPTIONS.map((s) => s.id) as [
   string,
@@ -102,6 +102,7 @@ export const clubRegistrationPayloadSchema = z
     medicalCertificateDeclaration: z.enum([
       "under_40_all_no",
       "over_40_cert_unchanged_all_no",
+      "over_40_first_or_changed_certificate_required",
       "questionnaire_yes_certificate_required",
     ]),
     wantsRegistrationCertificate: z.boolean(),
@@ -205,6 +206,32 @@ export const clubRegistrationPayloadSchema = z
         message:
           "Les représentants légaux ne s'appliquent qu'à l'inscription d'un mineur",
         path: ["representatives"],
+      });
+    }
+
+    /* Cohérence âge / déclaration médicale : on ne propose pas les options « 40+ »
+       à un adhérent qui a moins de 40 ans, et inversement. Le questionnaire « Oui »
+       (certificat médical requis) reste disponible quel que soit l'âge. */
+    const atLeast40 = isAtLeast40At(data.birthDate);
+    const decl = data.medicalCertificateDeclaration;
+    if (
+      !atLeast40 &&
+      (decl === "over_40_cert_unchanged_all_no" ||
+        decl === "over_40_first_or_changed_certificate_required")
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Cette option est réservée aux adhérents de 40 ans et plus ; choisissez l'option < 40 ans appropriée.",
+        path: ["medicalCertificateDeclaration"],
+      });
+    }
+    if (atLeast40 && decl === "under_40_all_no") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "L'option « moins de 40 ans » n'est pas applicable à votre date de naissance.",
+        path: ["medicalCertificateDeclaration"],
       });
     }
 

--- a/src/lib/club-registration/schema.ts
+++ b/src/lib/club-registration/schema.ts
@@ -235,8 +235,48 @@ export const clubRegistrationPayloadSchema = z
       });
     }
 
-    /* Cohérence âge / rôle */
+    /* Cohérence âge / autorisations légales : seuls les mineurs sont concernés par
+       les autorisations « actes médicaux d'urgence » et « prise en charge à l'heure
+       des cours ». L'UI les masque pour les majeurs et les exige (case cochée) pour
+       les mineurs. Côté serveur on refuse les combinaisons incohérentes. */
     const minor = isMinorAt(data.birthDate);
+    if (minor) {
+      if (data.emergencyMedicalAuthorization !== "yes") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "L'autorisation d'actes médicaux d'urgence est obligatoire pour un mineur.",
+          path: ["emergencyMedicalAuthorization"],
+        });
+      }
+      if (data.supervisionAcknowledgement !== "yes") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "L'engagement de prise en charge à l'heure des cours est obligatoire pour un mineur.",
+          path: ["supervisionAcknowledgement"],
+        });
+      }
+    } else {
+      if (data.emergencyMedicalAuthorization !== "not_applicable_adult") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "L'autorisation d'actes médicaux d'urgence ne s'applique pas à un adhérent majeur.",
+          path: ["emergencyMedicalAuthorization"],
+        });
+      }
+      if (data.supervisionAcknowledgement !== "not_applicable_adult") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "L'engagement de prise en charge à l'heure des cours ne s'applique pas à un adhérent majeur.",
+          path: ["supervisionAcknowledgement"],
+        });
+      }
+    }
+
+    /* Cohérence âge / rôle */
     if (minor && data.adherentRole === "self") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## Contexte

Poursuite de la traitement des préconisations UX. Adresse le point **#5** (priorité haute) : les champs conditionnels n'étaient pas pilotés par l'âge de l'adhérent, ce qui forçait l'utilisateur à choisir « non concerné » sur des autorisations qui n'avaient pas de sens pour son cas, et laissait passer des combinaisons médicales incohérentes avec l'âge.

Stackée sur PR3 (#281).

## Préconisations UX adressées

| # | Sujet | Statut |
|---|---|---|
| 5a | Questionnaire médical guidé par l'âge + couverture du cas « ≥ 40 ans, 1ʳᵉ inscription / changement de catégorie » | ✅ |
| 5b | Autorisations mineurs masquées si majeur, obligatoires si mineur (suppression de l'option « non concerné ») | ✅ |
| 5c | Déplacement de \`firstFemaleRegistrationSqy\` à l'étape 1 (à côté du Select sexe) | ✅ |

## Détail des 3 commits

### 1. \`feat: questionnaire médical guidé par l'âge + option < 40 / ≥ 40 manquante\`
- \`lib/club-registration/age.ts\` : ajout de \`computeAgeAt\` (âge en années révolues, \`null\` si invalide) et \`isAtLeast40At\`. \`isAdultAt\`/\`isMinorAt\` se réécrivent via \`computeAgeAt\` sans changement de comportement.
- \`schema.ts\` : nouvelle valeur d'enum \`over_40_first_or_changed_certificate_required\` + \`superRefine\` qui refuse les options « ≥ 40 ans » pour un < 40 ans et inversement.
- \`MedicalFamilyStep\` : options filtrées dynamiquement selon l'âge calculé depuis \`birthDate\`. Alert si la valeur précédemment sélectionnée n'est plus compatible avec le nouvel âge ; RadioGroup remis à vide pour forcer un nouveau choix.
- \`ClubRegistrationWizard.validateStep(2)\` : exige une déclaration médicale choisie et cohérente avec la date de naissance.
- \`RecapStep\` : nouveau libellé pour la 4ᵉ option, harmonisation « 40 ans et plus ».

### 2. \`feat: autorisations mineurs gérées par l'âge (UI + schema)\`
- \`LegalCompetitorStep\` : si \`isMinorAt(birthDate)\` est \`true\`, on remplace les 2 RadioGroup binaires par 2 Checkboxes obligatoires (« J'autorise les actes médicaux d'urgence », « Je m'engage à ce que mon enfant soit pris en charge »). Si majeur, masquage complet du bloc.
- \`schema.ts\` : \`superRefine\` exige \`yes/yes\` pour un mineur et \`not_applicable_adult/not_applicable_adult\` pour un majeur.
- \`ClubRegistrationWizard.validateStep(3)\` : exige les cases cochées si mineur.
- \`buildPayload\` : force \`not_applicable_adult\` côté majeur pour blinder les éventuelles transitions mineur → majeur après modification de la date de naissance.

### 3. \`feat: déplacement de la 1ʳᵉ inscription féminine à l'étape 1 + recap aligné\`
- \`IdentityStep\` : RadioGroup conditionnel \`firstFemaleRegistrationSqy\` affiché juste après le Select sexe quand \`sex === \"female\"\`.
- \`MedicalFamilyStep\` : suppression du bloc équivalent côté étape 3.
- \`RecapStep\` :
  - Champ « 1ʳᵉ inscription féminine » remonte dans le bloc « Identité de l'adhérent » avec bouton « Modifier » → étape 1.
  - Bloc « Autorisations » n'affiche plus les lignes mineurs pour un majeur (cohérent avec le masquage côté formulaire).

## Couverture tests

- **+13 tests Zod** sur \`schema.test.ts\` : médical (< 40 refusé pour over_40_*, ≥ 40 refusé pour under_40, nouvelle option acceptée, \`questionnaire_yes\` libre), autorisations légales (mineur sans yes/yes refusé, majeur avec yes refusé, etc.).
- **+5 tests** sur \`age.test.ts\` : \`isAtLeast40At\` (jour exact, veille, bien après, date invalide) et \`computeAgeAt\` (anniversaire, veille, date vide).
- **Total : 132 tests verts** (vs 117 avant PR4).

## Test plan manuel

- [ ] Saisir un birthDate < 18 ans : à l'étape 4, les 2 Checkboxes d'autorisation apparaissent et sont obligatoires.
- [ ] Saisir un birthDate ≥ 18 ans : le bloc « Autorisations mineurs » disparaît.
- [ ] Saisir un birthDate < 40 ans : à l'étape 3, on ne voit que les 2 options « < 40 ans » et « Oui à au moins une question ».
- [ ] Saisir un birthDate ≥ 40 ans : 3 options « 40 ans et plus » dont la nouvelle.
- [ ] Choisir une option médicale puis changer la date de naissance pour basculer de tranche : Alert affichée, RadioGroup remis à zéro.
- [ ] Sélectionner « Femme » à l'étape 1 : le RadioGroup « 1ʳᵉ inscription féminine au club » apparaît juste en dessous (et plus à l'étape 3).
- [ ] Soumettre un dossier mineur sans cocher l'une des cases : erreur ciblée à l'étape 4.

## Hors scope

Conservé pour PRs suivantes (cf. plan global) :
- PR5 : validation onBlur + saut sur étape en erreur + scroll-to-field (#2, #10, #11)
- PR6 : refonte étape 2 (créneaux groupés par public) + trichotomie étape 1 (#7, #8)
- PR7 : statut dossier dans le wizard (#4)
- PR8 : polish mobile + wording (#14, #15)

Made with [Cursor](https://cursor.com)