### PR TITLE
feat(club-registration): navigation des erreurs + validation onBlur

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
+  AlertTitle,
   Button,
   Card,
   CardContent,
@@ -13,10 +14,15 @@ import {
   Stepper,
   Typography,
 } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { isValidFrenchPhoneSurface } from "@/lib/club-registration/phone-fr";
 import type { ClubRegistrationPayload } from "@/lib/club-registration/schema";
 import { clubRegistrationPayloadSchema } from "@/lib/club-registration/schema";
 import { isAtLeast40At, isMinorAt } from "@/lib/club-registration/age";
+import {
+  firstStepWithError,
+  stepsWithError,
+} from "@/lib/club-registration/field-to-step";
 import { submitRegistration } from "@/lib/club-registration/submit";
 import type { RegistrationDraft } from "./registration-defaults";
 import { IdentityStep } from "./IdentityStep";
@@ -207,6 +213,17 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
   }, [hydrate, storageLoad]);
 
   /**
+   * Évaluation paresseuse de la validité de chaque étape. On l'utilise à la fois
+   * pour le rendu (icône erreur dans le stepper, résumé dans l'Alert global) et
+   * pour la navigation (impossible d'atteindre une étape postérieure tant que les
+   * étapes antérieures contiennent une erreur). 5 appels par render, négligeable.
+   */
+  const stepValidity = useMemo<(string | null)[]>(
+    () => STEPS.map((_, idx) => validateStep(idx, draft)),
+    [draft]
+  );
+
+  /**
    * Auto-save à chaque changement de draft. On dépend uniquement de la fonction `save`
    * (stable via `useCallback` dans le hook) pour éviter la boucle de re-render qui
    * faisait clignoter le bandeau de statut à chaque frappe.
@@ -216,6 +233,54 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
     if (hydrating) return;
     storageSave(draft);
   }, [draft, hydrating, storageSave]);
+
+  /**
+   * Quand le serveur retourne des fieldErrors (réponse 400), on saute automatiquement
+   * à la 1ʳᵉ étape qui contient une erreur et on fait défiler la vue vers le premier
+   * champ concerné pour réduire la friction (l'utilisateur n'a rien à chercher).
+   */
+  useEffect(() => {
+    if (!fieldErrors || Object.keys(fieldErrors).length === 0) return;
+    const target = firstStepWithError(fieldErrors);
+    if (target === null) return;
+    if (target !== activeStep) {
+      setActiveStep(target);
+    }
+    /* Le DOM doit avoir rendu l'étape cible avant qu'on cherche le 1er champ. On
+       attend deux frames pour couvrir le cas où le changement d'étape réordonne
+       la sous-arborescence. */
+    const errantFields = Object.entries(fieldErrors).filter(
+      ([, msgs]) => Array.isArray(msgs) && msgs.length > 0
+    );
+    if (errantFields.length === 0) return;
+    const firstField = errantFields[0][0];
+    let raf2: number | undefined;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        const escaped =
+          typeof CSS !== "undefined" && typeof CSS.escape === "function"
+            ? CSS.escape(firstField)
+            : firstField;
+        const el = document.querySelector<HTMLElement>(
+          `[name="${escaped}"], [data-field="${escaped}"]`
+        );
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          if (typeof el.focus === "function") {
+            try {
+              el.focus({ preventScroll: true });
+            } catch {
+              // Certains éléments ne supportent pas focus(); on ignore silencieusement.
+            }
+          }
+        }
+      });
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2 !== undefined) cancelAnimationFrame(raf2);
+    };
+  }, [fieldErrors, activeStep]);
 
   const handleNext = () => {
     setSubmitError(null);
@@ -410,11 +475,30 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
       </Typography>
 
       {submitError && <Alert severity="error">{submitError}</Alert>}
-      {fieldErrors && Object.keys(fieldErrors).length > 0 && (
+      {fieldErrors && Object.keys(fieldErrors).length > 0 ? (
         <Alert severity="error">
-          Vérifiez les champs signalés par le serveur. Détail technique disponible pour le support.
+          <AlertTitle>Des informations doivent être corrigées</AlertTitle>
+          <Stack spacing={0.5}>
+            {stepsWithError(fieldErrors).map((idx) => (
+              <Button
+                key={idx}
+                size="small"
+                variant="text"
+                color="error"
+                onClick={() => handleGoToStep(idx)}
+                sx={{
+                  justifyContent: "flex-start",
+                  textTransform: "none",
+                  px: 0,
+                  minHeight: 0,
+                }}
+              >
+                Étape {idx + 1} — {STEPS_SHORT[idx] ?? STEPS[idx]}
+              </Button>
+            ))}
+          </Stack>
         </Alert>
-      )}
+      ) : null}
 
       <Stepper
         activeStep={activeStep}
@@ -422,17 +506,39 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
         alternativeLabel
         sx={{ display: { xs: "none", md: "flex" } }}
       >
-        {STEPS.map((label, index) => (
-          <Step key={label} completed={index < activeStep}>
-            <StepButton
-              color="inherit"
-              disabled={!canNavigateToStep(index, activeStep, draft)}
-              onClick={() => handleGoToStep(index)}
-            >
-              {label}
-            </StepButton>
-          </Step>
-        ))}
+        {STEPS.map((label, index) => {
+          const isPast = index < activeStep;
+          const stepInvalid = stepValidity[index] !== null;
+          /* `completed` ne reflète plus uniquement la position de l'étape :
+             elle exige que validateStep retourne null. Si l'utilisateur est
+             passé sur une étape ultérieure puis a invalidé une étape précédente,
+             celle-ci affiche désormais un état erreur (icône + texte) au lieu
+             d'apparaître à tort comme « cochée ». */
+          const completed = isPast && !stepInvalid;
+          return (
+            <Step key={label} completed={completed}>
+              <StepButton
+                color="inherit"
+                disabled={!canNavigateToStep(index, activeStep, draft)}
+                onClick={() => handleGoToStep(index)}
+                icon={
+                  isPast && stepInvalid ? (
+                    <ErrorOutlineIcon color="error" fontSize="small" />
+                  ) : undefined
+                }
+                optional={
+                  isPast && stepInvalid ? (
+                    <Typography variant="caption" color="error">
+                      À corriger
+                    </Typography>
+                  ) : undefined
+                }
+              >
+                {label}
+              </StepButton>
+            </Step>
+          );
+        })}
       </Stepper>
 
       <Stack spacing={1} sx={{ display: { md: "none" } }}>
@@ -440,18 +546,28 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
           Étape {activeStep + 1} / {STEPS.length} — {STEPS[activeStep]}
         </Typography>
         <Stack direction="row" flexWrap="wrap" useFlexGap sx={{ gap: 1 }}>
-          {STEPS.map((label, index) => (
-            <Button
-              key={label}
-              size="small"
-              variant={activeStep === index ? "contained" : "outlined"}
-              disabled={!canNavigateToStep(index, activeStep, draft)}
-              onClick={() => handleGoToStep(index)}
-              aria-current={activeStep === index ? "step" : undefined}
-            >
-              {index + 1}. {STEPS_SHORT[index] ?? label}
-            </Button>
-          ))}
+          {STEPS.map((label, index) => {
+            const isPast = index < activeStep;
+            const stepInvalid = stepValidity[index] !== null;
+            return (
+              <Button
+                key={label}
+                size="small"
+                color={isPast && stepInvalid ? "error" : "primary"}
+                variant={activeStep === index ? "contained" : "outlined"}
+                disabled={!canNavigateToStep(index, activeStep, draft)}
+                onClick={() => handleGoToStep(index)}
+                aria-current={activeStep === index ? "step" : undefined}
+                startIcon={
+                  isPast && stepInvalid ? (
+                    <ErrorOutlineIcon fontSize="small" />
+                  ) : undefined
+                }
+              >
+                {index + 1}. {STEPS_SHORT[index] ?? label}
+              </Button>
+            );
+          })}
         </Stack>
       </Stack>
 

--- a/src/components/club-registration/IdentityStep.test.tsx
+++ b/src/components/club-registration/IdentityStep.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { IdentityStep } from "./IdentityStep";
+import { createEmptyDraft, type RegistrationDraft } from "./registration-defaults";
+
+function setup(overrides: Partial<RegistrationDraft> = {}) {
+  const draft: RegistrationDraft = { ...createEmptyDraft(), ...overrides };
+  const onPatch = jest.fn();
+  const onSetAdherentRole = jest.fn();
+  const onSetSex = jest.fn();
+  const onAddRepresentative = jest.fn();
+  const onUpdateRepresentative = jest.fn();
+  const onRemoveRepresentative = jest.fn();
+
+  render(
+    <IdentityStep
+      draft={draft}
+      onPatch={onPatch}
+      onSetAdherentRole={onSetAdherentRole}
+      onSetSex={onSetSex}
+      onAddRepresentative={onAddRepresentative}
+      onUpdateRepresentative={onUpdateRepresentative}
+      onRemoveRepresentative={onRemoveRepresentative}
+    />
+  );
+}
+
+describe("IdentityStep — validation onBlur", () => {
+  it("n'affiche pas d'erreur e-mail invalide avant le 1er blur (pas de friction)", () => {
+    setup({ adherentEmail: "pas-un-email" });
+    expect(
+      screen.queryByText(/adresse e-mail invalide/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("affiche l'erreur e-mail après le blur si le format est invalide", () => {
+    setup({ adherentEmail: "pas-un-email" });
+    const emailInput = screen.getByLabelText(/e-mail de l’adhérent/i);
+    fireEvent.blur(emailInput);
+    expect(screen.getByText(/adresse e-mail invalide/i)).toBeInTheDocument();
+  });
+
+  it("ne montre pas d'erreur si l'e-mail est vide même après blur (champ optionnel)", () => {
+    setup({ adherentEmail: "" });
+    const emailInput = screen.getByLabelText(/e-mail de l’adhérent/i);
+    fireEvent.blur(emailInput);
+    expect(
+      screen.queryByText(/adresse e-mail invalide/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("affiche « Téléphone obligatoire » après blur sur un téléphone primaire vide", () => {
+    setup({ adherentPhonePrimary: "" });
+    const phoneInput = screen.getByLabelText(/téléphone principal/i);
+    fireEvent.blur(phoneInput);
+    expect(screen.getByText(/téléphone obligatoire/i)).toBeInTheDocument();
+  });
+
+  it("affiche « Numéro français invalide » sur téléphone secondaire mal formé après blur", () => {
+    setup({ adherentPhoneSecondary: "12" });
+    const secondary = screen.getByLabelText(/téléphone secondaire/i);
+    fireEvent.blur(secondary);
+    expect(
+      screen.getByText(/numéro français invalide/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/club-registration/IdentityStep.tsx
+++ b/src/components/club-registration/IdentityStep.tsx
@@ -26,9 +26,13 @@ import { isMinorAt } from "@/lib/club-registration/age";
 import { getDevIdentityFixture } from "./dev-identity-fixture";
 import { PostalAddressSection } from "./PostalAddressSection";
 import { RepresentativesBlock } from "./RepresentativesBlock";
+import { useTouchedFields } from "./useTouchedFields";
 import type { RegistrationDraft, Representative } from "./registration-defaults";
 
 const IS_DEV = process.env.NODE_ENV === "development";
+
+/** Regex e-mail volontairement laxiste (mêmes contraintes que côté Zod). */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type Props = {
   draft: RegistrationDraft;
@@ -49,12 +53,34 @@ export function IdentityStep({
   onUpdateRepresentative,
   onRemoveRepresentative,
 }: Props) {
-  const primaryInvalid =
-    draft.adherentPhonePrimary.trim() !== "" &&
-    !isValidFrenchPhoneSurface(draft.adherentPhonePrimary);
-  const secondaryInvalid =
-    (draft.adherentPhoneSecondary ?? "").trim() !== "" &&
+  /* Validation onBlur : on n'affiche les erreurs au champ qu'après que
+     l'utilisateur ait quitté ce champ une première fois. Évite la friction
+     visuelle pendant la saisie tout en signalant clairement les formats. */
+  const { isTouched, markTouched } = useTouchedFields();
+
+  const emailValue = (draft.adherentEmail ?? "").trim();
+  const emailFormatInvalid = emailValue !== "" && !EMAIL_RE.test(emailValue);
+  const showEmailError = isTouched("adherentEmail") && emailFormatInvalid;
+
+  const primaryRaw = draft.adherentPhonePrimary.trim();
+  const primaryFormatInvalid =
+    primaryRaw !== "" && !isValidFrenchPhoneSurface(draft.adherentPhonePrimary);
+  const primaryRequiredMissing = primaryRaw === "";
+  const showPrimaryError =
+    isTouched("adherentPhonePrimary") &&
+    (primaryFormatInvalid || primaryRequiredMissing);
+  const primaryHelperText = primaryFormatInvalid
+    ? "Numéro français invalide (10 chiffres ou +33)."
+    : primaryRequiredMissing
+      ? "Téléphone obligatoire."
+      : undefined;
+
+  const secondaryRaw = (draft.adherentPhoneSecondary ?? "").trim();
+  const secondaryFormatInvalid =
+    secondaryRaw !== "" &&
     !isValidFrenchPhoneSurface(draft.adherentPhoneSecondary ?? "");
+  const showSecondaryError =
+    isTouched("adherentPhoneSecondary") && secondaryFormatInvalid;
 
   const handlePhoneChange =
     (field: "adherentPhonePrimary" | "adherentPhoneSecondary") =>
@@ -143,6 +169,7 @@ export function IdentityStep({
           onChange={(e) => onPatch({ firstName: e.target.value })}
           fullWidth
           autoComplete="given-name"
+          inputProps={{ "data-field": "firstName" }}
         />
         <TextField
           required
@@ -151,6 +178,7 @@ export function IdentityStep({
           onChange={(e) => onPatch({ lastName: e.target.value })}
           fullWidth
           autoComplete="family-name"
+          inputProps={{ "data-field": "lastName" }}
         />
       </Stack>
 
@@ -198,6 +226,7 @@ export function IdentityStep({
         fullWidth
         name="clubRegistrationBirthCity"
         autoComplete="section-club-birth address-level2"
+        inputProps={{ "data-field": "birthCity" }}
       />
 
       <TextField
@@ -213,6 +242,7 @@ export function IdentityStep({
         inputProps={{
           min: "1900-01-01",
           max: new Date().toISOString().slice(0, 10),
+          "data-field": "birthDate",
         }}
       />
 
@@ -225,9 +255,16 @@ export function IdentityStep({
         type="email"
         value={draft.adherentEmail ?? ""}
         onChange={(e) => onPatch({ adherentEmail: e.target.value })}
+        onBlur={() => markTouched("adherentEmail")}
         fullWidth
         autoComplete="email"
-        helperText="Si l’adhérent a sa propre adresse (ado, adulte) — sinon laissez vide."
+        error={showEmailError}
+        helperText={
+          showEmailError
+            ? "Adresse e-mail invalide."
+            : "Si l’adhérent a sa propre adresse (ado, adulte) — sinon laissez vide."
+        }
+        inputProps={{ "data-field": "adherentEmail" }}
       />
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
@@ -236,27 +273,38 @@ export function IdentityStep({
           label="Téléphone principal de l’adhérent"
           value={toFrenchPhoneMaskedDisplay(draft.adherentPhonePrimary)}
           onChange={handlePhoneChange("adherentPhonePrimary")}
+          onBlur={() => markTouched("adherentPhonePrimary")}
           fullWidth
           autoComplete="tel-national"
           placeholder="06 34 44 55 33"
           inputMode="numeric"
-          error={primaryInvalid}
-          helperText={primaryInvalid ? "Numéro invalide" : undefined}
+          error={showPrimaryError}
+          helperText={showPrimaryError ? primaryHelperText : undefined}
+          inputProps={{ "data-field": "adherentPhonePrimary" }}
         />
         <TextField
           label="Téléphone secondaire (optionnel)"
           value={toFrenchPhoneMaskedDisplay(draft.adherentPhoneSecondary ?? "")}
           onChange={handlePhoneChange("adherentPhoneSecondary")}
+          onBlur={() => markTouched("adherentPhoneSecondary")}
           fullWidth
           autoComplete="tel-national"
           placeholder="06 34 44 55 33"
           inputMode="numeric"
-          error={secondaryInvalid}
-          helperText={secondaryInvalid ? "Numéro invalide" : undefined}
+          error={showSecondaryError}
+          helperText={
+            showSecondaryError ? "Numéro français invalide." : undefined
+          }
+          inputProps={{ "data-field": "adherentPhoneSecondary" }}
         />
       </Stack>
 
-      <PostalAddressSection draft={draft} onChange={onPatch} />
+      <PostalAddressSection
+        draft={draft}
+        onChange={onPatch}
+        isTouched={isTouched}
+        markTouched={markTouched}
+      />
 
       {showRepresentatives ? (
         <Stack spacing={1}>
@@ -273,6 +321,8 @@ export function IdentityStep({
             onAdd={onAddRepresentative}
             onUpdate={onUpdateRepresentative}
             onRemove={onRemoveRepresentative}
+            isTouched={isTouched}
+            markTouched={markTouched}
           />
         </Stack>
       ) : null}

--- a/src/components/club-registration/PostalAddressSection.tsx
+++ b/src/components/club-registration/PostalAddressSection.tsx
@@ -13,6 +13,15 @@ import type { RegistrationDraft } from "./registration-defaults";
 type Props = {
   draft: RegistrationDraft;
   onChange: (patch: Partial<RegistrationDraft>) => void;
+  /**
+   * Helpers de validation onBlur fournis par le parent (`IdentityStep`).
+   * Si non fournis, on considère que les champs sont déjà "touchés" : les
+   * erreurs s'affichent dès que le format est invalide. Cela permet à ce
+   * composant de rester utilisable de manière autonome dans les tests ou
+   * dans un éventuel formulaire futur.
+   */
+  isTouched?: (field: string) => boolean;
+  markTouched?: (field: string) => void;
 };
 
 function hasAnyAddressValue(d: RegistrationDraft): boolean {
@@ -24,12 +33,29 @@ function hasAnyAddressValue(d: RegistrationDraft): boolean {
   );
 }
 
-export function PostalAddressSection({ draft, onChange }: Props) {
+export function PostalAddressSection({
+  draft,
+  onChange,
+  isTouched,
+  markTouched,
+}: Props) {
   const [manualMode, setManualMode] = useState(false);
   const [filledViaBan, setFilledViaBan] = useState(false);
 
   const persistedOrEditedAddress = hasAnyAddressValue(draft);
   const showDetailFields = manualMode || filledViaBan || persistedOrEditedAddress;
+
+  /* `isTouched`/`markTouched` peuvent être omis quand le composant est utilisé
+     hors du wizard ; on bascule alors en "toujours touché" pour conserver le
+     comportement historique (erreur dès le format invalide). */
+  const touched = isTouched ?? (() => true);
+  const mark = markTouched ?? (() => {});
+
+  const postalCodeRaw = draft.postalCode.trim();
+  const postalCodeFormatInvalid =
+    postalCodeRaw !== "" && !/^[0-9]{5}$/.test(postalCodeRaw);
+  const showPostalCodeError =
+    touched("postalCode") && postalCodeFormatInvalid;
 
   const handleBanSelect = (a: { addressLine1: string; postalCode: string; city: string }) => {
     onChange({
@@ -103,6 +129,7 @@ export function PostalAddressSection({ draft, onChange }: Props) {
             fullWidth
             name="clubRegistrationAddressLine1"
             autoComplete="section-club-residence street-address"
+            inputProps={{ "data-field": "addressLine1" }}
           />
           <TextField
             label="Complément d’adresse"
@@ -112,6 +139,7 @@ export function PostalAddressSection({ draft, onChange }: Props) {
             name="clubRegistrationAddressLine2"
             autoComplete="section-club-residence address-line2"
             helperText="Étage, bâtiment, résidence, appartement…"
+            inputProps={{ "data-field": "addressLine2" }}
           />
 
           <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
@@ -120,10 +148,21 @@ export function PostalAddressSection({ draft, onChange }: Props) {
               label="Code postal"
               value={draft.postalCode}
               onChange={(e) => onChange({ postalCode: e.target.value })}
+              onBlur={() => mark("postalCode")}
               fullWidth
               name="clubRegistrationPostalCode"
               autoComplete="section-club-residence postal-code"
-              inputProps={{ inputMode: "numeric", maxLength: 5 }}
+              inputProps={{
+                inputMode: "numeric",
+                maxLength: 5,
+                "data-field": "postalCode",
+              }}
+              error={showPostalCodeError}
+              helperText={
+                showPostalCodeError
+                  ? "Code postal français à 5 chiffres."
+                  : undefined
+              }
             />
             <TextField
               required
@@ -133,6 +172,7 @@ export function PostalAddressSection({ draft, onChange }: Props) {
               fullWidth
               name="clubRegistrationCity"
               autoComplete="section-club-residence address-level2"
+              inputProps={{ "data-field": "city" }}
             />
           </Stack>
         </Stack>

--- a/src/components/club-registration/RepresentativesBlock.tsx
+++ b/src/components/club-registration/RepresentativesBlock.tsx
@@ -32,6 +32,13 @@ type Props = {
   onAdd: () => void;
   onUpdate: (index: number, patch: Partial<Representative>) => void;
   onRemove: (index: number) => void;
+  /**
+   * Helpers de validation onBlur fournis par le parent. Si non fournis, les
+   * champs sont considérés comme déjà "touchés" pour conserver le
+   * comportement historique (affichage de l'erreur dès le format invalide).
+   */
+  isTouched?: (field: string) => boolean;
+  markTouched?: (field: string) => void;
 };
 
 const ROLE_OPTIONS: Array<{ value: Representative["role"]; label: string }> = [
@@ -53,7 +60,11 @@ export function RepresentativesBlock({
   onAdd,
   onUpdate,
   onRemove,
+  isTouched,
+  markTouched,
 }: Props) {
+  const touched = isTouched ?? (() => true);
+  const mark = markTouched ?? (() => {});
   const handleField =
     (index: number, field: keyof Representative) =>
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -84,9 +95,28 @@ export function RepresentativesBlock({
       {representatives.map((rep, index) => {
         const removable = !(firstIsRequired && index === 0);
         const required = firstIsRequired && index === 0;
-        const phoneInvalid =
+        const emailField = `representatives.${index}.email`;
+        const phoneField = `representatives.${index}.phone`;
+        const phoneFormatInvalid =
           rep.phone.trim() !== "" && !isValidFrenchPhoneSurface(rep.phone);
-        const emailInvalid = isInvalidEmail(rep.email);
+        const phoneRequiredMissing = required && rep.phone.trim() === "";
+        const showPhoneError =
+          touched(phoneField) && (phoneFormatInvalid || phoneRequiredMissing);
+        const phoneHelperText = phoneFormatInvalid
+          ? "Numéro français invalide."
+          : phoneRequiredMissing
+            ? "Téléphone obligatoire pour le représentant légal."
+            : undefined;
+
+        const emailFormatInvalid = isInvalidEmail(rep.email);
+        const emailRequiredMissing = required && rep.email.trim() === "";
+        const showEmailError =
+          touched(emailField) && (emailFormatInvalid || emailRequiredMissing);
+        const emailHelperText = emailFormatInvalid
+          ? "Adresse e-mail invalide."
+          : emailRequiredMissing
+            ? "E-mail obligatoire pour le représentant légal."
+            : undefined;
 
         return (
           <Card key={index} variant="outlined">
@@ -151,10 +181,11 @@ export function RepresentativesBlock({
                   type="email"
                   value={rep.email}
                   onChange={handleField(index, "email")}
+                  onBlur={() => mark(emailField)}
                   fullWidth
                   autoComplete="off"
-                  error={emailInvalid}
-                  helperText={emailInvalid ? "Adresse e-mail invalide" : undefined}
+                  error={showEmailError}
+                  helperText={showEmailError ? emailHelperText : undefined}
                 />
 
                 <TextField
@@ -162,12 +193,13 @@ export function RepresentativesBlock({
                   label="Téléphone"
                   value={toFrenchPhoneMaskedDisplay(rep.phone)}
                   onChange={handlePhone(index)}
+                  onBlur={() => mark(phoneField)}
                   fullWidth
                   inputMode="numeric"
                   placeholder="06 12 34 56 78"
                   autoComplete="off"
-                  error={phoneInvalid}
-                  helperText={phoneInvalid ? "Numéro invalide" : undefined}
+                  error={showPhoneError}
+                  helperText={showPhoneError ? phoneHelperText : undefined}
                 />
               </Stack>
             </CardContent>

--- a/src/components/club-registration/useTouchedFields.test.tsx
+++ b/src/components/club-registration/useTouchedFields.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook, act } from "@testing-library/react";
+import { useTouchedFields } from "./useTouchedFields";
+
+describe("useTouchedFields", () => {
+  it("retourne false avant tout markTouched", () => {
+    const { result } = renderHook(() => useTouchedFields());
+    expect(result.current.isTouched("foo")).toBe(false);
+  });
+
+  it("marque un champ comme touched et retourne true uniquement pour lui", () => {
+    const { result } = renderHook(() => useTouchedFields());
+    act(() => result.current.markTouched("foo"));
+    expect(result.current.isTouched("foo")).toBe(true);
+    expect(result.current.isTouched("bar")).toBe(false);
+  });
+
+  it("markAll active la sortie true sur tous les champs", () => {
+    const { result } = renderHook(() => useTouchedFields());
+    expect(result.current.isTouched("baz")).toBe(false);
+    act(() => result.current.markAll());
+    expect(result.current.isTouched("foo")).toBe(true);
+    expect(result.current.isTouched("anything")).toBe(true);
+  });
+
+  it("reset remet à zéro le set des champs touchés", () => {
+    const { result } = renderHook(() => useTouchedFields());
+    act(() => result.current.markTouched("foo"));
+    act(() => result.current.markAll());
+    expect(result.current.isTouched("foo")).toBe(true);
+    act(() => result.current.reset());
+    expect(result.current.isTouched("foo")).toBe(false);
+    expect(result.current.isTouched("bar")).toBe(false);
+  });
+
+  it("markTouched est idempotent (pas de set si déjà touché)", () => {
+    const { result } = renderHook(() => useTouchedFields());
+    act(() => result.current.markTouched("foo"));
+    const firstRef = result.current.isTouched;
+    act(() => result.current.markTouched("foo"));
+    expect(result.current.isTouched("foo")).toBe(true);
+    // Le callback isTouched est stable tant que touched/allTouched n'ont pas changé.
+    expect(result.current.isTouched).toBe(firstRef);
+  });
+});

--- a/src/components/club-registration/useTouchedFields.ts
+++ b/src/components/club-registration/useTouchedFields.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Petit hook utilitaire pour le pattern « validation onBlur » :
+ * - L'utilisateur ne voit pas d'erreur pendant qu'il tape (pas de friction).
+ * - Au premier `blur` du champ, on le marque comme "touched" : l'erreur de
+ *   validation associée peut alors s'afficher en `helperText`.
+ * - `markAll` permet d'afficher d'un coup toutes les erreurs (utilisé à la
+ *   tentative de passage à l'étape suivante ou de soumission finale).
+ *
+ * On reste minimaliste : la source de vérité reste le draft Zod + les fonctions
+ * `validateStep` du wizard. Ce hook ne stocke que la dimension UX « ce champ
+ * a déjà été visité ».
+ */
+export function useTouchedFields() {
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [allTouched, setAllTouched] = useState(false);
+
+  const markTouched = useCallback((field: string) => {
+    setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  const markAll = useCallback(() => {
+    setAllTouched(true);
+  }, []);
+
+  const reset = useCallback(() => {
+    setTouched({});
+    setAllTouched(false);
+  }, []);
+
+  const isTouched = useCallback(
+    (field: string) => allTouched || Boolean(touched[field]),
+    [touched, allTouched]
+  );
+
+  return { isTouched, markTouched, markAll, reset } as const;
+}
+
+export type UseTouchedFieldsReturn = ReturnType<typeof useTouchedFields>;

--- a/src/lib/club-registration/field-to-step.test.ts
+++ b/src/lib/club-registration/field-to-step.test.ts
@@ -1,0 +1,81 @@
+import {
+  REGISTRATION_FIELD_TO_STEP,
+  firstStepWithError,
+  stepsWithError,
+} from "./field-to-step";
+
+describe("REGISTRATION_FIELD_TO_STEP", () => {
+  it("mappe les champs identité sur l'étape 0", () => {
+    expect(REGISTRATION_FIELD_TO_STEP.firstName).toBe(0);
+    expect(REGISTRATION_FIELD_TO_STEP.birthDate).toBe(0);
+    expect(REGISTRATION_FIELD_TO_STEP.representatives).toBe(0);
+  });
+
+  it("mappe slotIds sur l'étape 1", () => {
+    expect(REGISTRATION_FIELD_TO_STEP.slotIds).toBe(1);
+    expect(REGISTRATION_FIELD_TO_STEP.mainSectionId).toBe(1);
+  });
+
+  it("mappe medical / aides sur l'étape 2", () => {
+    expect(REGISTRATION_FIELD_TO_STEP.medicalCertificateDeclaration).toBe(2);
+    expect(REGISTRATION_FIELD_TO_STEP.passSportCode).toBe(2);
+  });
+
+  it("mappe consentements / compétition sur l'étape 3", () => {
+    expect(REGISTRATION_FIELD_TO_STEP.photoConsent).toBe(3);
+    expect(REGISTRATION_FIELD_TO_STEP.competitionJerseySize).toBe(3);
+  });
+});
+
+describe("firstStepWithError", () => {
+  it("retourne null si aucun fieldErrors", () => {
+    expect(firstStepWithError(null)).toBeNull();
+    expect(firstStepWithError(undefined)).toBeNull();
+    expect(firstStepWithError({})).toBeNull();
+  });
+
+  it("retourne null si toutes les valeurs sont vides", () => {
+    expect(firstStepWithError({ firstName: [], slotIds: undefined })).toBeNull();
+  });
+
+  it("retourne l'étape la plus petite parmi les erreurs", () => {
+    expect(
+      firstStepWithError({
+        photoConsent: ["err"],
+        firstName: ["err"],
+        slotIds: ["err"],
+      })
+    ).toBe(0);
+  });
+
+  it("retourne 1 si l'erreur la plus en amont est sur slotIds", () => {
+    expect(
+      firstStepWithError({
+        photoConsent: ["err"],
+        slotIds: ["err"],
+      })
+    ).toBe(1);
+  });
+
+  it("retombe sur l'étape 0 pour une clé inconnue", () => {
+    expect(firstStepWithError({ unknownField: ["err"] })).toBe(0);
+  });
+});
+
+describe("stepsWithError", () => {
+  it("retourne un tableau vide si aucune erreur", () => {
+    expect(stepsWithError(null)).toEqual([]);
+    expect(stepsWithError({})).toEqual([]);
+  });
+
+  it("dédoublonne les étapes et les trie", () => {
+    expect(
+      stepsWithError({
+        photoConsent: ["err"],
+        firstName: ["err"],
+        slotIds: ["err"],
+        passSportCode: ["err"],
+      })
+    ).toEqual([0, 1, 2, 3]);
+  });
+});

--- a/src/lib/club-registration/field-to-step.ts
+++ b/src/lib/club-registration/field-to-step.ts
@@ -1,0 +1,93 @@
+/**
+ * Mapping nom de champ ↔ index d'étape du wizard d'inscription club.
+ *
+ * Utilisé pour :
+ * - Sur une erreur serveur (`fieldErrors` Zod), sauter automatiquement à la 1ʳᵉ étape
+ *   qui porte une erreur (la plus proche du début pour ne pas désorienter l'utilisateur).
+ * - Construire un résumé lisible des étapes en erreur dans l'Alert global du wizard.
+ *
+ * Les indices doivent rester alignés avec `STEPS` dans `ClubRegistrationWizard.tsx` :
+ *   0: Identité et coordonnées
+ *   1: Sections et créneaux
+ *   2: Certificat et aides
+ *   3: Consentements et compétition
+ *   4: Récapitulatif (lecture seule)
+ *
+ * Toute clé non listée tombe sur l'étape 0 par défaut (préférence à corriger côté
+ * client plutôt qu'à laisser l'utilisateur deviner).
+ */
+
+export const REGISTRATION_FIELD_TO_STEP: Readonly<Record<string, number>> = {
+  /* Étape 0 — Identité et coordonnées */
+  adherentRole: 0,
+  firstName: 0,
+  lastName: 0,
+  sex: 0,
+  firstFemaleRegistrationSqy: 0,
+  birthCity: 0,
+  birthDate: 0,
+  adherentEmail: 0,
+  adherentPhonePrimary: 0,
+  adherentPhoneSecondary: 0,
+  addressLine1: 0,
+  addressLine2: 0,
+  postalCode: 0,
+  city: 0,
+  representatives: 0,
+
+  /* Étape 1 — Sections et créneaux */
+  mainSectionId: 1,
+  additionalSectionIds: 1,
+  slotIds: 1,
+
+  /* Étape 2 — Certificat et aides */
+  medicalCertificateDeclaration: 2,
+  wantsRegistrationCertificate: 2,
+  familyRegistrationOrder: 2,
+  reductionTypes: 2,
+  passSportCode: 2,
+
+  /* Étape 3 — Consentements et compétition */
+  photoConsent: 3,
+  emergencyMedicalAuthorization: 3,
+  supervisionAcknowledgement: 3,
+  internalRulesAccepted: 3,
+  wantsCompetitorExtras: 3,
+  competitionJerseySize: 3,
+  competitionIds: 3,
+};
+
+/**
+ * Retourne l'index de la 1ʳᵉ étape qui contient une erreur (chaîne ou tableau non vide),
+ * ou null si aucun champ n'est en erreur. La 1ʳᵉ clé sans mapping connu tombe sur 0.
+ */
+export function firstStepWithError(
+  fieldErrors: Record<string, string[] | undefined> | null | undefined
+): number | null {
+  if (!fieldErrors) return null;
+  let best: number | null = null;
+  for (const [key, messages] of Object.entries(fieldErrors)) {
+    if (!messages || messages.length === 0) continue;
+    const step = REGISTRATION_FIELD_TO_STEP[key] ?? 0;
+    if (best === null || step < best) {
+      best = step;
+    }
+  }
+  return best;
+}
+
+/**
+ * Liste des étapes (uniques, triées) sur lesquelles porte au moins une erreur. Utilisé
+ * pour afficher un résumé compact « Erreurs sur les étapes 1 et 3 ».
+ */
+export function stepsWithError(
+  fieldErrors: Record<string, string[] | undefined> | null | undefined
+): number[] {
+  if (!fieldErrors) return [];
+  const set = new Set<number>();
+  for (const [key, messages] of Object.entries(fieldErrors)) {
+    if (!messages || messages.length === 0) continue;
+    set.add(REGISTRATION_FIELD_TO_STEP[key] ?? 0);
+  }
+  return Array.from(set).sort((a, b) => a - b);
+}


### PR DESCRIPTION
## Contexte

5ᵉ PR du chantier UX du formulaire d'inscription club, stackée sur **#282** (logique mineur/majeur). Cible les pain points #2, #10 et #11 du plan UX validé :
- Trop d'aller-retour pour retrouver les erreurs après une soumission rejetée.
- Aucune indication visuelle quand une étape passée devient invalide.
- Validation au format trop agressive pendant la saisie.

## Changements

### Navigation et stepper fiables

- `field-to-step.ts` : mapping nom de champ Zod → index d'étape du wizard, couvert par 11 tests unitaires.
- Sur réponse 400 (`fieldErrors`) : saut automatique vers la 1ʳᵉ étape concernée, scroll + focus sur le 1ᵉʳ champ via \`[name=...]\` ou \`[data-field=...]\`.
- L'Alert global d'erreur devient un résumé cliquable des étapes en erreur (remplace l'ancien message « détail technique pour le support »).
- Le Stepper affiche désormais une icône d'erreur et le libellé « À corriger » sur les étapes passées devenues invalides après modification (cas typique : l'utilisateur revient en arrière, corrige, casse, repart).
- `completed` ne reflète plus la simple position : il exige \`validateStep(step) === null\`.

### Validation onBlur sur l'étape 1

- `useTouchedFields` : hook (5 tests) centralisant la dimension « ce champ a été visité ».
- IdentityStep applique le pattern sur les champs avec format précis :
  - E-mail adhérent (optionnel, message uniquement si format invalide).
  - Téléphone principal (« obligatoire » vs « format invalide »).
  - Téléphone secondaire (optionnel, message uniquement si format invalide).
- PostalAddressSection : code postal \`^[0-9]{5}$\` avec onBlur.
- RepresentativesBlock : e-mail + téléphone du 1ᵉʳ représentant (obligatoire pour un mineur), messages différenciés vide/invalide.
- Ajout d'attributs \`data-field\` sur les TextField clés pour permettre le scroll-to-field automatique.

## Tests

- **+21 tests** ajoutés (\`field-to-step\`, \`useTouchedFields\`, \`IdentityStep\`).
- **Total : 153 tests verts.**
- \`npm run check\` (lint + type-check + build) ✅.

## Test plan

- [ ] Soumettre un dossier valide → succès, aucune régression.
- [ ] Soumettre un dossier dont le téléphone principal est mal formé → l'Alert global liste l'étape 1 ; le clic dessus saute à l'étape 1 et scrolle/focus sur le téléphone.
- [ ] Revenir à l'étape 1 et vider le prénom → le stepper marque l'étape 1 comme « À corriger » avec icône d'erreur.
- [ ] Taper un e-mail invalide sans quitter le champ → aucune erreur visible.
- [ ] Quitter le champ e-mail → l'erreur « Adresse e-mail invalide » apparaît.
- [ ] Code postal à 3 chiffres + blur → message « Code postal français à 5 chiffres ».
- [ ] Mineur sans représentant légal renseigné → blur sur les champs représentant → messages « obligatoire » différenciés.

## Stack

Cette PR est stackée sur #282 (mineur/majeur) qui est stackée sur #281 (quick wins UX).

Made with [Cursor](https://cursor.com)