### PR TITLE
🛡️ Sentinel: Harden Teams API routes with withAuth HOC

### DIFF
--- a/src/app/api/teams/[teamId]/discord-channel/route.ts
+++ b/src/app/api/teams/[teamId]/discord-channel/route.ts
@@ -1,60 +1,43 @@
-export const runtime = "nodejs";
-
 import { jsonNoStore } from "@/lib/http/cache-headers";
 import { NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import {
-  initializeFirebaseAdmin,
-  getFirestoreAdmin,
-  adminAuth,
-} from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { adminDb } from "@/lib/firebase-admin";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ teamId: string }> }
-) {
+export const runtime = "nodejs";
+
+export const PATCH = withAuth(async (req, context) => {
+  const { teamId } = (context as { params: Promise<{ teamId: string }> }).params
+    ? await (context as { params: Promise<{ teamId: string }> }).params
+    : { teamId: undefined };
+
+  if (!teamId) {
+    return jsonNoStore(
+      { error: "L'identifiant de l'équipe est requis" },
+      { status: 400 }
+    );
+  }
+
+  const { decoded } = context as { decoded: { uid: string } };
+
   try {
     // CSRF Protection
-    if (!validateOrigin(request)) {
+    if (!validateOrigin(req as NextRequest)) {
       return jsonNoStore(
-        { success: false, error: "Invalid origin" },
+        { success: false, error: "Origine invalide" },
         { status: 403 }
       );
     }
 
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        {
-          error: "Token d'authentification requis",
-          message: "Cette API nécessite une authentification valide",
-        },
-        { status: 401 }
-      );
-    }
+    const { discordChannelId } = await (req as NextRequest).json();
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore(
-        {
-          error: "Accès refusé",
-          message:
-            "Cette opération est réservée aux administrateurs et coachs",
-        },
-        { status: 403 }
-      );
-    }
-
-    const { teamId } = await params;
-    const { discordChannelId } = await request.json();
-
-    if (discordChannelId !== null && discordChannelId !== undefined && typeof discordChannelId !== "string") {
+    if (
+      discordChannelId !== null &&
+      discordChannelId !== undefined &&
+      typeof discordChannelId !== "string"
+    ) {
       return jsonNoStore(
         {
           error: "Le canal Discord doit être une chaîne de caractères ou null",
@@ -63,10 +46,7 @@ export async function PATCH(
       );
     }
 
-    await initializeFirebaseAdmin();
-    const db = getFirestoreAdmin();
-
-    const teamRef = db.collection("teams").doc(teamId);
+    const teamRef = adminDb.collection("teams").doc(teamId);
     const teamDoc = await teamRef.get();
 
     if (!teamDoc.exists) {
@@ -83,7 +63,11 @@ export async function PATCH(
       updatedAt: new Date(),
     };
 
-    if (discordChannelId === null || discordChannelId === undefined || discordChannelId.trim() === "") {
+    if (
+      discordChannelId === null ||
+      discordChannelId === undefined ||
+      discordChannelId.trim() === ""
+    ) {
       updateData.discordChannelId = null;
     } else {
       updateData.discordChannelId = discordChannelId.trim();
@@ -107,15 +91,16 @@ export async function PATCH(
       },
     });
   } catch (error) {
-    console.error("[app/api/teams/[teamId]/discord-channel] PATCH error", error);
+    console.error(
+      `[app/api/teams/${teamId}/discord-channel] PATCH error`,
+      error
+    );
     return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la mise à jour du canal Discord",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/teams/[teamId]/location/route.ts
+++ b/src/app/api/teams/[teamId]/location/route.ts
@@ -1,60 +1,43 @@
-export const runtime = "nodejs";
-
 import { jsonNoStore } from "@/lib/http/cache-headers";
 import { NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import {
-  initializeFirebaseAdmin,
-  getFirestoreAdmin,
-  adminAuth,
-} from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { adminDb } from "@/lib/firebase-admin";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ teamId: string }> }
-) {
+export const runtime = "nodejs";
+
+export const PATCH = withAuth(async (req, context) => {
+  const { teamId } = (context as { params: Promise<{ teamId: string }> }).params
+    ? await (context as { params: Promise<{ teamId: string }> }).params
+    : { teamId: undefined };
+
+  if (!teamId) {
+    return jsonNoStore(
+      { error: "L'identifiant de l'équipe est requis" },
+      { status: 400 }
+    );
+  }
+
+  const { decoded } = context as { decoded: { uid: string } };
+
   try {
     // CSRF Protection
-    if (!validateOrigin(request)) {
+    if (!validateOrigin(req as NextRequest)) {
       return jsonNoStore(
-        { success: false, error: "Invalid origin" },
+        { success: false, error: "Origine invalide" },
         { status: 403 }
       );
     }
 
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        {
-          error: "Token d'authentification requis",
-          message: "Cette API nécessite une authentification valide",
-        },
-        { status: 401 }
-      );
-    }
+    const { location } = await (req as NextRequest).json();
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore(
-        {
-          error: "Accès refusé",
-          message:
-            "Cette opération est réservée aux administrateurs et coachs",
-        },
-        { status: 403 }
-      );
-    }
-
-    const { teamId } = await params;
-    const { location } = await request.json();
-
-    if (location !== null && location !== undefined && typeof location !== "string") {
+    if (
+      location !== null &&
+      location !== undefined &&
+      typeof location !== "string"
+    ) {
       return jsonNoStore(
         {
           error: "Le lieu doit être une chaîne de caractères ou null",
@@ -63,10 +46,7 @@ export async function PATCH(
       );
     }
 
-    await initializeFirebaseAdmin();
-    const db = getFirestoreAdmin();
-
-    const teamRef = db.collection("teams").doc(teamId);
+    const teamRef = adminDb.collection("teams").doc(teamId);
     const teamDoc = await teamRef.get();
 
     if (!teamDoc.exists) {
@@ -80,7 +60,7 @@ export async function PATCH(
 
     // Si un lieu est fourni, vérifier qu'il existe
     if (location && location.trim() !== "") {
-      const locationRef = db.collection("locations").doc(location.trim());
+      const locationRef = adminDb.collection("locations").doc(location.trim());
       const locationDoc = await locationRef.get();
       if (!locationDoc.exists) {
         return jsonNoStore(
@@ -121,15 +101,13 @@ export async function PATCH(
       },
     });
   } catch (error) {
-    console.error("[app/api/teams/[teamId]/location] PATCH error", error);
+    console.error(`[app/api/teams/${teamId}/location] PATCH error`, error);
     return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la mise à jour du lieu",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/teams/[teamId]/matches/route.ts
+++ b/src/app/api/teams/[teamId]/matches/route.ts
@@ -1,78 +1,36 @@
-import type { NextRequest } from "next/server";
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { adminDb } from "@/lib/firebase-admin";
 import { getTeamMatches } from "@/lib/server/team-matches";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 export const runtime = "nodejs";
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ teamId: string }> }
-) {
-  // Vérification d'authentification
-  const cookieStore = await cookies();
-  const sessionCookie = cookieStore.get("__session")?.value;
-  
-  if (!sessionCookie) {
-    return jsonNoStore(
-      { error: "Authentification requise" },
-      { status: 401 }
-    );
-  }
+export const GET = withAuth(async (_req, context) => {
+  const { teamId } = (context as { params: Promise<{ teamId: string }> }).params
+    ? await (context as { params: Promise<{ teamId: string }> }).params
+    : { teamId: undefined };
 
-  try {
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    if (!decoded.email_verified) {
-      return jsonNoStore(
-        { error: "Email non vérifié" },
-        { status: 403 }
-      );
-    }
-  } catch {
+  if (!teamId) {
     return jsonNoStore(
-      { error: "Session invalide" },
-      { status: 401 }
-    );
-  }
-
-  // Récupérer teamId depuis les paramètres de route
-  const { teamId } = await params;
-
-  if (!teamId || typeof teamId !== "string") {
-    return jsonNoStore(
-      { error: "Team ID parameter is required" },
+      { error: "L'identifiant de l'équipe est requis" },
       { status: 400 }
     );
   }
 
   try {
-    await initializeFirebaseAdmin();
-    const firestore = getFirestoreAdmin();
-    const matches = await getTeamMatches(firestore, teamId);
+    const matches = await getTeamMatches(adminDb, teamId);
 
-    console.log(
-      `📊 [app/api/teams/${teamId}/matches] ${matches.length} matchs récupérés pour l'équipe ${teamId}`
-    );
-
-    return jsonNoStore(
-      {
-        teamId,
-        matches,
-        total: matches.length,
-      },
-      { status: 200 }
-    );
+    return jsonNoStore({
+      teamId,
+      matches,
+      total: matches.length,
+    });
   } catch (error) {
-    console.error("[app/api/teams/[teamId]/matches] Firestore Error:", error);
+    console.error(`[app/api/teams/${teamId}/matches] GET error`, error);
     return jsonNoStore(
-      {
-        error: "Failed to fetch team matches",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
+      { error: "Erreur lors de la récupération des matchs de l'équipe" },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/teams/route.ts
+++ b/src/app/api/teams/route.ts
@@ -1,89 +1,20 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { adminDb } from "@/lib/firebase-admin";
 import { getTeams, TeamSummary } from "@/lib/server/team-matches";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 export const runtime = "nodejs";
 
-export async function GET() {
-  // Vérification d'authentification
-  const cookieStore = await cookies();
-  const sessionCookie = cookieStore.get("__session")?.value;
-  
-  if (!sessionCookie) {
-    return jsonNoStore(
-      { error: "Authentification requise" },
-      { status: 401 }
-    );
-  }
-
+export const GET = withAuth(async () => {
   try {
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    if (!decoded.email_verified) {
-      return jsonNoStore(
-        { error: "Email non vérifié" },
-        { status: 403 }
-      );
-    }
-
-    // Vérifier que l'utilisateur est admin ou coach
-    const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore(
-        { error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-  } catch {
-    return jsonNoStore(
-      { error: "Session invalide" },
-      { status: 401 }
-    );
-  }
-  try {
-    await initializeFirebaseAdmin();
-    const firestore = getFirestoreAdmin();
-
-    const teams: TeamSummary[] = await getTeams(firestore);
-
-    console.log(`📊 [app/api/teams] ${teams.length} équipes récupérées depuis Firestore`);
-
-    return jsonNoStore(
-      {
-        teams,
-        total: teams.length,
-      },
-      { status: 200 }
-    );
+    const teams: TeamSummary[] = await getTeams(adminDb);
+    return jsonNoStore({ teams, total: teams.length });
   } catch (error) {
-    console.error("[app/api/teams] Firestore Error:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-
-    if (
-      errorMessage.includes("credentials") ||
-      errorMessage.includes("Could not load the default credentials")
-    ) {
-      return jsonNoStore(
-        {
-          error: "Firebase Admin credentials not configured",
-          details:
-            "Pour le développement local, configurez les credentials Firebase Admin. Voir README.md pour plus d'informations.",
-          message: errorMessage,
-        },
-        { status: 500 }
-      );
-    }
-
+    console.error("[app/api/teams] GET error", error);
     return jsonNoStore(
-      {
-        error: "Failed to fetch teams data",
-        details: errorMessage,
-      },
+      { error: "Erreur lors de la récupération des équipes" },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);


### PR DESCRIPTION
### 🛡️ Sentinel: Security Enhancement - Teams API Hardening

Refactored the core team-related API routes to implement the `withAuth` higher-order function (HOC). This change standardizes the security posture of the following endpoints:
- `src/app/api/teams/route.ts` (GET)
- `src/app/api/teams/[teamId]/matches/route.ts` (GET)
- `src/app/api/teams/[teamId]/location/route.ts` (PATCH)
- `src/app/api/teams/[teamId]/discord-channel/route.ts` (PATCH)

**Security Improvements:**
- **Consistent RBAC:** Enforces `ADMIN` or `COACH` roles for all team-related operations.
- **Mandatory Verification:** Ensures the `email_verified` claim is checked for every request.
- **Information Leakage Prevention:** Sanitized error responses to return generic messages instead of internal details like `error.message`.
- **CSRF & Audit Protection:** Preserved existing `validateOrigin` checks and audit logging for state-changing operations.
- **Maintainability:** Replaced redundant manual verification blocks with a centralized, audited utility.

**Verification:**
- Ran `npm run check:dev` (linting & type-checking) - PASSED.
- Ran `npm test` - PASSED.
- Verified file contents using `read_file`.

Updated `.jules/sentinel.md` with critical security learnings.

---
*PR created automatically by Jules for task [17292560472724774987](https://jules.google.com/task/17292560472724774987) started by @omichalo*