### PR TITLE
🛡️ Sentinel: Harden FFTT API routes with withAuth

### DIFF
--- a/src/app/api/fftt/pool-ranking/route.ts
+++ b/src/app/api/fftt/pool-ranking/route.ts
@@ -1,8 +1,6 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import type { NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 import {
   createInitializedFFTTApi,
   resolveEquipeByTeamId,
@@ -32,28 +30,10 @@ export interface PoolRankingEntry {
  * Si phase est fourni (aller|retour), utilise l'équipe FFTT dont la division correspond à cette phase.
  * Réservé aux coachs et admins.
  */
-export async function GET(req: NextRequest) {
+export const GET = withAuth(async (req: Request) => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Authentification requise" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore(
-        { error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
-    const teamId = req.nextUrl.searchParams.get("teamId");
+    const url = new URL(req.url);
+    const teamId = url.searchParams.get("teamId");
     if (!teamId || !teamId.trim()) {
       return jsonNoStore(
         { error: "Paramètre teamId requis" },
@@ -61,7 +41,7 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    const phaseParam = req.nextUrl.searchParams.get("phase");
+    const phaseParam = url.searchParams.get("phase");
     const phase =
       phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
 
@@ -135,4 +115,4 @@ export async function GET(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);

--- a/src/app/api/fftt/pool-schedule/route.ts
+++ b/src/app/api/fftt/pool-schedule/route.ts
@@ -1,8 +1,6 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import type { NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 import {
   createInitializedFFTTApi,
   resolveEquipeByTeamId,
@@ -16,27 +14,15 @@ export const runtime = "nodejs";
  * Calendrier de la poule : toutes les rencontres à venir (données FFTT live).
  * Réservé aux coachs et admins.
  */
-export async function GET(req: NextRequest) {
+export const GET = withAuth(async (req: Request) => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
-      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
-    }
-
-    const teamId = req.nextUrl.searchParams.get("teamId");
+    const url = new URL(req.url);
+    const teamId = url.searchParams.get("teamId");
     if (!teamId?.trim()) {
       return jsonNoStore({ error: "Paramètre teamId requis" }, { status: 400 });
     }
 
-    const phaseParam = req.nextUrl.searchParams.get("phase");
+    const phaseParam = url.searchParams.get("phase");
     const phase =
       phaseParam === "retour" || phaseParam === "aller" ? phaseParam : null;
 
@@ -60,4 +46,4 @@ export async function GET(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN, USER_ROLES.COACH]);


### PR DESCRIPTION
🛡️ Sentinel: Harden FFTT API routes with withAuth

I have identified that some FFTT-related API routes were bypassing the project's security standard of verifying the `email_verified` claim in the session token. These routes were using manual authentication logic, which was inconsistent with the rest of the application.

### Changes:
- **Refactored `src/app/api/fftt/pool-ranking/route.ts`**: Replaced manual auth with `withAuth` HOC, enforcing `ADMIN`/`COACH` roles and mandatory email verification.
- **Refactored `src/app/api/fftt/pool-schedule/route.ts`**: Replaced manual auth with `withAuth` HOC, enforcing `ADMIN`/`COACH` roles and mandatory email verification.
- **Security Journaling**: Created/Updated `.jules/sentinel.md` with critical learnings about standardized API hardening in this codebase.

### Security Impact:
- **Email Verification Enforcement**: Prevents users with unverified emails from accessing sensitive match and ranking data.
- **Consistency**: Centralizes authentication logic, making it easier to maintain and audit.
- **Standardized Error Responses**: Ensures that authentication and authorization failures return consistent, non-leaking error messages.

### Verification:
- Ran `npm run check:dev` (linting, type-checking).
- Ran `npm test` (full suite passed).
- Verified file contents after modification.

---
*PR created automatically by Jules for task [15615273267891413399](https://jules.google.com/task/15615273267891413399) started by @omichalo*