### PR TITLE
fix(test): CI resolveAppOrigin avec NEXT_PUBLIC_APP_URL injectée

### DIFF
--- a/src/lib/auth/resolve-app-origin.test.ts
+++ b/src/lib/auth/resolve-app-origin.test.ts
@@ -50,6 +50,8 @@ describe("resolveAppOrigin", () => {
 
   it("uses Origin when env is localhost", () => {
     process.env.APP_URL = "http://localhost:3000";
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
     expect(
       resolveAppOrigin(
         requestWithHeaders({


### PR DESCRIPTION
## Summary

Corrige l'échec CI sur `resolve-app-origin.test.ts` : le workflow injecte `NEXT_PUBLIC_APP_URL` (prod/staging) via les variables GitHub, ce qui masquait le scénario testé (APP_URL localhost + Origin staging).

## Test plan

- [x] `npm test -- --testPathPatterns=resolve-app-origin` avec `NEXT_PUBLIC_APP_URL=https://teamup.sqyping.fr`
- [ ] CI staging verte


Made with [Cursor](https://cursor.com)