### PR TITLE
fix(auth): liens email staging (continueUrl localhost)

### DIFF
--- a/docs/APP_HOSTING_STAGING_SETUP.md
+++ b/docs/APP_HOSTING_STAGING_SETUP.md
@@ -92,12 +92,18 @@ Accorder l’accès au backend :
 firebase apphosting:secrets:grantaccess SECRET_NAME --backend teamup-staging --project sqyping-teamup-dev
 ```
 
-## 4. Firebase Auth — domaines autorisés
+## 4. Firebase Auth — domaines autorisés et callback email
 
 Dans **sqyping-teamup-dev** → **Authentication** → **Settings** → **Authorized domains**, ajouter :
 
 - `teamup-staging--sqyping-teamup-dev.us-east4.hosted.app`
 - Domaine custom si configuré (ex. `staging.teamup.sqyping.fr`)
+
+Dans **Authentication** → **Templates** (ou paramètres email du projet), vérifier que l’**URL de redirection par défaut** (`callbackUri`) n’est plus `http://localhost:3000/...` mais l’URL staging :
+
+- `https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app/auth/verify-email`
+
+Sans cela, les liens générés par Firebase peuvent contenir `continueUrl=localhost` même depuis staging. Le code serveur force aussi le `continueUrl` dans les liens oob (`resolve-app-origin` + `withActionContinueUrl`).
 
 ## 5. Stripe (mode test)
 

--- a/src/app/api/auth/send-password-reset/route.ts
+++ b/src/app/api/auth/send-password-reset/route.ts
@@ -6,6 +6,11 @@ import path from "path";
 import { getFirebaseErrorMessage } from "@/lib/firebase-error-utils";
 import { checkRateLimit } from "@/lib/auth/rate-limit";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  isAuthOriginDebugEnabled,
+  resolveAppOrigin,
+  withActionContinueUrl,
+} from "@/lib/auth/resolve-app-origin";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -51,38 +56,10 @@ export async function POST(req: Request) {
       );
     }
 
-    // Déterminer l'URL de base
-    // Priorité: APP_URL (serveur) > NEXT_PUBLIC_APP_URL > headers > localhost
-    const appUrl = process.env.APP_URL; // Variable serveur (sans NEXT_PUBLIC_)
-    const envBase = process.env.NEXT_PUBLIC_APP_URL; // Variable client (peut ne pas être disponible au runtime serveur)
-    const forwardedProto = req.headers.get("x-forwarded-proto") || "https";
-    const host = req.headers.get("host") || req.headers.get("x-forwarded-host");
-
-    let origin: string;
-
-    // Priorité 1: APP_URL (variable serveur, toujours disponible au runtime)
-    if (appUrl && appUrl.trim() !== "") {
-      origin = appUrl.trim().replace(/\/$/, "");
-    }
-    // Priorité 2: NEXT_PUBLIC_APP_URL (peut ne pas être disponible au runtime serveur)
-    else if (envBase && envBase.trim() !== "") {
-      origin = envBase.trim().replace(/\/$/, "");
-    }
-    // Priorité 3: Headers de la requête
-    else if (host) {
-      const proto = host.includes("localhost") ? "http" : forwardedProto;
-      origin = `${proto}://${host}`;
-    }
-    // Priorité 4: Fallback localhost uniquement en développement
-    else {
-      origin = "http://localhost:3000";
-    }
-
-    // S'assurer que l'URL est bien formatée
+    const origin = resolveAppOrigin(req);
     const redirectUrl = `${origin}/reset-password`;
 
-    // Logs uniquement en mode debug (développement)
-    if (process.env.NODE_ENV === "development" && process.env.DEBUG === "true") {
+    if (isAuthOriginDebugEnabled()) {
       console.log("[send-password-reset] Environment variables:", {
         APP_URL: process.env.APP_URL ? "***" : undefined,
         NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL ? "***" : undefined,
@@ -90,6 +67,7 @@ export async function POST(req: Request) {
       });
       console.log("[send-password-reset] Headers:", {
         host: req.headers.get("host"),
+        origin: req.headers.get("origin"),
         "x-forwarded-host": req.headers.get("x-forwarded-host"),
         "x-forwarded-proto": req.headers.get("x-forwarded-proto"),
       });
@@ -100,10 +78,13 @@ export async function POST(req: Request) {
     // Générer le lien de réinitialisation via Firebase Admin
     let link: string;
     try {
-      link = await adminAuth.generatePasswordResetLink(email, {
-        url: redirectUrl,
-        handleCodeInApp: false,
-      });
+      link = withActionContinueUrl(
+        await adminAuth.generatePasswordResetLink(email, {
+          url: redirectUrl,
+          handleCodeInApp: false,
+        }),
+        redirectUrl
+      );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       const authCode = getAuthErrorCode(error);

--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -6,6 +6,11 @@ import path from "path";
 import { getFirebaseErrorMessage } from "@/lib/firebase-error-utils";
 import { checkRateLimit } from "@/lib/auth/rate-limit";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
+import {
+  isAuthOriginDebugEnabled,
+  resolveAppOrigin,
+  withActionContinueUrl,
+} from "@/lib/auth/resolve-app-origin";
 
 export const runtime = "nodejs";
 
@@ -50,38 +55,10 @@ export async function POST(req: Request) {
       );
     }
 
-    // Déterminer l'URL de base
-    // Priorité: APP_URL (serveur) > NEXT_PUBLIC_APP_URL > headers > localhost
-    const appUrl = process.env.APP_URL; // Variable serveur (sans NEXT_PUBLIC_)
-    const envBase = process.env.NEXT_PUBLIC_APP_URL; // Variable client (peut ne pas être disponible au runtime serveur)
-    const forwardedProto = req.headers.get("x-forwarded-proto") || "https";
-    const host = req.headers.get("host") || req.headers.get("x-forwarded-host");
-    
-    let origin: string;
-    
-    // Priorité 1: APP_URL (variable serveur, toujours disponible au runtime)
-    if (appUrl && appUrl.trim() !== "") {
-      origin = appUrl.trim().replace(/\/$/, "");
-    }
-    // Priorité 2: NEXT_PUBLIC_APP_URL (peut ne pas être disponible au runtime serveur)
-    else if (envBase && envBase.trim() !== "") {
-      origin = envBase.trim().replace(/\/$/, "");
-    }
-    // Priorité 3: Headers de la requête
-    else if (host) {
-      const proto = host.includes("localhost") ? "http" : forwardedProto;
-      origin = `${proto}://${host}`;
-    }
-    // Priorité 4: Fallback localhost uniquement en développement
-    else {
-      origin = "http://localhost:3000";
-    }
-    
-    // S'assurer que l'URL est bien formatée
+    const origin = resolveAppOrigin(req);
     const redirectUrl = `${origin}/auth/verify-email`;
 
-    // Logs uniquement en mode debug
-    if (process.env.NODE_ENV === "development" && process.env.DEBUG === "true") {
+    if (isAuthOriginDebugEnabled()) {
       console.log("[send-verification] Environment variables:", {
         APP_URL: process.env.APP_URL ? "***" : undefined,
         NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL ? "***" : undefined,
@@ -89,6 +66,7 @@ export async function POST(req: Request) {
       });
       console.log("[send-verification] Headers:", {
         host: req.headers.get("host"),
+        origin: req.headers.get("origin"),
         "x-forwarded-host": req.headers.get("x-forwarded-host"),
         "x-forwarded-proto": req.headers.get("x-forwarded-proto"),
       });
@@ -99,10 +77,13 @@ export async function POST(req: Request) {
     // Générer le lien de vérification via Firebase Admin
     let link: string;
     try {
-      link = await adminAuth.generateEmailVerificationLink(email, {
-        url: redirectUrl,
-        handleCodeInApp: false,
-      });
+      link = withActionContinueUrl(
+        await adminAuth.generateEmailVerificationLink(email, {
+          url: redirectUrl,
+          handleCodeInApp: false,
+        }),
+        redirectUrl
+      );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       const authCode = getAuthErrorCode(error);
@@ -140,7 +121,7 @@ export async function POST(req: Request) {
     }
 
     // Log uniquement en mode debug
-    if (process.env.NODE_ENV === "development" && process.env.DEBUG === "true") {
+    if (isAuthOriginDebugEnabled()) {
       console.log("[send-verification] Generated link:", link);
     }
 

--- a/src/lib/auth/resolve-app-origin.test.ts
+++ b/src/lib/auth/resolve-app-origin.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+import {
+  isLocalhostUrl,
+  resolveAppOrigin,
+  withActionContinueUrl,
+} from "./resolve-app-origin";
+
+function requestWithHeaders(headers: Record<string, string>): Request {
+  const normalized = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  return {
+    headers: {
+      get: (name: string) => normalized[name.toLowerCase()] ?? null,
+    },
+  } as Request;
+}
+
+describe("resolveAppOrigin", () => {
+  const originalAppUrl = process.env.APP_URL;
+  const originalPublicUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  afterEach(() => {
+    if (originalAppUrl === undefined) {
+      delete process.env.APP_URL;
+    } else {
+      process.env.APP_URL = originalAppUrl;
+    }
+    if (originalPublicUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+    } else {
+      process.env.NEXT_PUBLIC_APP_URL = originalPublicUrl;
+    }
+  });
+
+  it("prefers non-localhost APP_URL", () => {
+    process.env.APP_URL =
+      "https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app";
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    expect(
+      resolveAppOrigin(
+        requestWithHeaders({
+          origin: "http://localhost:3000",
+        })
+      )
+    ).toBe("https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app");
+  });
+
+  it("uses Origin when env is localhost", () => {
+    process.env.APP_URL = "http://localhost:3000";
+    expect(
+      resolveAppOrigin(
+        requestWithHeaders({
+          origin: "https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app",
+        })
+      )
+    ).toBe("https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app");
+  });
+
+  it("uses forwarded host when env is missing", () => {
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    expect(
+      resolveAppOrigin(
+        requestWithHeaders({
+          "x-forwarded-proto": "https",
+          "x-forwarded-host":
+            "teamup-staging--sqyping-teamup-dev.us-east4.hosted.app",
+        })
+      )
+    ).toBe("https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app");
+  });
+
+  it("falls back to localhost in local dev", () => {
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    expect(
+      resolveAppOrigin(
+        requestWithHeaders({
+          host: "localhost:3000",
+        })
+      )
+    ).toBe("http://localhost:3000");
+  });
+});
+
+describe("isLocalhostUrl", () => {
+  it("detects localhost URLs", () => {
+    expect(isLocalhostUrl("http://localhost:3000/auth")).toBe(true);
+    expect(
+      isLocalhostUrl(
+        "https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("withActionContinueUrl", () => {
+  it("replaces continueUrl in Firebase oob links", () => {
+    const link =
+      "https://sqyping-teamup-dev.firebaseapp.com/__/auth/action?mode=verifyEmail&continueUrl=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fverify-email&oobCode=abc";
+    const updated = withActionContinueUrl(
+      link,
+      "https://teamup-staging--sqyping-teamup-dev.us-east4.hosted.app/auth/verify-email"
+    );
+
+    expect(updated).toContain(
+      "continueUrl=https%3A%2F%2Fteamup-staging--sqyping-teamup-dev.us-east4.hosted.app%2Fauth%2Fverify-email"
+    );
+    expect(updated).not.toContain("localhost");
+  });
+});

--- a/src/lib/auth/resolve-app-origin.ts
+++ b/src/lib/auth/resolve-app-origin.ts
@@ -1,0 +1,73 @@
+function trimTrailingSlash(value: string): string {
+  return value.trim().replace(/\/$/, "");
+}
+
+function isLocalhostHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    return isLocalhostHostname(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * URL publique de l'application pour les liens Auth (emails, redirects).
+ * Priorité : env non-localhost > Origin > headers > env localhost > fallback dev.
+ */
+export function resolveAppOrigin(req: Request): string {
+  const envCandidates = [
+    process.env.APP_URL,
+    process.env.NEXT_PUBLIC_APP_URL,
+  ]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  const nonLocalEnv = envCandidates.find((value) => !isLocalhostUrl(value));
+  if (nonLocalEnv) {
+    return trimTrailingSlash(nonLocalEnv);
+  }
+
+  const originHeader = req.headers.get("origin")?.trim();
+  if (originHeader && !isLocalhostUrl(originHeader)) {
+    return trimTrailingSlash(originHeader);
+  }
+
+  const forwardedProto = req.headers.get("x-forwarded-proto") || "https";
+  const host =
+    req.headers.get("x-forwarded-host")?.trim() ||
+    req.headers.get("host")?.trim();
+
+  if (host && !isLocalhostHostname(host.split(":")[0] ?? host)) {
+    return trimTrailingSlash(`${forwardedProto}://${host}`);
+  }
+
+  if (envCandidates[0]) {
+    return trimTrailingSlash(envCandidates[0]);
+  }
+
+  if (host) {
+    const proto = host.includes("localhost") ? "http" : forwardedProto;
+    return trimTrailingSlash(`${proto}://${host}`);
+  }
+
+  return "http://localhost:3000";
+}
+
+export function isAuthOriginDebugEnabled(): boolean {
+  return process.env.DEBUG === "true";
+}
+
+/** Force le continueUrl des liens Firebase Auth (oob) — le projet dev avait callbackUri=localhost. */
+export function withActionContinueUrl(link: string, continueUrl: string): string {
+  try {
+    const parsed = new URL(link);
+    parsed.searchParams.set("continueUrl", continueUrl);
+    return parsed.toString();
+  } catch {
+    return link;
+  }
+}


### PR DESCRIPTION
## Summary

- Corrige les liens de vérification / reset qui redirigent vers `localhost:3000` depuis staging.
- Cause : `callbackUri` Firebase dev = localhost + résolution d'origine insuffisante.
- Ajoute `resolveAppOrigin` (env non-localhost, Origin, headers) et `withActionContinueUrl` pour forcer le `continueUrl` dans les liens oob.

## Test plan

- [ ] Rollout staging terminé
- [ ] Renvoi email vérification depuis `/club/inscription` → lien avec URL staging dans `continueUrl`
- [ ] Reset password depuis staging → même vérification


Made with [Cursor](https://cursor.com)