### PR TITLE
🛡️ Sentinel: [HIGH] Harden Discord members API with RBAC

### DIFF
--- a/src/app/api/discord/members/route.ts
+++ b/src/app/api/discord/members/route.ts
@@ -1,27 +1,14 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { adminAuth } from "@/lib/firebase-admin";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 const DISCORD_SERVER_ID = process.env.DISCORD_SERVER_ID;
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    // Vérifier l'authentification
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Non authentifié" },
-        { status: 401 }
-      );
-    }
-
-    await adminAuth.verifySessionCookie(sessionCookie, true);
-
     if (!DISCORD_TOKEN || !DISCORD_SERVER_ID) {
       return jsonNoStore(
         { success: false, error: "Configuration Discord manquante" },
@@ -106,11 +93,11 @@ export async function GET() {
 
     return jsonNoStore({ success: true, members });
   } catch (error) {
-    console.error("[Discord] Erreur:", error);
+    console.error("[Discord Members] Erreur:", error);
     return jsonNoStore(
       { success: false, error: "Erreur lors de la récupération des membres" },
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/discord/members` route lacked role-based access control (RBAC) and email verification, exposing Discord member PII (IDs, usernames, display names) to all authenticated users.
🎯 **Impact:** Any authenticated user could potentially scrape or access the list of Discord members and their identifiers.
🔧 **Fix:** Implemented the standardized `withAuth` higher-order function to enforce that only users with `ADMIN` or `COACH` roles and verified emails can access this endpoint.
✅ **Verification:** 
- Ran `npm run check:dev` (linting and type-checking) - PASSED.
- Ran `npm test` - PASSED.
- Verified code logic ensures RBAC enforcement.

---
*PR created automatically by Jules for task [1889258526585206790](https://jules.google.com/task/1889258526585206790) started by @omichalo*