### PR TITLE
🛡️ Sentinel: [HIGH] Harden Discord member access and fix email enumeration

### DIFF
--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -109,10 +109,9 @@ export async function POST(req: Request) {
         errorMessage.includes("USER_NOT_FOUND") ||
         errorMessage.includes("no user record")
       ) {
-        return jsonNoStore(
-          { error: "Utilisateur non trouvé", message: "Aucun compte n'est associé à cet email" },
-          { status: 404 }
-        );
+        // Ne pas révéler si l'utilisateur existe ou non (sécurité)
+        // Retourner toujours 200 pour éviter l'énumération d'emails
+        return jsonNoStore({ ok: true });
       }
       
       if (
@@ -192,7 +191,8 @@ export async function POST(req: Request) {
     // Déterminer le code HTTP approprié
     let statusCode = 500;
     if (errorString.includes("user-not-found") || errorString.includes("USER_NOT_FOUND")) {
-      statusCode = 404;
+      // Ne pas révéler si l'utilisateur existe ou non (sécurité)
+      return jsonNoStore({ ok: true });
     } else if (errorString.includes("invalid-email") || errorString.includes("INVALID_EMAIL")) {
       statusCode = 400;
     } else if (errorString.includes("too-many-requests") || errorString.includes("TOO_MANY_REQUESTS")) {

--- a/src/app/api/discord/members/route.ts
+++ b/src/app/api/discord/members/route.ts
@@ -1,27 +1,14 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { adminAuth } from "@/lib/firebase-admin";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 const DISCORD_SERVER_ID = process.env.DISCORD_SERVER_ID;
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    // Vérifier l'authentification
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Non authentifié" },
-        { status: 401 }
-      );
-    }
-
-    await adminAuth.verifySessionCookie(sessionCookie, true);
-
     if (!DISCORD_TOKEN || !DISCORD_SERVER_ID) {
       return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
@@ -112,5 +99,5 @@ export async function GET() {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);
 


### PR DESCRIPTION
This PR addresses two security issues:

1. **Broken Access Control**: The `/api/discord/members` route was accessible to any authenticated user (including the PLAYER role). It now requires the ADMIN or COACH role and a verified email via the `withAuth` HOC.
2. **Information Disclosure (Email Enumeration)**: The `/api/auth/send-verification` route returned a 404 error when an email was not found in Firebase Auth. It now returns a generic `{ ok: true }` with a 200 status to prevent identifying registered accounts.

Verified with `npm run lint` and `npm test`.

---
*PR created automatically by Jules for task [12751089006887370563](https://jules.google.com/task/12751089006887370563) started by @omichalo*