### PR TITLE
🛡️ Sentinel: Harden Administrative Sync APIs and Standardize `withAuth` Error Messages

### DIFF
--- a/src/app/api/admin/sync-players/route.ts
+++ b/src/app/api/admin/sync-players/route.ts
@@ -1,51 +1,28 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import { syncPlayers } from "@/lib/shared/sync-utils";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
 import {
   enforceRateLimit,
   RATE_LIMIT_ADMIN_SYNC_PER_UID,
 } from "@/lib/auth/rate-limit-http";
+import { withAuth } from "@/lib/auth/api-utils";
+import { DecodedIdToken } from "firebase-admin/auth";
 
 export const runtime = "nodejs";
 
-export async function POST(req: NextRequest) {
+async function postHandler(req: Request, context: unknown) {
   try {
+    const { decoded } = context as { decoded: DecodedIdToken };
+
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
       return jsonNoStore(
         {
           error: "Invalid origin",
           message: "Requête non autorisée",
-        },
-        { status: 403 }
-      );
-    }
-
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        {
-          error: "Token d'authentification requis",
-          message: "Cette API nécessite une authentification valide",
-        },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          error: "Accès refusé",
-          message: "Cette opération est réservée aux administrateurs",
         },
         { status: 403 }
       );
@@ -75,6 +52,17 @@ export async function POST(req: NextRequest) {
       success: result.success,
     });
 
+    // Sanitize the result to avoid leaking details if success is false
+    if (!result.success) {
+      return jsonNoStore(
+        {
+          success: false,
+          error: "Erreur lors de la synchronisation des joueurs",
+        },
+        { status: 500 }
+      );
+    }
+
     return jsonNoStore(result, { status: 200 });
   } catch (error) {
     console.error("❌ [app/api/admin/sync-players] Erreur lors de la synchronisation des joueurs:", error);
@@ -82,11 +70,10 @@ export async function POST(req: NextRequest) {
       {
         success: false,
         error: "Erreur lors de la synchronisation des joueurs",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
 }
 
-
+export const POST = withAuth(postHandler, [USER_ROLES.ADMIN]);

--- a/src/app/api/admin/sync-team-matches/route.ts
+++ b/src/app/api/admin/sync-team-matches/route.ts
@@ -1,55 +1,31 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import {
   initializeFirebaseAdmin,
   getFirestoreAdmin,
-  adminAuth,
 } from "@/lib/firebase-admin";
 import { Timestamp } from "firebase-admin/firestore";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
 import {
   enforceRateLimit,
   RATE_LIMIT_ADMIN_SYNC_PER_UID,
 } from "@/lib/auth/rate-limit-http";
+import { withAuth } from "@/lib/auth/api-utils";
+import { DecodedIdToken } from "firebase-admin/auth";
 
 export const runtime = "nodejs";
 
-export async function POST(req: NextRequest) {
+async function postHandler(req: Request, context: unknown) {
   try {
+    const { decoded } = context as { decoded: DecodedIdToken };
+
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
       return jsonNoStore(
         {
           error: "Invalid origin",
           message: "Requête non autorisée",
-        },
-        { status: 403 }
-      );
-    }
-
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        {
-          error: "Token d'authentification requis",
-          message: "Cette API nécessite une authentification valide",
-        },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          error: "Accès refusé",
-          message: "Cette opération est réservée aux administrateurs",
         },
         { status: 403 }
       );
@@ -79,7 +55,6 @@ export async function POST(req: NextRequest) {
         {
           success: false,
           error: "Erreur lors de la synchronisation",
-          details: syncResult.error || "Unknown error",
         },
         { status: 500 }
       );
@@ -139,11 +114,10 @@ export async function POST(req: NextRequest) {
       {
         success: false,
         error: "Erreur lors de la synchronisation des matchs",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
 }
 
-
+export const POST = withAuth(postHandler, [USER_ROLES.ADMIN]);

--- a/src/app/api/admin/sync-teams/route.ts
+++ b/src/app/api/admin/sync-teams/route.ts
@@ -1,54 +1,30 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import {
   initializeFirebaseAdmin,
   getFirestoreAdmin,
-  adminAuth,
 } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
 import {
   enforceRateLimit,
   RATE_LIMIT_ADMIN_SYNC_PER_UID,
 } from "@/lib/auth/rate-limit-http";
+import { withAuth } from "@/lib/auth/api-utils";
+import { DecodedIdToken } from "firebase-admin/auth";
 
 export const runtime = "nodejs";
 
-export async function POST(req: NextRequest) {
+async function postHandler(req: Request, context: unknown) {
   try {
+    const { decoded } = context as { decoded: DecodedIdToken };
+
     // Valider l'origine de la requête pour prévenir les attaques CSRF
     if (!validateOrigin(req)) {
       return jsonNoStore(
         {
           error: "Invalid origin",
           message: "Requête non autorisée",
-        },
-        { status: 403 }
-      );
-    }
-
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        {
-          error: "Token d'authentification requis",
-          message: "Cette API nécessite une authentification valide",
-        },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          error: "Accès refusé",
-          message: "Cette opération est réservée aux administrateurs",
         },
         { status: 403 }
       );
@@ -76,7 +52,6 @@ export async function POST(req: NextRequest) {
         {
           success: false,
           error: "Erreur lors de la synchronisation",
-          details: syncResult.error || "Unknown error",
         },
         { status: 500 }
       );
@@ -127,11 +102,10 @@ export async function POST(req: NextRequest) {
       {
         success: false,
         error: "Erreur lors de la synchronisation des équipes",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
 }
 
-
+export const POST = withAuth(postHandler, [USER_ROLES.ADMIN]);

--- a/src/lib/auth/api-utils.ts
+++ b/src/lib/auth/api-utils.ts
@@ -8,14 +8,14 @@ export const withAuth = (handler: (req: Request, context: unknown) => Promise<Ne
   async (req: Request, context: unknown) => {
     try {
       const session = (await cookies()).get("__session")?.value;
-      if (!session) return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+      if (!session) return jsonNoStore({ error: "Authentication required" }, { status: 401 });
       const decoded = await adminAuth.verifySessionCookie(session, true);
-      if (!decoded.email_verified) return jsonNoStore({ error: "Email non vérifié" }, { status: 403 });
+      if (!decoded.email_verified) return jsonNoStore({ error: "Email not verified" }, { status: 403 });
       const role = resolveRole(decoded.role as string);
-      if (allowedRoles && !hasAnyRole(role, allowedRoles)) return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+      if (allowedRoles && !hasAnyRole(role, allowedRoles)) return jsonNoStore({ error: "Access denied" }, { status: 403 });
       const res = await handler(req, { ... (context as object), decoded, role });
       return applyNoStoreHeaders(res);
     } catch {
-      return jsonNoStore({ error: "Session invalide" }, { status: 401 });
+      return jsonNoStore({ error: "Invalid session" }, { status: 401 });
     }
   };


### PR DESCRIPTION
This PR improves the security of administrative synchronization endpoints by standardizing their authentication and authorization logic using the `withAuth` Higher-Order Component (HOC). 

Key enhancements:
1. **Authentication/Authorization Standardization**: The manual session and role checks in `/api/admin/sync-teams`, `/api/admin/sync-players`, and `/api/admin/sync-team-matches` were replaced with `withAuth`. This ensures that the `email_verified` claim is consistently checked, preventing unverified users from triggering resource-intensive sync operations.
2. **Information Leakage Mitigation**: Error responses in these routes were hardened to remove the `details: error.message` field, preventing internal implementation details or stack traces from being exposed to the client.
3. **Generic Error Messages**: Generic error messages in `src/lib/auth/api-utils.ts` were translated to English to align with project standards and provide a consistent, safe experience.
4. **Security Journaling**: A new entry was added to `.jules/sentinel.md` documenting these improvements and the associated security learnings.

Verified by running `npm run check:dev` and `npm test`.

---
*PR created automatically by Jules for task [16793586331796640808](https://jules.google.com/task/16793586331796640808) started by @omichalo*