### PR TITLE
fix(compositions): brûlage masculin aligné sur la feuille FFTT

### DIFF
--- a/src/components/compositions/CompositionsTable.tsx
+++ b/src/components/compositions/CompositionsTable.tsx
@@ -40,19 +40,7 @@ function formatDate(dateStr: string): string {
   return dateStr;
 }
 
-type PlayerKey = string;
-
-function isMissingPlayer(j: { nom: string; prenom: string }): boolean {
-  const nomTrim = (j.nom ?? "").trim();
-  const prenomTrim = (j.prenom ?? "").trim();
-  return nomTrim === "" && prenomTrim === "";
-}
-
-function playerKey(j: { nom: string; prenom: string; licence?: string }): PlayerKey {
-  const licence = (j.licence ?? "").trim();
-  if (licence) return licence;
-  return `${(j.nom ?? "").trim()}|${(j.prenom ?? "").trim()}`;
-}
+import { buildPlayersByMatchIndex } from "./compositions-table-utils";
 
 function formatPlayerLabel(j: {
   nom: string;
@@ -71,62 +59,16 @@ function formatPlayerLabel(j: {
   return `${namePart}${pts}`;
 }
 
-function findPlayerPositionInMatch(
-  key: PlayerKey,
-  composition: MatchCompositionRow["composition"]
-): number {
-  return composition.findIndex((j) => playerKey(j) === key);
-}
-
 export interface CompositionsTableProps {
   matches: MatchCompositionRow[];
 }
 
 /** Tableau joueurs × journées : une ligne par joueur, une colonne par match. */
 export function CompositionsTable({ matches }: CompositionsTableProps) {
-  const { allPlayers, cellByPlayerAndMatch } = React.useMemo(() => {
-    const keyToPlayer = new Map<
-      PlayerKey,
-      { nom: string; prenom: string; points: number | null; licence?: string }
-    >();
-    for (const m of matches) {
-      for (const j of m.composition) {
-        if (isMissingPlayer(j)) continue;
-        const k = playerKey(j);
-        if (!keyToPlayer.has(k)) {
-          keyToPlayer.set(k, {
-            nom: j.nom,
-            prenom: j.prenom,
-            points: j.points ?? null,
-            ...(j.licence ? { licence: j.licence } : {}),
-          });
-        }
-      }
-    }
-    const allPlayers = Array.from(keyToPlayer.entries()).map(([key, p]) => ({ key, ...p }));
-    const cellByPlayerAndMatch = new Map<
-      string,
-      { position: number; victoires: number; defaites: number }
-    >();
-    for (const { key } of allPlayers) {
-      for (let matchIdx = 0; matchIdx < matches.length; matchIdx++) {
-        const compo = matches[matchIdx].composition;
-        const pos = findPlayerPositionInMatch(key, compo);
-        const cellKey = `${key}|${matchIdx}`;
-        if (pos >= 0) {
-          const j = compo[pos];
-          const victoires = typeof j.victoires === "number" ? j.victoires : 0;
-          const defaites = typeof j.defaites === "number" ? j.defaites : 0;
-          cellByPlayerAndMatch.set(cellKey, {
-            position: pos + 1,
-            victoires,
-            defaites,
-          });
-        }
-      }
-    }
-    return { allPlayers, cellByPlayerAndMatch };
-  }, [matches]);
+  const { allPlayers, cellByPlayerAndMatch } = React.useMemo(
+    () => buildPlayersByMatchIndex(matches),
+    [matches]
+  );
 
   if (allPlayers.length === 0) {
     return (
@@ -161,12 +103,15 @@ export function CompositionsTable({ matches }: CompositionsTableProps) {
                     <br />
                     {formatDate(m.date)}
                     {m.score != null ? ` — ${m.score}` : ""}
+                    {m.journee && m.journee > 0 && m.journee !== idx + 1
+                      ? ` (journée FFTT ${m.journee})`
+                      : ""}
                   </Box>
                 }
                 placement="top"
               >
                 <span style={{ cursor: "help", textDecoration: "underline dotted" }}>
-                  J{m.journee ?? idx + 1}
+                  J{idx + 1}
                 </span>
               </Tooltip>
             </TableCell>
@@ -178,9 +123,9 @@ export function CompositionsTable({ matches }: CompositionsTableProps) {
           <TableRow key={key} hover sx={{ "&:nth-of-type(even)": { bgcolor: "grey.50" } }}>
             <TableCell sx={{ fontWeight: 500 }}>
               {formatPlayerLabel({
-                nom,
-                prenom,
-                points,
+                nom: nom ?? "",
+                prenom: prenom ?? "",
+                ...(points !== undefined ? { points } : {}),
                 ...(licence ? { licence } : {}),
               })}
             </TableCell>

--- a/src/components/compositions/compositions-table-utils.ts
+++ b/src/components/compositions/compositions-table-utils.ts
@@ -1,0 +1,67 @@
+import {
+  buildCanonicalCompositionPlayerKeys,
+  mergeCompositionPlayerRecords,
+  type CompositionTablePlayer,
+} from "@/lib/shared/match-composition-utils";
+import { hasUsablePlayerName } from "@/lib/shared/team-matches-roster-utils";
+import type { MatchCompositionRow } from "./CompositionsTable";
+
+export function isMissingCompositionPlayer(j: { nom: string; prenom: string }): boolean {
+  return !hasUsablePlayerName(j);
+}
+
+export function buildPlayersByMatchIndex(matches: MatchCompositionRow[]): {
+  allPlayers: Array<CompositionTablePlayer & { key: string }>;
+  cellByPlayerAndMatch: Map<string, { position: number; victoires: number; defaites: number }>;
+} {
+  const allEntries: CompositionTablePlayer[] = [];
+  for (const m of matches) {
+    for (const j of m.composition) {
+      if (isMissingCompositionPlayer(j)) continue;
+      allEntries.push(j);
+    }
+  }
+
+  const { canonicalKey } = buildCanonicalCompositionPlayerKeys(allEntries);
+  const keyToPlayer = new Map<string, CompositionTablePlayer>();
+
+  for (const entry of allEntries) {
+    const key = canonicalKey(entry);
+    if (!key) continue;
+    const existing = keyToPlayer.get(key);
+    keyToPlayer.set(
+      key,
+      existing ? mergeCompositionPlayerRecords(existing, entry) : { ...entry }
+    );
+  }
+
+  const allPlayers = Array.from(keyToPlayer.entries()).map(([key, player]) => ({
+    key,
+    ...player,
+  }));
+
+  const cellByPlayerAndMatch = new Map<
+    string,
+    { position: number; victoires: number; defaites: number }
+  >();
+
+  for (const { key } of allPlayers) {
+    for (let matchIdx = 0; matchIdx < matches.length; matchIdx++) {
+      const compo = matches[matchIdx].composition;
+      const pos = compo.findIndex((j) => {
+        if (isMissingCompositionPlayer(j)) return false;
+        return canonicalKey(j) === key;
+      });
+      if (pos < 0) continue;
+
+      const j = compo[pos];
+      cellByPlayerAndMatch.set(`${key}|${matchIdx}`, {
+        position: pos + 1,
+        victoires: typeof j.victoires === "number" ? j.victoires : 0,
+        defaites: typeof j.defaites === "number" ? j.defaites : 0,
+      });
+    }
+  }
+
+  return { allPlayers, cellByPlayerAndMatch };
+}

--- a/src/components/equipes/EquipeAccordion.tsx
+++ b/src/components/equipes/EquipeAccordion.tsx
@@ -21,6 +21,12 @@ import {
   type MatchCompositionRow,
 } from "@/components/compositions/CompositionsTable";
 import {
+  compareMatchesByJourneeThenDate,
+  compositionPlayerKey,
+  getSQYCompositionPlayers,
+  isPlayedTeamMatch,
+} from "@/lib/shared/match-composition-utils";
+import {
   computeVictoiresDefaitesFromParties,
   playerNameMatches,
 } from "@/lib/shared/victoires-defaites";
@@ -77,39 +83,6 @@ type CompositionPlayer = {
   points?: number | null;
 };
 
-function hasNamedPlayers(players: CompositionPlayer[]): boolean {
-  return players.some(
-    (p) => ((p.nom ?? "").trim().length > 0 || (p.prenom ?? "").trim().length > 0)
-  );
-}
-
-function getSQYCompositionPlayers(match: Match): CompositionPlayer[] {
-  const joueursSQY = (match.joueursSQY ?? []) as CompositionPlayer[];
-  if (joueursSQY.length > 0 && hasNamedPlayers(joueursSQY)) {
-    return joueursSQY;
-  }
-
-  const resultats = match.resultatsIndividuels;
-  if (!resultats) return [];
-
-  const joueursA = Object.values(resultats.joueursA ?? {});
-  const joueursB = Object.values(resultats.joueursB ?? {});
-  if (joueursA.length === 0 && joueursB.length === 0) {
-    return [];
-  }
-
-  const nomEquipeA = (resultats.nomEquipeA ?? "").toUpperCase();
-  const nomEquipeB = (resultats.nomEquipeB ?? "").toUpperCase();
-  const sqyInA = nomEquipeA.includes("SQY PING");
-  const sqyInB = nomEquipeB.includes("SQY PING");
-
-  if (sqyInA && !sqyInB) return joueursA;
-  if (sqyInB && !sqyInA) return joueursB;
-
-  // Fallback défensif si les noms d'équipe sont absents/incohérents.
-  return ourSideIsA(match) ? joueursA : joueursB;
-}
-
 /**
  * Calcule victoires/défaites par joueur pour un match (simples uniquement, logique partagée avec l'API).
  */
@@ -133,7 +106,7 @@ function computeVictoiresDefaitesForMatch(
       playerNameMatches(playerName, j.nom ?? "", j.prenom ?? "")
     );
     if (!joueur) return null;
-    return (joueur.licence ?? "").trim() || `${(joueur.nom ?? "").trim()}|${(joueur.prenom ?? "").trim()}`;
+    return compositionPlayerKey(joueur);
   };
   return computeVictoiresDefaitesFromParties(
     partieLike,
@@ -164,9 +137,10 @@ export function EquipeAccordion({
         : equipeWithMatches.matches;
 
   const matchesForTable: MatchCompositionRow[] = React.useMemo(() => {
-    const sorted = [...displayMatches].sort(
-      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    const playedMatches = displayMatches.filter(
+      (m) => isPlayedTeamMatch(m) && getSQYCompositionPlayers(m).length > 0
     );
+    const sorted = [...playedMatches].sort(compareMatchesByJourneeThenDate);
     return sorted.map((m) => {
       const compositionPlayers = getSQYCompositionPlayers(m);
       const vdByPlayer = computeVictoiresDefaitesForMatch(m, compositionPlayers);
@@ -179,9 +153,7 @@ export function EquipeAccordion({
         otherTeamName: m.opponent || "Adversaire",
         ...(m.score ? { score: m.score } : {}),
         composition: compositionPlayers.map((j) => {
-          const key =
-            (j.licence ?? "").trim() ||
-            `${(j.nom ?? "").trim()}|${(j.prenom ?? "").trim()}`;
+          const key = compositionPlayerKey(j);
           const vd = vdByPlayer.get(key) ?? { victoires: 0, defaites: 0 };
           return {
             nom: j.nom ?? "",

--- a/src/lib/client/team-match-transform.ts
+++ b/src/lib/client/team-match-transform.ts
@@ -115,7 +115,10 @@ export const transformAggregatedTeamEntry = (
       isExempt: Boolean(match.isExempt),
       isForfeit: Boolean(match.isForfeit),
       phase: (match.phase as string) || "aller",
-      journee: (match.journee as number) || 0,
+      journee:
+        typeof match.journee === "number" && match.journee > 0
+          ? match.journee
+          : 0,
       createdAt: toDate(match.createdAt),
       updatedAt: toDate(match.updatedAt),
     };

--- a/src/lib/shared/match-composition-utils.test.ts
+++ b/src/lib/shared/match-composition-utils.test.ts
@@ -1,0 +1,111 @@
+import type { Match } from "@/types";
+import type { MatchData } from "./team-matches-sync-types";
+import {
+  buildCanonicalCompositionPlayerKeys,
+  compareMatchesByJourneeThenDate,
+  getSQYCompositionPlayers,
+  isPlayedTeamMatch,
+  listLicensedSqyPlayersInMatch,
+} from "./match-composition-utils";
+
+describe("getSQYCompositionPlayers", () => {
+  it("utilise la feuille FFTT et ignore les entrées joueursSQY fantômes", () => {
+    const match = {
+      resultatsIndividuels: {
+        nomEquipeA: "SQY PING 5",
+        nomEquipeB: "ADV",
+        joueursA: {
+          a: { nom: "BARGET", prenom: "Yannis" },
+          b: { nom: "FERREIRA", prenom: "Joao Marques" },
+          c: { nom: "FOUCHE", prenom: "Erwann" },
+        },
+        joueursB: {},
+        parties: [],
+      },
+      joueursSQY: [
+        { licence: "7891628", nom: "FERREIRA", prenom: "Joao Marques" },
+        { licence: "7885728", nom: "BARGET", prenom: "Yannis" },
+        { licence: "7886612", nom: "FOUCHE", prenom: "Erwann" },
+        { licence: "217409", nom: "", prenom: "" },
+      ],
+    } as unknown as Match;
+
+    const players = getSQYCompositionPlayers(match);
+    expect(players).toHaveLength(3);
+    expect(players.map((p) => p.nom)).toEqual(
+      expect.arrayContaining(["BARGET", "FERREIRA", "FOUCHE"])
+    );
+  });
+
+  it("reconstruit depuis les parties individuelles si la feuille est absente", () => {
+    const match = {
+      isHome: false,
+      resultatsIndividuels: {
+        nomEquipeA: "ADV",
+        nomEquipeB: "SQY PING 5",
+        joueursA: {},
+        joueursB: {},
+        parties: [
+          { joueurA: "ADV Player", joueurB: "Baptiste GOSSA", scoreA: 0, scoreB: 3 },
+          { joueurA: "Other ADV", joueurB: "Yannis BARGET", scoreA: 1, scoreB: 3 },
+        ],
+      },
+      joueursSQY: [],
+    } as unknown as Match;
+
+    const players = getSQYCompositionPlayers(match);
+    expect(players).toHaveLength(2);
+    expect(players.map((p) => p.nom)).toEqual(
+      expect.arrayContaining(["GOSSA", "BARGET"])
+    );
+  });
+});
+
+describe("isPlayedTeamMatch", () => {
+  it("exclut les matchs 0-0", () => {
+    expect(isPlayedTeamMatch({ score: "0-0" } as Match)).toBe(false);
+    expect(isPlayedTeamMatch({ score: "11-27" } as Match)).toBe(true);
+  });
+});
+
+describe("listLicensedSqyPlayersInMatch", () => {
+  it("compte un joueur issu des parties avec licence rattachee par nom", () => {
+    const match = {
+      isHome: false,
+      resultatsIndividuels: {
+        nomEquipeA: "ADV",
+        nomEquipeB: "SQY PING 3",
+        joueursA: {},
+        joueursB: {},
+        parties: [
+          { joueurA: "ADV", joueurB: "Thibaud LEROY", scoreA: 0, scoreB: 3 },
+        ],
+      },
+      joueursSQY: [{ licence: "111", nom: "LEROY", prenom: "Thibaud", points: 1990 }],
+    } as unknown as MatchData;
+
+    const players = listLicensedSqyPlayersInMatch(match);
+    expect(players).toHaveLength(1);
+    expect(players[0]?.licence).toBe("111");
+  });
+});
+
+describe("buildCanonicalCompositionPlayerKeys", () => {
+  it("fusionne licence et nom pour le même joueur", () => {
+    const players = [
+      { nom: "LEROY", prenom: "Thibaud" },
+      { nom: "LEROY", prenom: "Thibaud", licence: "123456", points: 1990 },
+    ];
+    const { canonicalKey } = buildCanonicalCompositionPlayerKeys(players);
+    expect(canonicalKey(players[0])).toBe("123456");
+    expect(canonicalKey(players[1])).toBe("123456");
+  });
+});
+
+describe("compareMatchesByJourneeThenDate", () => {
+  it("trie par numéro de journée", () => {
+    const m1 = { journee: 2, date: new Date("2026-03-01") } as Match;
+    const m2 = { journee: 1, date: new Date("2026-04-01") } as Match;
+    expect(compareMatchesByJourneeThenDate(m1, m2)).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/shared/match-composition-utils.ts
+++ b/src/lib/shared/match-composition-utils.ts
@@ -1,0 +1,205 @@
+import type { Match } from "@/types";
+import type { MatchData } from "./team-matches-sync-types";
+import {
+  buildSqyRosterFromMatch,
+  hasUsablePlayerName,
+  isLicenceListedInMatchRoster,
+  playerNameKey,
+} from "./team-matches-roster-utils";
+
+export type CompositionPlayer = {
+  licence?: string;
+  nom?: string;
+  prenom?: string;
+  points?: number | null;
+};
+
+function normalizeLicence(licence: unknown): string {
+  if (licence === undefined || licence === null) return "";
+  return String(licence).trim();
+}
+
+function hasNamedPlayers(players: CompositionPlayer[]): boolean {
+  return players.some((p) => hasUsablePlayerName(p));
+}
+
+/** Même logique que l'affichage « Joueurs par journée », pour les données sync (MatchData). */
+export function getSQYCompositionPlayersFromMatchData(
+  match: MatchData
+): CompositionPlayer[] {
+  return getSQYCompositionPlayers(match as unknown as Match);
+}
+
+/**
+ * Joueurs SQY à compter pour le brûlage / participation : composition fiable + licence.
+ * Aligné sur le tableau joueurs × journées (feuille FFTT, parties, fusion nom/licence).
+ */
+export function listLicensedSqyPlayersInMatch(match: MatchData): CompositionPlayer[] {
+  return getSQYCompositionPlayersFromMatchData(match).filter((player) => {
+    const licence = normalizeLicence(player.licence);
+    if (!licence || !hasUsablePlayerName(player)) {
+      return false;
+    }
+    return isLicenceListedInMatchRoster(match, { ...player, licence });
+  });
+}
+
+/** Composition SQY fiable : feuille FFTT + licences depuis joueursSQY. */
+export function getSQYCompositionPlayers(match: Match): CompositionPlayer[] {
+  const joueursSQY = (match.joueursSQY ?? []) as CompositionPlayer[];
+  const roster = buildSqyRosterFromMatch(match as Parameters<typeof buildSqyRosterFromMatch>[0]);
+
+  if (roster.length > 0) {
+    const licenceByName = new Map<string, CompositionPlayer>();
+    for (const j of joueursSQY) {
+      if (!hasUsablePlayerName(j)) continue;
+      licenceByName.set(playerNameKey(j), j);
+    }
+
+    return roster.map((player) => {
+      const existing = licenceByName.get(playerNameKey(player));
+      return {
+        nom: player.nom || existing?.nom || "",
+        prenom: player.prenom || existing?.prenom || "",
+        points: existing?.points ?? null,
+        licence: normalizeLicence(existing?.licence),
+      };
+    });
+  }
+
+  if (joueursSQY.length > 0 && hasNamedPlayers(joueursSQY)) {
+    return joueursSQY
+      .filter((p) => hasUsablePlayerName(p))
+      .map((p) => ({
+        ...p,
+        licence: normalizeLicence(p.licence),
+      }));
+  }
+
+  return buildSqyPlayersFromParties(match);
+}
+
+/** Dernier recours : extraire les joueurs SQY depuis les parties individuelles (simples). */
+function buildSqyPlayersFromParties(match: Match): CompositionPlayer[] {
+  const details = match.resultatsIndividuels;
+  const parties = details?.parties;
+  if (!parties || parties.length === 0) return [];
+
+  const nomEquipeA = (details.nomEquipeA ?? "").toUpperCase();
+  const nomEquipeB = (details.nomEquipeB ?? "").toUpperCase();
+  const sqyInA = nomEquipeA.includes("SQY PING");
+  const sqyInB = nomEquipeB.includes("SQY PING");
+  const sideAIsSqy =
+    sqyInA && !sqyInB ? true : sqyInB && !sqyInA ? false : Boolean(match.isHome);
+
+  const seen = new Set<string>();
+  const players: CompositionPlayer[] = [];
+
+  for (const partie of parties) {
+    const rawName = (sideAIsSqy ? partie.joueurA : partie.joueurB) ?? "";
+    const name = rawName.trim();
+    if (!name || name.includes(" / ")) continue;
+    const key = name.toUpperCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const tokens = name.split(/\s+/).filter(Boolean);
+    const nom = tokens.length > 0 ? (tokens[tokens.length - 1] ?? "") : "";
+    const prenom = tokens.length > 1 ? tokens.slice(0, -1).join(" ") : "";
+    const parsed: CompositionPlayer = { nom, prenom, points: null };
+
+    const joueursSQY = (match.joueursSQY ?? []) as CompositionPlayer[];
+    const fromSqy = joueursSQY.find(
+      (j) => hasUsablePlayerName(j) && playerNameKey(j) === playerNameKey(parsed)
+    );
+    if (fromSqy) {
+      parsed.licence = normalizeLicence(fromSqy.licence);
+      parsed.points = typeof fromSqy.points === "number" ? fromSqy.points : null;
+    }
+
+    players.push(parsed);
+  }
+
+  return players;
+}
+
+/** Match compté comme joué (score renseigné et au moins un point). */
+export function isPlayedTeamMatch(match: Match): boolean {
+  if (!match.score) return false;
+  const parts = match.score.split("-");
+  if (parts.length !== 2) return false;
+  const a = parseInt(parts[0], 10);
+  const b = parseInt(parts[1], 10);
+  if (Number.isNaN(a) || Number.isNaN(b)) return false;
+  return a > 0 || b > 0;
+}
+
+export function compareMatchesByJourneeThenDate(a: Match, b: Match): number {
+  const ja = a.journee ?? 0;
+  const jb = b.journee ?? 0;
+  if (ja !== jb) return ja - jb;
+  return new Date(a.date).getTime() - new Date(b.date).getTime();
+}
+
+export function compositionPlayerKey(player: CompositionPlayer): string {
+  const licence = normalizeLicence(player.licence);
+  if (licence) return licence;
+  return playerNameKey(player);
+}
+
+export type CompositionTablePlayer = CompositionPlayer & {
+  victoires?: number;
+  defaites?: number;
+};
+
+/**
+ * Fusionne les entrées sans licence avec la licence connue pour le même nom (J1 parties vs J2+ feuille).
+ */
+export function buildCanonicalCompositionPlayerKeys(
+  players: CompositionTablePlayer[]
+): {
+  canonicalKey: (player: CompositionTablePlayer) => string;
+} {
+  const nameToLicence = new Map<string, string>();
+
+  for (const player of players) {
+    if (!hasUsablePlayerName(player)) continue;
+    const licence = normalizeLicence(player.licence);
+    if (licence) {
+      nameToLicence.set(playerNameKey(player), licence);
+    }
+  }
+
+  const canonicalKey = (player: CompositionTablePlayer): string => {
+    if (!hasUsablePlayerName(player)) return "";
+    const licence =
+      normalizeLicence(player.licence) ||
+      nameToLicence.get(playerNameKey(player)) ||
+      "";
+    if (licence) return licence;
+    return `name:${playerNameKey(player)}`;
+  };
+
+  return { canonicalKey };
+}
+
+export function mergeCompositionPlayerRecords(
+  existing: CompositionTablePlayer,
+  incoming: CompositionTablePlayer
+): CompositionTablePlayer {
+  const licence =
+    normalizeLicence(existing.licence) || normalizeLicence(incoming.licence);
+  const points =
+    typeof existing.points === "number"
+      ? existing.points
+      : typeof incoming.points === "number"
+        ? incoming.points
+        : null;
+
+  return {
+    nom: existing.nom || incoming.nom || "",
+    prenom: existing.prenom || incoming.prenom || "",
+    points,
+    ...(licence ? { licence } : {}),
+  };
+}

--- a/src/lib/shared/team-matches-roster-utils.test.ts
+++ b/src/lib/shared/team-matches-roster-utils.test.ts
@@ -1,0 +1,71 @@
+import type { MatchData } from "./team-matches-sync-types";
+import { isLicenceListedInMatchRoster } from "./team-matches-roster-utils";
+
+describe("isLicenceListedInMatchRoster", () => {
+  const baseMatch: MatchData = {
+    id: "m1",
+    ffttId: "link",
+    teamId: "1_retour",
+    teamNumber: 5,
+    opponent: "ADV",
+    opponentClub: "ADV",
+    date: new Date(),
+    location: "home",
+    isHome: true,
+    isExempt: false,
+    isForfeit: false,
+    phase: "retour",
+    journee: 3,
+    isFemale: false,
+    division: "div",
+    epreuve: "epreuve",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    resultatsIndividuels: {
+      nomEquipeA: "SQY PING 5",
+      nomEquipeB: "ADV 1",
+      joueursA: {
+        a: { nom: "BARGET", prenom: "Yannis" },
+        b: { nom: "FERREIRA", prenom: "Joao Marques" },
+        c: { nom: "FOUCHE", prenom: "Erwann" },
+      },
+      joueursB: {},
+    },
+    joueursSQY: [
+      { id: "1", licence: "217409", nom: "", prenom: "", points: 1009, sexe: "M" },
+    ],
+  };
+
+  it("rejette une licence fantôme absente de la feuille FFTT", () => {
+    expect(isLicenceListedInMatchRoster(baseMatch, baseMatch.joueursSQY![0])).toBe(
+      false
+    );
+  });
+
+  it("accepte un joueur présent dans la feuille FFTT", () => {
+    const match: MatchData = {
+      ...baseMatch,
+      teamNumber: 10,
+      resultatsIndividuels: {
+        nomEquipeA: "SQY PING 10",
+        nomEquipeB: "ADV 1",
+        joueursA: {
+          a: { nom: "JACOBY", prenom: "Stephane" },
+        },
+        joueursB: {},
+      },
+      joueursSQY: [
+        {
+          id: "1",
+          licence: "217409",
+          nom: "JACOBY",
+          prenom: "Stephane",
+          points: 1009,
+          sexe: "M",
+        },
+      ],
+    };
+
+    expect(isLicenceListedInMatchRoster(match, match.joueursSQY![0])).toBe(true);
+  });
+});

--- a/src/lib/shared/team-matches-roster-utils.ts
+++ b/src/lib/shared/team-matches-roster-utils.ts
@@ -1,0 +1,93 @@
+import type { MatchData } from "./team-matches-sync-types";
+
+export function normalizePlayerName(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .toUpperCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+export function playerNameKey(player: { nom?: string; prenom?: string }): string {
+  return `${normalizePlayerName(player.prenom)}|${normalizePlayerName(player.nom)}`;
+}
+
+export function hasUsablePlayerName(player: { nom?: string; prenom?: string }): boolean {
+  return (
+    normalizePlayerName(player.nom) !== "" &&
+    normalizePlayerName(player.prenom) !== ""
+  );
+}
+
+/** Composition SQY issue des résultats individuels FFTT (source fiable). */
+export function buildSqyRosterFromMatch(
+  match: Pick<MatchData, "resultatsIndividuels">
+): Array<{ nom: string; prenom: string }> {
+  const details = match.resultatsIndividuels;
+  if (!details) return [];
+
+  const joueursA = Object.values(details.joueursA ?? {});
+  const joueursB = Object.values(details.joueursB ?? {});
+  if (joueursA.length === 0 && joueursB.length === 0) return [];
+
+  const nomEquipeA = normalizePlayerName(details.nomEquipeA);
+  const nomEquipeB = normalizePlayerName(details.nomEquipeB);
+
+  if (nomEquipeA.includes("SQY PING") && !nomEquipeB.includes("SQY PING")) {
+    return joueursA;
+  }
+  if (nomEquipeB.includes("SQY PING") && !nomEquipeA.includes("SQY PING")) {
+    return joueursB;
+  }
+
+  return joueursA.length >= joueursB.length ? joueursA : joueursB;
+}
+
+/**
+ * Indique si une licence doit compter pour le brûlage / la participation.
+ * Évite les faux positifs quand une licence a été injectée par enrichissement
+ * sans nom/prénom alors que le joueur n'est pas dans la feuille de match FFTT.
+ */
+export function isLicenceListedInMatchRoster(
+  match: MatchData,
+  joueur: { licence?: string; nom?: string; prenom?: string }
+): boolean {
+  const licence = joueur.licence?.trim();
+  if (!licence) return false;
+
+  const roster = buildSqyRosterFromMatch(match);
+  if (roster.length > 0) {
+    if (!hasUsablePlayerName(joueur)) {
+      return false;
+    }
+    const key = playerNameKey(joueur);
+    return roster.some((r) => playerNameKey(r) === key);
+  }
+
+  return hasUsablePlayerName(joueur);
+}
+
+/** Indique si le match contient une composition exploitable (feuille ou joueursSQY nommés). */
+export function hasMatchCompositionData(
+  match: Pick<MatchData, "joueursSQY" | "resultatsIndividuels">
+): boolean {
+  const joueursSQY = match.joueursSQY ?? [];
+  if (joueursSQY.some((j) => hasUsablePlayerName(j))) {
+    return true;
+  }
+  return buildSqyRosterFromMatch(match).length > 0;
+}
+
+export function addPlayerLicencesFromMatchIfRostered(
+  match: MatchData,
+  joueurs: NonNullable<MatchData["joueursSQY"]>,
+  licences: Set<string>
+): void {
+  for (const joueur of joueurs) {
+    const licence = joueur.licence?.trim();
+    if (licence && isLicenceListedInMatchRoster(match, joueur)) {
+      licences.add(licence);
+    }
+  }
+}

--- a/src/lib/shared/team-matches-sync-enrichment.ts
+++ b/src/lib/shared/team-matches-sync-enrichment.ts
@@ -1,5 +1,6 @@
 import type { Firestore } from "firebase-admin/firestore";
 import type { MatchData, PlayerSearch } from "./team-matches-sync-types";
+import { hasUsablePlayerName } from "./team-matches-roster-utils";
 
 /**
  * Extrait l'ID du club depuis le lien de rencontre.
@@ -38,7 +39,10 @@ export async function enrichSQYPlayersFromClub(
     }
 
     const enrichedJoueursSQY = match.joueursSQY.map((joueur) => {
-      if (!joueur.licence || joueur.licence.trim() === "") {
+      if (
+        (!joueur.licence || joueur.licence.trim() === "") &&
+        hasUsablePlayerName(joueur)
+      ) {
         const normalizeName = (name: string) =>
           name
             .toLowerCase()

--- a/src/lib/shared/team-matches-sync-save.ts
+++ b/src/lib/shared/team-matches-sync-save.ts
@@ -1,38 +1,17 @@
 import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import type { MatchData } from "./team-matches-sync-types";
+import {
+  buildSqyRosterFromMatch,
+  hasMatchCompositionData,
+  playerNameKey,
+} from "./team-matches-roster-utils";
 
 type SyncPlayer = NonNullable<MatchData["joueursSQY"]>[number];
 type ResultPlayer = { nom: string; prenom: string; points?: number };
 
-function normalizeName(value: string | undefined): string {
-  return (value ?? "").trim().toUpperCase().replace(/\s+/g, " ");
-}
-
-function playerNameKey(player: { nom?: string; prenom?: string }): string {
-  return `${normalizeName(player.prenom)}|${normalizeName(player.nom)}`;
-}
-
 function buildPlayersFromResults(match: MatchData): ResultPlayer[] {
-  const details = match.resultatsIndividuels;
-  if (!details) return [];
-
-  const joueursA = Object.values(details.joueursA ?? {});
-  const joueursB = Object.values(details.joueursB ?? {});
-  if (joueursA.length === 0 && joueursB.length === 0) return [];
-
-  const nomEquipeA = normalizeName(details.nomEquipeA);
-  const nomEquipeB = normalizeName(details.nomEquipeB);
-
-  if (nomEquipeA.includes("SQY PING") && !nomEquipeB.includes("SQY PING")) {
-    return joueursA;
-  }
-  if (nomEquipeB.includes("SQY PING") && !nomEquipeA.includes("SQY PING")) {
-    return joueursB;
-  }
-
-  // Fallback défensif si les noms équipes sont absents/incohérents.
-  return joueursA.length >= joueursB.length ? joueursA : joueursB;
+  return buildSqyRosterFromMatch(match);
 }
 
 function reconcileJoueursSQY(match: MatchData): SyncPlayer[] {
@@ -56,15 +35,53 @@ function reconcileJoueursSQY(match: MatchData): SyncPlayer[] {
   return resultPlayers.map((player, index) => {
     const key = playerNameKey(player);
     const existing = existingByName.get(key);
+    const phantomKey = key === "|";
     return {
       id: existing?.id || `${key || "unknown"}_${index + 1}`,
       nom: player.nom || existing?.nom || "",
       prenom: player.prenom || existing?.prenom || "",
-      licence: existing?.licence || "",
+      licence: phantomKey ? "" : existing?.licence || "",
       points: typeof existing?.points === "number" ? existing.points : (player.points ?? 0),
       sexe: existing?.sexe || "M",
     };
   });
+}
+
+function mergeCompositionWithExisting(
+  match: MatchData,
+  reconciledJoueursSQY: SyncPlayer[],
+  existing: Record<string, unknown> | undefined
+): { joueursSQY: SyncPlayer[]; resultatsIndividuels: MatchData["resultatsIndividuels"] } {
+  const incomingHasComposition = hasMatchCompositionData({
+    joueursSQY: reconciledJoueursSQY,
+    resultatsIndividuels: match.resultatsIndividuels,
+  });
+
+  if (incomingHasComposition || !existing) {
+    return {
+      joueursSQY: reconciledJoueursSQY,
+      resultatsIndividuels: match.resultatsIndividuels,
+    };
+  }
+
+  const existingJoueursSQY = existing.joueursSQY as MatchData["joueursSQY"];
+  const existingResultats = existing.resultatsIndividuels as MatchData["resultatsIndividuels"];
+  const existingHasComposition = hasMatchCompositionData({
+    joueursSQY: existingJoueursSQY,
+    resultatsIndividuels: existingResultats,
+  });
+
+  if (existingHasComposition) {
+    return {
+      joueursSQY: (existingJoueursSQY ?? []) as SyncPlayer[],
+      resultatsIndividuels: existingResultats ?? match.resultatsIndividuels,
+    };
+  }
+
+  return {
+    joueursSQY: reconciledJoueursSQY,
+    resultatsIndividuels: match.resultatsIndividuels,
+  };
 }
 
 export async function saveMatchesToTeamSubcollections(
@@ -149,6 +166,22 @@ export async function saveMatchesToTeamSubcollections(
         `💾 Préparation de ${teamMatches.length} matchs pour ${safeTeamId}...`
       );
 
+      const existingByMatchId = new Map<string, Record<string, unknown>>();
+      const matchRefs = teamMatches
+        .map((m) => (typeof m.id === "string" ? m.id.trim() : ""))
+        .filter((id) => id.length > 0)
+        .map((id) =>
+          db.collection("teams").doc(safeTeamId).collection("matches").doc(id)
+        );
+      if (matchRefs.length > 0) {
+        const existingDocs = await db.getAll(...matchRefs);
+        existingDocs.forEach((doc) => {
+          if (doc.exists) {
+            existingByMatchId.set(doc.id, doc.data() as Record<string, unknown>);
+          }
+        });
+      }
+
       for (let i = 0; i < teamMatches.length; i += batchSize) {
         const batch = db.batch();
         const batchEnd = Math.min(i + batchSize, teamMatches.length);
@@ -170,9 +203,16 @@ export async function saveMatchesToTeamSubcollections(
             .doc(matchId);
 
           const reconciledJoueursSQY = reconcileJoueursSQY(match);
+          const mergedComposition = mergeCompositionWithExisting(
+            match,
+            reconciledJoueursSQY,
+            existingByMatchId.get(matchId)
+          );
 
           const matchData = {
             ...match,
+            joueursSQY: mergedComposition.joueursSQY,
+            resultatsIndividuels: mergedComposition.resultatsIndividuels,
             date: Timestamp.fromDate(match.date),
             createdAt: Timestamp.fromDate(match.createdAt),
             updatedAt: Timestamp.fromDate(match.updatedAt),

--- a/src/lib/shared/team-matches-sync.ts
+++ b/src/lib/shared/team-matches-sync.ts
@@ -18,6 +18,7 @@ import {
 } from "./team-matches-sync-enrichment";
 import { recalculateJourneesByDate } from "./team-matches-sync-journee";
 import { saveMatchesToTeamSubcollections } from "./team-matches-sync-save";
+import { listLicensedSqyPlayersInMatch } from "./match-composition-utils";
 
 export type {
   TeamMatchesSyncResult,
@@ -507,11 +508,10 @@ export class TeamMatchesSyncService {
           // Note: resultatsIndividuels ne contient pas de licence, on utilise joueursSQY
 
           // Vérifier aussi joueursSQY (nouveau format)
-          if (hasPlayers) {
-            for (const joueur of match.joueursSQY!) {
-              if (joueur.licence && joueur.licence.trim() !== "") {
-                participatingPlayers.add(joueur.licence);
-              }
+          for (const player of listLicensedSqyPlayersInMatch(match)) {
+            const licence = player.licence?.trim();
+            if (licence) {
+              participatingPlayers.add(licence);
             }
           }
         }
@@ -541,11 +541,10 @@ export class TeamMatchesSyncService {
 
         if (hasPlayers || hasResults || hasScore) {
           // Vérifier aussi joueursSQY (nouveau format)
-          if (hasPlayers) {
-            for (const joueur of match.joueursSQY!) {
-              if (joueur.licence && joueur.licence.trim() !== "") {
-                participatingPlayersParis.add(joueur.licence);
-              }
+          for (const player of listLicensedSqyPlayersInMatch(match)) {
+            const licence = player.licence?.trim();
+            if (licence) {
+              participatingPlayersParis.add(licence);
             }
           }
         }
@@ -604,35 +603,28 @@ export class TeamMatchesSyncService {
         const phase = match.phase || "aller";
         const teamNumber = match.teamNumber;
 
-        // Parcourir les joueurs SQY de ce match
-        if (match.joueursSQY && Array.isArray(match.joueursSQY)) {
-          for (const joueur of match.joueursSQY) {
-            const playerLicence = joueur.licence;
-
-            // Ignorer les joueurs sans licence
-            if (!playerLicence || playerLicence.trim() === "") {
-              continue;
-            }
-
-            // Initialiser les structures si nécessaire
-            if (!matchCountMap.has(playerLicence)) {
-              matchCountMap.set(playerLicence, new Map());
-            }
-
-            const phaseMap = matchCountMap.get(playerLicence)!;
-            if (!phaseMap.has(phase)) {
-              phaseMap.set(phase, new Map());
-            }
-
-            const teamMap = phaseMap.get(phase)!;
-            if (!teamMap.has(teamNumber)) {
-              teamMap.set(teamNumber, 0);
-            }
-
-            // Incrémenter le compteur
-            const currentCount = teamMap.get(teamNumber)!;
-            teamMap.set(teamNumber, currentCount + 1);
+        for (const joueur of listLicensedSqyPlayersInMatch(match)) {
+          const playerLicence = joueur.licence?.trim();
+          if (!playerLicence) {
+            continue;
           }
+
+          if (!matchCountMap.has(playerLicence)) {
+            matchCountMap.set(playerLicence, new Map());
+          }
+
+          const phaseMap = matchCountMap.get(playerLicence)!;
+          if (!phaseMap.has(phase)) {
+            phaseMap.set(phase, new Map());
+          }
+
+          const teamMap = phaseMap.get(phase)!;
+          if (!teamMap.has(teamNumber)) {
+            teamMap.set(teamNumber, 0);
+          }
+
+          const currentCount = teamMap.get(teamNumber)!;
+          teamMap.set(teamNumber, currentCount + 1);
         }
       }
 
@@ -712,7 +704,6 @@ export class TeamMatchesSyncService {
               // Règle FFTT championnat par équipes : Un joueur est brûlé dans l'équipe où il a joué son 2ème match
               // (en comptant tous les matchs dans l'ordre croissant des numéros d'équipe)
               // Exemple : {1: 3, 2: 1} -> liste triée : [1, 1, 1, 2] -> 2ème match = équipe 1
-              
               // Créer une liste de tous les matchs triés par numéro d'équipe croissant
               const allMatches: number[] = [];
               for (const [teamNumber, matchCount] of matchesByTeamInPhase) {
@@ -867,6 +858,41 @@ export class TeamMatchesSyncService {
         }
       }
 
+      type BurnoutTeamByPhase = { aller?: number; retour?: number };
+      type BurnoutPhaseFieldUpdate =
+        | BurnoutTeamByPhase
+        | FieldValue
+        | undefined;
+
+      /** Recalcule le champ brûlé par phase ; supprime les valeurs obsolètes (ex. 1 seul match). */
+      const resolveBurnoutByPhaseFieldUpdate = (
+        computedByPhase: Map<string, number> | undefined,
+        existing: BurnoutTeamByPhase | undefined
+      ): BurnoutPhaseFieldUpdate => {
+        if (computedByPhase && computedByPhase.size > 0) {
+          const next: BurnoutTeamByPhase = {};
+          for (const [phase, teamNumber] of computedByPhase) {
+            if (phase === "aller" || phase === "retour") {
+              next[phase] = teamNumber;
+            }
+          }
+          if (Object.keys(next).length === 0) {
+            return existing !== undefined ? FieldValue.delete() : undefined;
+          }
+          if (
+            existing?.aller === next.aller &&
+            existing?.retour === next.retour
+          ) {
+            return undefined;
+          }
+          return next;
+        }
+        if (existing !== undefined) {
+          return FieldValue.delete();
+        }
+        return undefined;
+      };
+
       for (const playerId of playerIds) {
         try {
           const playerData = playerDataMap.get(playerId);
@@ -908,118 +934,24 @@ export class TeamMatchesSyncService {
               updates["participation.championnatParis"] = true;
             }
 
-            // Mettre à jour highestMasculineTeamNumberByPhase si le joueur est brûlé en masculin
-            const highestMasculineBurnedTeamByPhase =
-              highestMasculineBurnedTeamByPlayerByPhase.get(playerId);
-            const hasMasculineMatches =
-              masculineMatchesByTeamByPlayerByPhase.has(playerId);
-
-            if (highestMasculineBurnedTeamByPhase) {
-              // Le joueur est brûlé en masculin pour au moins une phase
-              const currentHighestByPhase =
-                (playerData?.highestMasculineTeamNumberByPhase as
-                  | { aller?: number; retour?: number }
-                  | undefined) || {};
-
-              const newHighestByPhase: {
-                aller?: number;
-                retour?: number;
-              } = { ...currentHighestByPhase };
-
-              // Mettre à jour pour chaque phase
-              for (const [
-                phase,
-                burnedTeam,
-              ] of highestMasculineBurnedTeamByPhase) {
-                if (phase === "aller" || phase === "retour") {
-                  const currentHighest = currentHighestByPhase[phase] ?? null;
-
-                  // Mettre à jour si la valeur actuelle est absente ou si la nouvelle valeur est différente
-                  // La valeur calculée est la source de vérité basée sur les matchs réels
-                  if (
-                    currentHighest === null ||
-                    burnedTeam !== currentHighest
-                  ) {
-                    newHighestByPhase[phase] = burnedTeam;
-                  }
-                }
-              }
-
-              // Si au moins une phase a été mise à jour, sauvegarder
-              const hasChanges = Object.keys(newHighestByPhase).some(
-                (phase) =>
-                  newHighestByPhase[phase as "aller" | "retour"] !==
-                  currentHighestByPhase[phase as "aller" | "retour"]
-              );
-
-              if (hasChanges || Object.keys(newHighestByPhase).length > 0) {
-                updates.highestMasculineTeamNumberByPhase = newHighestByPhase;
-              }
-            } else if (!hasMasculineMatches) {
-              // Le joueur n'a plus de matchs masculins, supprimer le brûlage si le champ existe
-              if (
-                (playerData?.highestMasculineTeamNumberByPhase as unknown) !==
-                undefined
-              ) {
-                updates.highestMasculineTeamNumberByPhase = FieldValue.delete();
-              }
+            const masculineBurnUpdate = resolveBurnoutByPhaseFieldUpdate(
+              highestMasculineBurnedTeamByPlayerByPhase.get(playerId),
+              playerData?.highestMasculineTeamNumberByPhase as
+                | BurnoutTeamByPhase
+                | undefined
+            );
+            if (masculineBurnUpdate !== undefined) {
+              updates.highestMasculineTeamNumberByPhase = masculineBurnUpdate;
             }
 
-            // Mettre à jour highestFeminineTeamNumberByPhase si le joueur est brûlé en féminin
-            const highestFeminineBurnedTeamByPhase =
-              highestFeminineBurnedTeamByPlayerByPhase.get(playerId);
-            const hasFeminineMatches =
-              feminineMatchesByTeamByPlayerByPhase.has(playerId);
-
-            if (highestFeminineBurnedTeamByPhase) {
-              // Le joueur est brûlé en féminin pour au moins une phase
-              const currentHighestByPhase =
-                (playerData?.highestFeminineTeamNumberByPhase as
-                  | { aller?: number; retour?: number }
-                  | undefined) || {};
-
-              const newHighestByPhase: {
-                aller?: number;
-                retour?: number;
-              } = { ...currentHighestByPhase };
-
-              // Mettre à jour pour chaque phase
-              for (const [
-                phase,
-                burnedTeam,
-              ] of highestFeminineBurnedTeamByPhase) {
-                if (phase === "aller" || phase === "retour") {
-                  const currentHighest = currentHighestByPhase[phase] ?? null;
-
-                  // Mettre à jour si la valeur actuelle est absente ou si la nouvelle valeur est différente
-                  // La valeur calculée est la source de vérité basée sur les matchs réels
-                  if (
-                    currentHighest === null ||
-                    burnedTeam !== currentHighest
-                  ) {
-                    newHighestByPhase[phase] = burnedTeam;
-                  }
-                }
-              }
-
-              // Si au moins une phase a été mise à jour, sauvegarder
-              const hasChanges = Object.keys(newHighestByPhase).some(
-                (phase) =>
-                  newHighestByPhase[phase as "aller" | "retour"] !==
-                  currentHighestByPhase[phase as "aller" | "retour"]
-              );
-
-              if (hasChanges || Object.keys(newHighestByPhase).length > 0) {
-                updates.highestFeminineTeamNumberByPhase = newHighestByPhase;
-              }
-            } else if (!hasFeminineMatches) {
-              // Le joueur n'a plus de matchs féminins, supprimer le brûlage si le champ existe
-              if (
-                (playerData?.highestFeminineTeamNumberByPhase as unknown) !==
-                undefined
-              ) {
-                updates.highestFeminineTeamNumberByPhase = FieldValue.delete();
-              }
+            const feminineBurnUpdate = resolveBurnoutByPhaseFieldUpdate(
+              highestFeminineBurnedTeamByPlayerByPhase.get(playerId),
+              playerData?.highestFeminineTeamNumberByPhase as
+                | BurnoutTeamByPhase
+                | undefined
+            );
+            if (feminineBurnUpdate !== undefined) {
+              updates.highestFeminineTeamNumberByPhase = feminineBurnUpdate;
             }
 
             // Mettre à jour masculineMatchesByTeamByPhase pour l'affichage dans le tooltip
@@ -1068,55 +1000,14 @@ export class TeamMatchesSyncService {
               updates.feminineMatchesByTeamByPhase = matchesByTeamByPhaseObj;
             }
 
-            // Mettre à jour highestTeamNumberByPhaseParis si le joueur est brûlé au championnat de Paris (mixte)
-            const highestBurnedTeamByPhaseParis =
-              highestBurnedTeamByPlayerByPhaseParis.get(playerId);
-            const hasMatchesParis =
-              matchesByTeamByPlayerByPhaseParis.has(playerId);
-
-            if (highestBurnedTeamByPhaseParis) {
-              // Le joueur est brûlé pour au moins une phase (Paris)
-              const currentHighestByPhase =
-                (playerData?.highestTeamNumberByPhaseParis as
-                  | { aller?: number; retour?: number }
-                  | undefined) || {};
-
-              const newHighestByPhase: {
-                aller?: number;
-                retour?: number;
-              } = { ...currentHighestByPhase };
-
-              // Mettre à jour pour chaque phase
-              for (const [phase, burnedTeam] of highestBurnedTeamByPhaseParis) {
-                if (phase === "aller" || phase === "retour") {
-                  const currentHighest = currentHighestByPhase[phase] ?? null;
-
-                  if (
-                    currentHighest === null ||
-                    burnedTeam !== currentHighest
-                  ) {
-                    newHighestByPhase[phase] = burnedTeam;
-                  }
-                }
-              }
-
-              const hasChanges = Object.keys(newHighestByPhase).some(
-                (phase) =>
-                  newHighestByPhase[phase as "aller" | "retour"] !==
-                  currentHighestByPhase[phase as "aller" | "retour"]
-              );
-
-              if (hasChanges || Object.keys(newHighestByPhase).length > 0) {
-                updates.highestTeamNumberByPhaseParis = newHighestByPhase;
-              }
-            } else if (!hasMatchesParis) {
-              // Le joueur n'a plus de matchs Paris, supprimer le brûlage si le champ existe
-              if (
-                (playerData?.highestTeamNumberByPhaseParis as unknown) !==
-                undefined
-              ) {
-                updates.highestTeamNumberByPhaseParis = FieldValue.delete();
-              }
+            const parisBurnUpdate = resolveBurnoutByPhaseFieldUpdate(
+              highestBurnedTeamByPlayerByPhaseParis.get(playerId),
+              playerData?.highestTeamNumberByPhaseParis as
+                | BurnoutTeamByPhase
+                | undefined
+            );
+            if (parisBurnUpdate !== undefined) {
+              updates.highestTeamNumberByPhaseParis = parisBurnUpdate;
             }
 
             // Mettre à jour matchesByTeamByPhaseParis pour l'affichage dans le tooltip


### PR DESCRIPTION
## Summary

- Compte le brûlage et la participation à partir d’une composition SQY fiable (feuille FFTT, repli parties, fusion nom/licence).
- Ignore les entrées `joueursSQY` fantômes qui gonflaient artificiellement le 2ᵉ match (ex. Jacoby 217409).
- Supprime `highestMasculineTeamNumberByPhase` obsolète quand le recalcul ne donne plus de brûlage (badge vs tooltip incohérents).
- Améliore le tableau « Joueurs par journée » : colonnes J1/J2…, matchs 0-0 exclus, anti-doublons licence/nom.

## Test plan

- [x] `npm test` — `match-composition-utils`, `team-matches-roster-utils`
- [x] `npm run check:dev` (lint + type-check)
- [ ] Resync matchs en prod/staging puis vérifier Jacoby (217409) : pas de badge « Équipe 5 », tooltip = 1 match équipe 10
- [ ] Vérifier tableau compositions équipe 3 retour et équipe 5 retour (J1 visible si composition présente)


Made with [Cursor](https://cursor.com)