### PR TITLE
🛡️ Sentinel: Harden Discord members API with RBAC

### DIFF
--- a/src/app/api/discord/members/route.ts
+++ b/src/app/api/discord/members/route.ts
@@ -20,7 +20,17 @@ export async function GET() {
       );
     }
 
-    await adminAuth.verifySessionCookie(sessionCookie, true);
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+
+    // Vérifier l'autorisation (seuls les admins et coachs peuvent voir les membres Discord)
+    const { resolveRole, hasAnyRole, USER_ROLES } = await import("@/lib/auth/roles");
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return jsonNoStore(
+        { success: false, error: "Accès refusé" },
+        { status: 403 }
+      );
+    }
 
     if (!DISCORD_TOKEN || !DISCORD_SERVER_ID) {
       return jsonNoStore(


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Broken Access Control in Discord Members API

🚨 Severity: HIGH
💡 Vulnerability: Missing Role-Based Access Control (RBAC) on the `/api/discord/members` endpoint.
🎯 Impact: Any authenticated user (including regular players) could retrieve a list of all Discord members in the server, including their Discord IDs and display names, potentially leading to information disclosure or enabling social engineering attacks.
🔧 Fix: Added a check for `ADMIN` or `COACH` roles using the `role` claim from the session cookie.
✅ Verification: Ran `npm run check:dev` and `npm test` to ensure no regressions. Verified that the route now explicitly checks for authorized roles before proceeding with the Discord API request.

---
*PR created automatically by Jules for task [13505407619102105668](https://jules.google.com/task/13505407619102105668) started by @omichalo*