### PR TITLE
feat(club-registration): focus management + data-field sur toutes les étapes

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.test.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, act } from "@testing-library/react";
+import { ClubRegistrationWizard } from "./ClubRegistrationWizard";
+
+/* On mocke les hooks de storage : ils dépendent de localStorage et d'effets
+   asynchrones (debounce de save) qui ne nous intéressent pas pour tester le
+   focus management — on veut juste pouvoir manipuler activeStep via clic. */
+jest.mock("./useRegistrationDraftStorage", () => ({
+  useRegistrationDraftStorage: () => ({
+    load: () => null,
+    save: jest.fn(),
+    clear: jest.fn(),
+    status: "idle" as const,
+    isDisabled: false,
+    lastSavedAt: null,
+    disable: jest.fn(),
+    enable: jest.fn(),
+  }),
+}));
+
+/* On évite d'instancier Firebase à l'import en stubbant l'AuthDialog. */
+jest.mock("@/components/auth/AuthDialog", () => ({
+  AuthDialog: () => null,
+}));
+
+describe("ClubRegistrationWizard — focus management", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+  });
+
+  function flushRaf() {
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+  }
+
+  it("place le focus sur le titre invisible de l'étape au mount", () => {
+    jest.useFakeTimers();
+    /* requestAnimationFrame est mocké pour s'exécuter de manière synchrone
+       lorsque l'on avance les timers. */
+    const rafSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        return setTimeout(() => cb(0), 0) as unknown as number;
+      });
+
+    render(<ClubRegistrationWizard accountEmail={null} />);
+    flushRaf();
+    /* Le titre invisible <h2> doit exister pour l'étape 1. */
+    const heading = screen.getByRole("heading", {
+      level: 2,
+      name: /étape 1 sur 5 .* identité/i,
+    });
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName.toLowerCase()).toBe("h2");
+
+    rafSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   AlertTitle,
+  Box,
   Button,
   Card,
   CardContent,
@@ -14,6 +15,7 @@ import {
   Stepper,
   Typography,
 } from "@mui/material";
+import { visuallyHidden } from "@mui/utils";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { isValidFrenchPhoneSurface } from "@/lib/club-registration/phone-fr";
 import type { ClubRegistrationPayload } from "@/lib/club-registration/schema";
@@ -197,6 +199,10 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const pendingPayloadRef = useRef<ClubRegistrationPayload | null>(null);
   const hasHydratedRef = useRef(false);
+  /* Refs pour la gestion du focus au changement d'étape. */
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const stepHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const prevActiveStepRef = useRef(0);
 
   /* Hydratation au mount : local-first, fallback éventuel sur le draft serveur (lecture seule pour l'instant). */
   const storageLoad = storage.load;
@@ -281,6 +287,36 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
       if (raf2 !== undefined) cancelAnimationFrame(raf2);
     };
   }, [fieldErrors, activeStep]);
+
+  /**
+   * Gestion du focus au changement d'étape (accessibilité + fluidité au clavier) :
+   * - Remonte le scroll en haut de la Card pour que l'utilisateur ne se retrouve
+   *   pas au milieu de la nouvelle étape.
+   * - Donne le focus au titre invisible de l'étape (lu par les lecteurs d'écran).
+   *
+   * Si une erreur serveur vient d'arriver et va déclencher un focus ciblé sur le
+   * 1ᵉʳ champ en erreur, on laisse la main à l'autre effet pour ne pas voler le
+   * focus à un emplacement plus pertinent.
+   */
+  useEffect(() => {
+    if (prevActiveStepRef.current === activeStep) return;
+    prevActiveStepRef.current = activeStep;
+
+    cardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    const hasServerFieldErrors =
+      fieldErrors !== null &&
+      Object.values(fieldErrors).some(
+        (msgs) => Array.isArray(msgs) && msgs.length > 0
+      );
+    if (hasServerFieldErrors) return;
+
+    /* RAF pour laisser React peindre le nouveau step avant de focus. */
+    const raf = requestAnimationFrame(() => {
+      stepHeadingRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [activeStep, fieldErrors]);
 
   const handleNext = () => {
     setSubmitError(null);
@@ -571,8 +607,20 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
         </Stack>
       </Stack>
 
-      <Card variant="outlined">
+      <Card variant="outlined" ref={cardRef}>
         <CardContent>
+          {/* Titre invisible mais focusable : annonce l'étape courante aux
+              lecteurs d'écran et reçoit le focus à chaque changement d'étape.
+              On utilise `style` plutôt que `sx` car `visuallyHidden` retourne
+              du CSSProperties brut, incompatible avec le typage `SxProps`. */}
+          <Box
+            component="h2"
+            ref={stepHeadingRef}
+            tabIndex={-1}
+            style={visuallyHidden}
+          >
+            Étape {activeStep + 1} sur {STEPS.length} : {STEPS[activeStep]}
+          </Box>
           {activeStep === 0 && (
             <IdentityStep
               draft={draft}

--- a/src/components/club-registration/LegalCompetitorStep.tsx
+++ b/src/components/club-registration/LegalCompetitorStep.tsx
@@ -2,6 +2,7 @@
 
 import {
   Alert,
+  Box,
   Checkbox,
   FormControl,
   FormControlLabel,
@@ -64,6 +65,7 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
         </Typography>
         <RadioGroup
           aria-labelledby="photo-consent-label"
+          name="photoConsent"
           value={draft.photoConsent}
           onChange={(e) =>
             onChange({
@@ -83,50 +85,55 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
             Ces deux autorisations sont obligatoires pour l’inscription d’un mineur. Elles ne
             sont pas affichées si l’adhérent est majeur.
           </Typography>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={draft.emergencyMedicalAuthorization === "yes"}
-                onChange={(e) =>
-                  onChange({
-                    emergencyMedicalAuthorization: e.target.checked
-                      ? "yes"
-                      : "not_applicable_adult",
-                  })
-                }
-              />
-            }
-            label={
-              <Typography variant="body2" component="span">
-                J’autorise les actes médicaux ou chirurgicaux en urgence pour mon enfant
-                mineur.
-              </Typography>
-            }
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={draft.supervisionAcknowledgement === "yes"}
-                onChange={(e) =>
-                  onChange({
-                    supervisionAcknowledgement: e.target.checked
-                      ? "yes"
-                      : "not_applicable_adult",
-                  })
-                }
-              />
-            }
-            label={
-              <Typography variant="body2" component="span">
-                Je m’engage à ce que mon enfant soit pris en charge par le responsable à
-                l’heure des cours.
-              </Typography>
-            }
-          />
+          <Box data-field="emergencyMedicalAuthorization" tabIndex={-1}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={draft.emergencyMedicalAuthorization === "yes"}
+                  onChange={(e) =>
+                    onChange({
+                      emergencyMedicalAuthorization: e.target.checked
+                        ? "yes"
+                        : "not_applicable_adult",
+                    })
+                  }
+                />
+              }
+              label={
+                <Typography variant="body2" component="span">
+                  J’autorise les actes médicaux ou chirurgicaux en urgence pour mon enfant
+                  mineur.
+                </Typography>
+              }
+            />
+          </Box>
+          <Box data-field="supervisionAcknowledgement" tabIndex={-1}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={draft.supervisionAcknowledgement === "yes"}
+                  onChange={(e) =>
+                    onChange({
+                      supervisionAcknowledgement: e.target.checked
+                        ? "yes"
+                        : "not_applicable_adult",
+                    })
+                  }
+                />
+              }
+              label={
+                <Typography variant="body2" component="span">
+                  Je m’engage à ce que mon enfant soit pris en charge par le responsable à
+                  l’heure des cours.
+                </Typography>
+              }
+            />
+          </Box>
         </>
       ) : null}
 
       <FormControlLabel
+        data-field="internalRulesAccepted"
         control={
           <Checkbox
             checked={draft.rulesAccepted}
@@ -158,6 +165,7 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
           </Alert>
         ) : (
           <FormControlLabel
+            data-field="wantsCompetitorExtras"
             control={
               <Switch
                 checked={draft.wantsCompetitorExtras}
@@ -175,6 +183,7 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
               <Select
                 labelId="jersey-label"
                 label="Taille de maillot de compétition"
+                name="competitionJerseySize"
                 value={draft.competitionJerseySize ?? ""}
                 onChange={(e) =>
                   onChange({
@@ -193,7 +202,13 @@ export function LegalCompetitorStep({ draft, onChange }: Props) {
               </Select>
             </FormControl>
 
-            <Typography variant="subtitle2">Compétitions envisagées</Typography>
+            <Typography
+              variant="subtitle2"
+              data-field="competitionIds"
+              tabIndex={-1}
+            >
+              Compétitions envisagées
+            </Typography>
             <FormGroup>
               {COMPETITION_OPTIONS.map((c) => (
                 <FormControlLabel

--- a/src/components/club-registration/MedicalFamilyStep.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.tsx
@@ -107,6 +107,7 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
       <FormControl component="fieldset" required>
         <RadioGroup
           aria-labelledby="medical-certificate-label"
+          name="medicalCertificateDeclaration"
           value={declarationIsIncompatible ? "" : draft.medicalCertificateDeclaration}
           onChange={(e) =>
             onChange({
@@ -130,6 +131,7 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
         <Select
           labelId="cert-attestation-label"
           label="Attestation d’inscription"
+          name="wantsRegistrationCertificate"
           value={draft.wantsRegistrationCertificate ? "yes" : "no"}
           onChange={(e) =>
             onChange({ wantsRegistrationCertificate: e.target.value === "yes" })
@@ -146,6 +148,7 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
         </Typography>
         <RadioGroup
           aria-labelledby="family-order-label"
+          name="familyRegistrationOrder"
           value={draft.familyRegistrationOrder}
           onChange={(e) =>
             onChange({
@@ -165,7 +168,13 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
       </FormControl>
 
       <Stack spacing={0.5}>
-        <Typography variant="subtitle2">Réductions éventuelles</Typography>
+        <Typography
+          variant="subtitle2"
+          data-field="reductionTypes"
+          tabIndex={-1}
+        >
+          Réductions éventuelles
+        </Typography>
         <FormGroup>
           {REDUCTION_OPTIONS.map((r) => (
             <FormControlLabel
@@ -187,6 +196,7 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
         value={draft.passSportCode ?? ""}
         onChange={(e) => onChange({ passSportCode: e.target.value })}
         fullWidth
+        inputProps={{ "data-field": "passSportCode" }}
       />
 
       <Alert severity="info">

--- a/src/components/club-registration/SectionSlotsStep.tsx
+++ b/src/components/club-registration/SectionSlotsStep.tsx
@@ -78,6 +78,7 @@ export function SectionSlotsStep({ draft, onChange }: Props) {
         <Select
           labelId="main-section-label"
           label="Section principale"
+          name="mainSectionId"
           value={draft.mainSectionId}
           onChange={(e) => {
             const next = e.target.value as RegistrationDraft["mainSectionId"];
@@ -94,7 +95,13 @@ export function SectionSlotsStep({ draft, onChange }: Props) {
       </FormControl>
 
       <Stack spacing={0.5}>
-        <Typography variant="subtitle2">Autres sections</Typography>
+        <Typography
+          variant="subtitle2"
+          data-field="additionalSectionIds"
+          tabIndex={-1}
+        >
+          Autres sections
+        </Typography>
         <FormGroup>
           {SECTION_PRINCIPALE_OPTIONS.filter((s) => s.id !== draft.mainSectionId).map((s) => (
             <FormControlLabel
@@ -111,7 +118,9 @@ export function SectionSlotsStep({ draft, onChange }: Props) {
         </FormGroup>
       </Stack>
 
-      <Typography variant="subtitle2">Créneaux souhaités</Typography>
+      <Typography variant="subtitle2" data-field="slotIds" tabIndex={-1}>
+        Créneaux souhaités
+      </Typography>
       {CLUB_REGISTRATION_SITES.map((site) => (
         <Accordion
           key={site.id}


### PR DESCRIPTION
## Contexte

6ᵉ PR du chantier UX du formulaire d'inscription club, stackée sur **#283**. Améliore l'accessibilité (clavier / lecteurs d'écran) et étend le mécanisme de scroll-to-field (introduit en #283) aux étapes 2, 3 et 4.

## Changements

### Focus management au changement d'étape

- Titre \`<h2>\` invisible (\`@mui/utils.visuallyHidden\`) injecté dans la Card du wizard, libellé « Étape N sur 5 : … ». Il reçoit le focus à chaque changement d'étape — annoncé par les lecteurs d'écran et indispensable pour les utilisateurs clavier.
- À chaque changement d'étape : scroll smooth en haut de la Card pour que l'utilisateur ne se retrouve plus à mi-parcours de la nouvelle étape.
- Si une erreur serveur vient d'arriver et va focus un champ précis, l'effet de focus du titre se désactive pour ne pas voler le focus à un emplacement plus utile.

### Cohérence du scroll-to-field sur toutes les étapes

Propagation de \`name\` ou \`data-field\` sur les champs structurants des étapes 2/3/4, pour que le saut automatique vers la 1ʳᵉ étape en erreur (introduit en #283) puisse scroller / focus le champ même hors de l'étape 1 :

- **SectionSlotsStep** : \`mainSectionId\`, \`additionalSectionIds\`, \`slotIds\`.
- **MedicalFamilyStep** : \`medicalCertificateDeclaration\`, \`wantsRegistrationCertificate\`, \`familyRegistrationOrder\`, \`reductionTypes\`, \`passSportCode\`.
- **LegalCompetitorStep** : \`photoConsent\`, \`emergencyMedicalAuthorization\`, \`supervisionAcknowledgement\`, \`internalRulesAccepted\`, \`wantsCompetitorExtras\`, \`competitionJerseySize\`, \`competitionIds\`.

Pour les Checkbox / Switch MUI dont \`inputProps\` est typé strictement (\`InputHTMLAttributes<HTMLInputElement>\` n'accepte pas les data-*), on porte l'attribut sur un wrapper \`<Box data-field=...>\` — plus visible pour \`scrollIntoView\` et propre du point de vue TypeScript.

## Tests

- Nouveau test \`ClubRegistrationWizard.test.tsx\` : vérifie le rendu du titre \`<h2>\` invisible avec le bon libellé.
- **154 tests Jest verts** au total.
- \`npm run check\` (lint + type-check + build) ✅.

## Test plan

- [ ] Au chargement de \`/club/inscription\`, lecteur d'écran annonce « Étape 1 sur 5 : Identité… ».
- [ ] Clic sur « Continuer » : la page scrolle au haut de la Card, le focus est au début (Tab → 1ᵉʳ champ de la nouvelle étape).
- [ ] Soumettre un dossier où le téléphone principal est mal formé → saut à l'étape 1 + scroll/focus sur \`adherentPhonePrimary\` (déjà testé en #283).
- [ ] Forger côté DevTools une 400 \`fieldErrors: { medicalCertificateDeclaration: ["..."] }\` → saut à l'étape 3 et scroll sur le RadioGroup.
- [ ] Forger \`fieldErrors: { internalRulesAccepted: ["..."] }\` → saut à l'étape 4 et scroll sur le label « J'ai lu et j'accepte le règlement intérieur ».

## Stack

#281 → #282 → #283 → **#284**

Made with [Cursor](https://cursor.com)