### PR TITLE
🛡️ Sentinel: [HIGH] Standardize admin API security and fix email verification bypass

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,32 +1,14 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
 import type { DocumentData, QueryDocumentSnapshot, Query } from "firebase-admin/firestore";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
+import { USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
 import type { User } from "@/types";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        { success: false, error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
     const firestore = getFirestoreAdmin();
 
     // Récupérer tous les utilisateurs avec pagination
@@ -168,11 +150,9 @@ export async function GET() {
     return jsonNoStore(
       {
         success: false,
-        error: "Impossible de récupérer la liste des utilisateurs",
+        error: "Failed to fetch users list",
       },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN]);

--- a/src/lib/auth/api-utils.ts
+++ b/src/lib/auth/api-utils.ts
@@ -8,14 +8,14 @@ export const withAuth = (handler: (req: Request, context: unknown) => Promise<Ne
   async (req: Request, context: unknown) => {
     try {
       const session = (await cookies()).get("__session")?.value;
-      if (!session) return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+      if (!session) return jsonNoStore({ success: false, error: "Authentication required" }, { status: 401 });
       const decoded = await adminAuth.verifySessionCookie(session, true);
-      if (!decoded.email_verified) return jsonNoStore({ error: "Email non vérifié" }, { status: 403 });
+      if (!decoded.email_verified) return jsonNoStore({ success: false, error: "Email not verified" }, { status: 403 });
       const role = resolveRole(decoded.role as string);
-      if (allowedRoles && !hasAnyRole(role, allowedRoles)) return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+      if (allowedRoles && !hasAnyRole(role, allowedRoles)) return jsonNoStore({ success: false, error: "Access denied" }, { status: 403 });
       const res = await handler(req, { ... (context as object), decoded, role });
       return applyNoStoreHeaders(res);
     } catch {
-      return jsonNoStore({ error: "Session invalide" }, { status: 401 });
+      return jsonNoStore({ success: false, error: "Invalid session" }, { status: 401 });
     }
   };


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/admin/users` route was missing the critical `email_verified` check and using manual session verification.
🎯 Impact: Users with unverified emails but possessing the `admin` role could potentially access the full list of users, including PII.
🔧 Fix: Refactored the route to use the standardized `withAuth` HOC, which enforces `email_verified` and RBAC. Also standardized error messages in `withAuth` to English and a consistent JSON format.
✅ Verification: Verified via `npm test` and `npm run check:dev`.

---
*PR created automatically by Jules for task [10044909773355487665](https://jules.google.com/task/10044909773355487665) started by @omichalo*