### PR TITLE
🛡️ Sentinel: Harden FFTT API routes with mandatory email verification

### DIFF
--- a/src/app/api/fftt/opponent-compositions/route.ts
+++ b/src/app/api/fftt/opponent-compositions/route.ts
@@ -1,8 +1,6 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import type { NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 import {
   getFFTTConfig,
   createFFTTAPI,
@@ -218,32 +216,14 @@ export interface OpponentMatchComposition {
  * Récupère les compositions de l'équipe adverse lors de ses précédents matchs (données FFTT, pas stockées).
  * Réservé aux coachs et admins.
  */
-export async function GET(req: NextRequest) {
+export const GET = withAuth(async (req: Request) => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Authentification requise" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore(
-        { error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
-    const teamId = req.nextUrl.searchParams.get("teamId")?.trim();
-    const phaseParam = req.nextUrl.searchParams.get("phase");
+    const { searchParams } = new URL(req.url);
+    const teamId = searchParams.get("teamId")?.trim();
+    const phaseParam = searchParams.get("phase");
     const phase =
       phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
-    const opponentName = req.nextUrl.searchParams.get("opponentName")?.trim();
+    const opponentName = searchParams.get("opponentName")?.trim();
 
     if (!teamId || !phase || !opponentName) {
       return jsonNoStore(
@@ -474,4 +454,4 @@ export async function GET(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/fftt/pool-ranking/route.ts
+++ b/src/app/api/fftt/pool-ranking/route.ts
@@ -1,8 +1,6 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import type { NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 import {
   getFFTTConfig,
   createFFTTAPI,
@@ -61,28 +59,10 @@ type FFTTEquipeLike = {
  * Si phase est fourni (aller|retour), utilise l'équipe FFTT dont la division correspond à cette phase.
  * Réservé aux coachs et admins.
  */
-export async function GET(req: NextRequest) {
+export const GET = withAuth(async (req: Request) => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Authentification requise" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore(
-        { error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
-    const teamId = req.nextUrl.searchParams.get("teamId");
+    const { searchParams } = new URL(req.url);
+    const teamId = searchParams.get("teamId");
     if (!teamId || !teamId.trim()) {
       return jsonNoStore(
         { error: "Paramètre teamId requis" },
@@ -90,7 +70,7 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    const phaseParam = req.nextUrl.searchParams.get("phase");
+    const phaseParam = searchParams.get("phase");
     const phase =
       phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
 
@@ -217,4 +197,4 @@ export async function GET(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/fftt/pool-ranking` and `/api/fftt/opponent-compositions` routes were using manual authentication logic that missed the `email_verified` check, allowing users with unverified emails to access these endpoints if they had the correct role.
🎯 Impact: Unauthorized access to FFTT-related data by unverified users.
🔧 Fix: Refactored both routes to use the project's standard `withAuth` higher-order function, which enforces session verification, RBAC (ADMIN/COACH), and the `email_verified` claim.
✅ Verification: Verified correct HOC implementation via code review and ran `npm test` and `npm run check:dev` to ensure stability.

---
*PR created automatically by Jules for task [3858009477431800650](https://jules.google.com/task/3858009477431800650) started by @omichalo*