### PR TITLE
fix(auth): Firebase Admin staging (send-verification 403)

### DIFF
--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -1,0 +1,131 @@
+# Overrides App Hosting pour le backend staging (sqyping-teamup-dev).
+# Fusionné avec apphosting.yaml lorsque Environment name = "staging".
+# Firebase client : FIREBASE_WEBAPP_CONFIG est injecté au build (voir src/lib/firebase.ts).
+
+runConfig:
+  minInstances: 0
+  cpu: 1
+  memoryMiB: 512
+  concurrency: 80
+
+env:
+  # Firebase client (sqyping-teamup-dev) — override apphosting.yaml (prod) après fusion
+  - variable: NEXT_PUBLIC_FIREBASE_API_KEY
+    value: AIzaSyDFcEfGk4_-OENR-SWy29QnoC5I9wMmbC0
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    value: sqyping-teamup-dev.firebaseapp.com
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    value: sqyping-teamup-dev
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    value: sqyping-teamup-dev.firebasestorage.app
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+    value: "544871588374"
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: NEXT_PUBLIC_FIREBASE_APP_ID
+    value: 1:544871588374:web:095f855304c8684c78cb37
+    availability:
+      - BUILD
+      - RUNTIME
+
+  # URL publique du backend staging (teamup-staging sur sqyping-teamup-dev)
+  - variable: NEXT_PUBLIC_APP_URL
+    value: https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: APP_URL
+    value: https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app
+    availability:
+      - RUNTIME
+
+  - variable: DEBUG
+    value: "true"
+    availability:
+      - RUNTIME
+
+  # Secrets : mêmes noms que prod, valeurs distinctes dans Secret Manager (projet teamup-dev).
+  # Créer / copier via : firebase apphosting:secrets:set SECRET_NAME --project sqyping-teamup-dev
+  - variable: ID_FFTT
+    secret: fftt-id-secret
+    availability:
+      - RUNTIME
+
+  - variable: PWD_FFTT
+    secret: fftt-pwd-secret
+    availability:
+      - RUNTIME
+
+  - variable: SMTP_USER
+    secret: SMTP_USER
+    availability:
+      - RUNTIME
+
+  - variable: SMTP_PASS
+    secret: SMTP_PASS
+    availability:
+      - RUNTIME
+
+  - variable: SMTP_HOST
+    secret: SMTP_HOST
+    availability:
+      - RUNTIME
+
+  - variable: SMTP_PORT
+    secret: SMTP_PORT
+    availability:
+      - RUNTIME
+
+  - variable: DISCORD_TOKEN
+    secret: DISCORD_TOKEN
+    availability:
+      - RUNTIME
+
+  - variable: DISCORD_PUBLIC_KEY
+    secret: DISCORD_PUBLIC_KEY
+    availability:
+      - RUNTIME
+
+  - variable: DISCORD_APPLICATION_ID
+    secret: DISCORD_APPLICATION_ID
+    availability:
+      - RUNTIME
+
+  - variable: DISCORD_SERVER_ID
+    secret: DISCORD_SERVER_ID
+    availability:
+      - RUNTIME
+
+  - variable: CSRF_SECRET
+    secret: CSRF_SECRET
+    availability:
+      - RUNTIME
+
+  - variable: STRIPE_SECRET_KEY
+    secret: STRIPE_SECRET_KEY
+    availability:
+      - RUNTIME
+
+  - variable: STRIPE_WEBHOOK_SECRET
+    secret: STRIPE_WEBHOOK_SECRET
+    availability:
+      - RUNTIME

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -4,16 +4,42 @@ import { getAuth } from "firebase-admin/auth";
 import * as fs from "fs";
 import * as path from "path";
 
+/** Projet Firebase côté serveur : aligné sur le projet hébergé (App Hosting / Cloud Run). */
+function resolveFirebaseAdminProjectId(): string {
+  if (process.env.FIREBASE_WEBAPP_CONFIG) {
+    try {
+      const parsed = JSON.parse(process.env.FIREBASE_WEBAPP_CONFIG) as {
+        projectId?: string;
+      };
+      if (parsed.projectId?.trim()) {
+        return parsed.projectId.trim();
+      }
+    } catch {
+      // ignore invalid JSON
+    }
+  }
+
+  const cloudProject =
+    process.env.GCLOUD_PROJECT?.trim() ||
+    process.env.GOOGLE_CLOUD_PROJECT?.trim();
+  if (cloudProject) {
+    return cloudProject;
+  }
+
+  return (
+    process.env.FB_PROJECT_ID?.trim() ||
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID?.trim() ||
+    "sqyping-teamup"
+  );
+}
+
 // Initialiser Firebase Admin (une seule fois)
 const app = (() => {
   if (getApps().length > 0) {
     return getApps()[0];
   }
 
-  const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 
-    process.env.GCLOUD_PROJECT || 
-    process.env.GOOGLE_CLOUD_PROJECT || 
-    "sqyping-teamup";
+  const projectId = resolveFirebaseAdminProjectId();
 
   // Vérifier si un fichier de service account est spécifié via GOOGLE_APPLICATION_CREDENTIALS
   const rawServiceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
@@ -74,10 +100,7 @@ const app = (() => {
     process.env.FB_PRIVATE_KEY?.replace(/\\n/g, "\n") ||
     process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
   const clientEmail = process.env.FB_CLIENT_EMAIL || process.env.FIREBASE_CLIENT_EMAIL;
-  const explicitProjectId =
-    process.env.FB_PROJECT_ID ||
-    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ||
-    projectId;
+  const explicitProjectId = process.env.FB_PROJECT_ID?.trim() || projectId;
 
   if (privateKey && clientEmail) {
     // Log uniquement en mode debug (sans exposer la présence de la clé privée)


### PR DESCRIPTION
## Summary

- Corrige l'erreur 403 Identity Toolkit sur staging lors de `POST /api/auth/send-verification`.
- Le backend App Hosting staging (`sqyping-teamup-dev`) utilisait les credentials du projet dev mais ciblait `sqyping-teamup` via `NEXT_PUBLIC_FIREBASE_PROJECT_ID` fusionné depuis `apphosting.yaml`.
- `firebase-admin.ts` résout désormais le projectId depuis `FIREBASE_WEBAPP_CONFIG` / `GCLOUD_PROJECT` (projet hébergé).
- Ajout de `apphosting.staging.yaml` avec les overrides Firebase dev + URLs staging.

## Contexte IAM

Le rôle `roles/serviceusage.serviceUsageConsumer` a aussi été ajouté sur `firebase-app-hosting-compute@sqyping-teamup-dev.iam.gserviceaccount.com` (hors repo).

## Test plan

- [ ] Merger et attendre le rollout App Hosting staging
- [ ] Inscription ou renvoi de vérification sur https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app
- [ ] Vérifier que `POST /api/auth/send-verification` répond 200 et que l'email arrive
- [ ] Vérifier que le lien de vérification pointe vers le domaine staging (pas prod)


Made with [Cursor](https://cursor.com)