### PR TITLE
feat(club-registration): polish UX (confirmation, lien médical, progression, scroll)

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -203,6 +203,12 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
   const cardRef = useRef<HTMLDivElement | null>(null);
   const stepHeadingRef = useRef<HTMLHeadingElement | null>(null);
   const prevActiveStepRef = useRef(0);
+  /* Mémorisation du scroll par étape : on enregistre la position au moment du
+     départ et on la restaure quand l'utilisateur revient en arrière sur cette
+     même étape. Cas typique : SectionSlotsStep est long, l'utilisateur clique
+     « Continuer » pendant qu'il était à mi-hauteur, puis revient en arrière —
+     on évite de le re-projeter en haut s'il avait déjà parcouru la liste. */
+  const scrollPositionsRef = useRef<Map<number, number>>(new Map());
 
   /* Hydratation au mount : local-first, fallback éventuel sur le draft serveur (lecture seule pour l'instant). */
   const storageLoad = storage.load;
@@ -227,6 +233,14 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
   const stepValidity = useMemo<(string | null)[]>(
     () => STEPS.map((_, idx) => validateStep(idx, draft)),
     [draft]
+  );
+
+  /* Nombre d'étapes 0..3 (toutes sauf le récap) sans erreur. Sert d'indicateur
+     de progression neutre — on évite un pourcentage flou qui dépendrait du
+     nombre de sous-champs validés. */
+  const completedStepsCount = useMemo(
+    () => stepValidity.slice(0, STEPS.length - 1).filter((v) => v === null).length,
+    [stepValidity]
   );
 
   /**
@@ -289,20 +303,39 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
   }, [fieldErrors, activeStep]);
 
   /**
-   * Gestion du focus au changement d'étape (accessibilité + fluidité au clavier) :
-   * - Remonte le scroll en haut de la Card pour que l'utilisateur ne se retrouve
-   *   pas au milieu de la nouvelle étape.
-   * - Donne le focus au titre invisible de l'étape (lu par les lecteurs d'écran).
+   * Gestion du focus / scroll au changement d'étape :
+   * - Sauvegarde la position de scroll de l'étape qu'on quitte (utilisée si
+   *   l'utilisateur y revient en arrière).
+   * - Si on revient sur une étape qui avait une position enregistrée, on
+   *   restaure ce scroll plutôt que de remonter en haut de la Card.
+   * - Sinon, scroll en haut de la Card (cas d'une étape jamais visitée ou
+   *   d'une avancée linéaire).
+   * - Donne le focus au titre invisible de l'étape (annoncé par les lecteurs
+   *   d'écran).
    *
-   * Si une erreur serveur vient d'arriver et va déclencher un focus ciblé sur le
-   * 1ᵉʳ champ en erreur, on laisse la main à l'autre effet pour ne pas voler le
-   * focus à un emplacement plus pertinent.
+   * Si une erreur serveur vient d'arriver et va déclencher un focus ciblé sur
+   * le 1ᵉʳ champ en erreur, on laisse la main à l'autre effet pour ne pas voler
+   * le focus à un emplacement plus pertinent.
    */
   useEffect(() => {
-    if (prevActiveStepRef.current === activeStep) return;
+    const previous = prevActiveStepRef.current;
+    if (previous === activeStep) return;
+
+    /* On enregistre la position de scroll vertical actuelle pour l'étape qu'on
+       quitte, AVANT de modifier le scroll. */
+    if (typeof window !== "undefined") {
+      scrollPositionsRef.current.set(previous, window.scrollY);
+    }
     prevActiveStepRef.current = activeStep;
 
-    cardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    const goingBackward = activeStep < previous;
+    const memorized = scrollPositionsRef.current.get(activeStep);
+
+    if (goingBackward && typeof memorized === "number") {
+      window.scrollTo({ top: memorized, behavior: "smooth" });
+    } else {
+      cardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
 
     const hasServerFieldErrors =
       fieldErrors !== null &&
@@ -508,6 +541,17 @@ export function ClubRegistrationWizard({ accountEmail }: Props) {
       <Typography variant="body1" color="text.secondary">
         Préparez votre dossier d’inscription en quelques étapes. Vous pourrez vous connecter
         ou créer un compte juste avant l’envoi.
+      </Typography>
+
+      <Typography
+        variant="caption"
+        component="p"
+        color="text.secondary"
+        aria-live="polite"
+      >
+        Progression&nbsp;: {completedStepsCount} étape
+        {completedStepsCount > 1 ? "s" : ""} sur {STEPS.length - 1} validée
+        {completedStepsCount > 1 ? "s" : ""}.
       </Typography>
 
       {submitError && <Alert severity="error">{submitError}</Alert>}

--- a/src/components/club-registration/DraftStorageDisclosure.test.tsx
+++ b/src/components/club-registration/DraftStorageDisclosure.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DraftStorageDisclosure } from "./DraftStorageDisclosure";
+
+function setup() {
+  const onClear = jest.fn();
+  const onDisable = jest.fn();
+  const onEnable = jest.fn();
+  render(
+    <DraftStorageDisclosure
+      status="saved"
+      isDisabled={false}
+      lastSavedAt={new Date()}
+      onDisable={onDisable}
+      onEnable={onEnable}
+      onClear={onClear}
+    />
+  );
+  return { onClear, onDisable, onEnable };
+}
+
+describe("DraftStorageDisclosure — confirmation de suppression", () => {
+  it("n'appelle pas onClear immédiatement quand on clique sur « Effacer mon brouillon »", () => {
+    const { onClear } = setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: /effacer mon brouillon/i })
+    );
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it("ouvre un Dialog de confirmation explicite", () => {
+    setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: /effacer mon brouillon/i })
+    );
+    expect(
+      screen.getByRole("dialog", { name: /effacer le brouillon/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/supprimées de ce navigateur/i, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("appelle onClear seulement si on confirme dans le Dialog", () => {
+    const { onClear } = setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: /effacer mon brouillon/i })
+    );
+    /* Le bouton de confirmation est le second bouton « Effacer le brouillon »
+       à l'intérieur du Dialog (titre id-é « confirm-clear-title »). */
+    const dialog = screen.getByRole("dialog");
+    const confirmBtn = Array.from(
+      dialog.querySelectorAll("button")
+    ).find((b) => /effacer le brouillon/i.test(b.textContent ?? ""));
+    expect(confirmBtn).toBeDefined();
+    fireEvent.click(confirmBtn!);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("annuler ferme le Dialog sans appeler onClear", () => {
+    const { onClear } = setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: /effacer mon brouillon/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /annuler/i }));
+    expect(onClear).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/club-registration/DraftStorageDisclosure.tsx
+++ b/src/components/club-registration/DraftStorageDisclosure.tsx
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import {
   Box,
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Link as MuiLink,
   Popover,
   Stack,
@@ -52,6 +57,10 @@ export function DraftStorageDisclosure({
 }: Props) {
   const [now, setNow] = useState<number>(() => Date.now());
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
+  /* Le bouton « Effacer mon brouillon » est destructif (toute la saisie en
+     cours disparaît) : on demande une confirmation explicite avant d'appeler
+     `onClear`. */
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false);
   const infoButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
@@ -128,7 +137,7 @@ export function DraftStorageDisclosure({
               component="button"
               type="button"
               variant="caption"
-              onClick={onClear}
+              onClick={() => setConfirmClearOpen(true)}
               underline="hover"
             >
               Effacer mon brouillon
@@ -180,6 +189,34 @@ export function DraftStorageDisclosure({
           </Box>
         </Stack>
       </Popover>
+
+      <Dialog
+        open={confirmClearOpen}
+        onClose={() => setConfirmClearOpen(false)}
+        aria-labelledby="confirm-clear-title"
+        aria-describedby="confirm-clear-description"
+      >
+        <DialogTitle id="confirm-clear-title">Effacer le brouillon ?</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="confirm-clear-description">
+            Toutes les informations saisies dans le formulaire vont être supprimées
+            de ce navigateur, sans possibilité de récupération. Confirmez-vous ?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmClearOpen(false)}>Annuler</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => {
+              setConfirmClearOpen(false);
+              onClear();
+            }}
+          >
+            Effacer le brouillon
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/club-registration/MedicalFamilyStep.test.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MedicalFamilyStep } from "./MedicalFamilyStep";
+import { createEmptyDraft, type RegistrationDraft } from "./registration-defaults";
+
+function renderStep(overrides: Partial<RegistrationDraft> = {}) {
+  const draft: RegistrationDraft = { ...createEmptyDraft(), ...overrides };
+  render(<MedicalFamilyStep draft={draft} onChange={jest.fn()} />);
+}
+
+describe("MedicalFamilyStep — questionnaire de santé conditionnel", () => {
+  it("propose le questionnaire MINEUR pour un adhérent mineur", () => {
+    const minorBirthDate = new Date();
+    minorBirthDate.setFullYear(minorBirthDate.getFullYear() - 10);
+    renderStep({ birthDate: minorBirthDate.toISOString().slice(0, 10) });
+
+    expect(
+      screen.getByRole("link", { name: /questionnaire de santé mineur/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /questionnaire de santé majeur/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("propose le questionnaire MAJEUR pour un adhérent adulte (< 40 ans)", () => {
+    /* Adulte clairement majeur mais sous 40 ans. */
+    renderStep({ birthDate: "2000-04-12" });
+
+    expect(
+      screen.getByRole("link", { name: /questionnaire de santé majeur/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /questionnaire de santé mineur/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("propose le questionnaire MAJEUR pour un adhérent de 40 ans et plus", () => {
+    renderStep({ birthDate: "1970-04-12" });
+
+    expect(
+      screen.getByRole("link", { name: /questionnaire de santé majeur/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/club-registration/MedicalFamilyStep.tsx
+++ b/src/components/club-registration/MedicalFamilyStep.tsx
@@ -19,7 +19,7 @@ import {
   CLUB_REGISTRATION_EXTERNAL_LINKS,
   REDUCTION_OPTIONS,
 } from "@/lib/club-registration/constants";
-import { isAtLeast40At } from "@/lib/club-registration/age";
+import { isAtLeast40At, isMinorAt } from "@/lib/club-registration/age";
 import type { RegistrationDraft } from "./registration-defaults";
 
 type MedicalOptionId = RegistrationDraft["medicalCertificateDeclaration"];
@@ -71,6 +71,7 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
   /* L'âge dérive de la date de naissance saisie à l'étape 1. Le wizard interdit déjà
      de passer à l'étape 3 sans `birthDate`. */
   const atLeast40 = isAtLeast40At(draft.birthDate);
+  const minor = isMinorAt(draft.birthDate);
   const medicalOptions = atLeast40
     ? MEDICAL_OPTIONS_AT_LEAST_40
     : MEDICAL_OPTIONS_UNDER_40;
@@ -79,22 +80,28 @@ export function MedicalFamilyStep({ draft, onChange }: Props) {
     Boolean(draft.medicalCertificateDeclaration) &&
     !allowedIds.has(draft.medicalCertificateDeclaration);
 
+  /* On présente uniquement le questionnaire pertinent au regard de l'âge de
+     l'adhérent : afficher les deux liens force l'utilisateur à choisir alors
+     qu'on a déjà l'information de l'âge (cf. étape 1). */
+  const questionnaireUrl = minor
+    ? CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMineur
+    : CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMajeur;
+  const questionnaireLabel = minor
+    ? "questionnaire de santé mineur"
+    : "questionnaire de santé majeur";
+
   return (
     <Stack spacing={2}>
       <Typography variant="subtitle1" id="medical-certificate-label">
         Certificat médical
       </Typography>
       <Typography variant="body2" color="text.secondary">
-        Téléchargez le questionnaire adapté si besoin :{" "}
-        <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMajeur} target="_blank" rel="noreferrer">
-          majeur
-        </a>
-        {" · "}
-        <a href={CLUB_REGISTRATION_EXTERNAL_LINKS.questionnaireMineur} target="_blank" rel="noreferrer">
-          mineur
-        </a>
-        . En cas de certificat à fournir, vous pourrez le transmettre au secrétariat selon les
-        modalités du club.
+        Téléchargez le{" "}
+        <a href={questionnaireUrl} target="_blank" rel="noreferrer">
+          {questionnaireLabel}
+        </a>{" "}
+        si besoin. En cas de certificat à fournir, vous pourrez le transmettre au
+        secrétariat selon les modalités du club.
       </Typography>
 
       {declarationIsIncompatible ? (


### PR DESCRIPTION
## Contexte

7ᵉ PR du chantier UX du formulaire d'inscription club, stackée sur **#284**. Regroupe quatre raffinements UX sans nouvelle dépendance — préparation au futur \`DatePicker\` (PR8 à venir).

## Changements

### A. Confirmation avant « Effacer mon brouillon »

- \`DraftStorageDisclosure\` : le lien « Effacer mon brouillon » ouvre désormais un Dialog MUI demandant une confirmation explicite avant d'appeler \`onClear\`.
- Empêche une perte accidentelle de toute la saisie en cours (irréversible).
- 4 tests RTL.

### B. Lien médical conditionnel selon âge

- \`MedicalFamilyStep\` n'affiche plus les deux questionnaires de santé côte à côte. On présente uniquement celui qui correspond à la date de naissance saisie à l'étape 1.
- Texte d'introduction simplifié, libellé du lien plus explicite (« questionnaire de santé mineur / majeur »).
- 3 tests RTL (mineur 10 ans, adulte 26 ans, adulte 56 ans).

### C. Indicateur de progression

- Petit libellé sous l'intro du wizard : « **Progression : N étapes sur 4 validées.** ». Calculé à partir de \`stepValidity\` (déjà mémoïsé). On compte uniquement les 4 étapes de saisie ; le récap n'est pas une étape au même titre.
- \`aria-live=\"polite\"\` pour que les lecteurs d'écran annoncent les changements.

### D. Mémorisation du scroll par étape (retour arrière)

- Au changement d'étape, on enregistre \`window.scrollY\` de l'étape qu'on quitte dans une Map.
- Si l'utilisateur revient en arrière sur une étape déjà visitée, on restaure cette position au lieu de remonter en haut.
- Cas d'usage : \`SectionSlotsStep\` est long, l'utilisateur clique « Continuer » en bas puis revient — il retrouve sa position au lieu de re-parcourir toute la liste.
- Pour une étape jamais visitée ou une avancée linéaire, on garde le scroll au top.

## Tests

- **+7 tests** (4 DraftStorageDisclosure + 3 MedicalFamilyStep).
- **Total : 161 tests verts.**
- \`npm run check\` (lint + type-check + build) ✅.

## Test plan

- [ ] Cliquer « Effacer mon brouillon » → Dialog apparaît, rien n'est effacé.
- [ ] « Annuler » dans le Dialog → ferme sans effacer, formulaire intact.
- [ ] « Effacer le brouillon » dans le Dialog → tous les champs sont réinitialisés.
- [ ] Saisir une date de naissance < 18 ans à l'étape 1 → étape 3 affiche le lien « questionnaire de santé mineur » uniquement.
- [ ] Saisir une date de naissance ≥ 18 ans → étape 3 affiche « questionnaire de santé majeur ».
- [ ] Au chargement, indicateur indique « Progression : 0 étape sur 4 validée ».
- [ ] Remplir entièrement l'étape 1 et passer à l'étape 2 → indicateur passe à « 1 étape sur 4 validée ».
- [ ] Aller à l'étape 2, scroller en bas, cliquer Continuer, revenir à l'étape 2 → la position de scroll est restaurée.

## Stack

#281 → #282 → #283 → #284 → **#285**

Made with [Cursor](https://cursor.com)