### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden registration manager authentication

### DIFF
--- a/src/lib/club-registration/payment/api-auth.ts
+++ b/src/lib/club-registration/payment/api-auth.ts
@@ -14,11 +14,22 @@ export async function requireRegistrationManager(): Promise<
     return { ok: false, status: 401, error: "Authentification requise" };
   }
 
-  const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-  const role = resolveRole(decoded.role as string | undefined);
-  if (!hasAnyRole(role, REGISTRATION_MANAGER_ROLES)) {
-    return { ok: false, status: 403, error: "Accès refusé" };
-  }
+  try {
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
 
-  return { ok: true, uid: decoded.uid };
+    // Security: Enforce email verification for all administrative actions
+    // to prevent access from unverified or potentially malicious accounts.
+    if (!decoded.email_verified) {
+      return { ok: false, status: 403, error: "Email non vérifié" };
+    }
+
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, REGISTRATION_MANAGER_ROLES)) {
+      return { ok: false, status: 403, error: "Accès refusé" };
+    }
+
+    return { ok: true, uid: decoded.uid };
+  } catch {
+    return { ok: false, status: 401, error: "Session invalide" };
+  }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `requireRegistrationManager` auth helper was missing a check for the `email_verified` claim and did not gracefully handle session verification failures.
🎯 Impact: This could allow users with unverified emails to perform administrative payment actions if they had the required role, and might result in 500 errors instead of proper 401 responses for invalid sessions.
🔧 Fix: Updated the helper to explicitly verify the `email_verified` claim and wrapped the session verification in a try-catch block.
✅ Verification: Ran `npm test` (all 321 tests passed) and manually verified the code logic.

---
*PR created automatically by Jules for task [12414230635758843536](https://jules.google.com/task/12414230635758843536) started by @omichalo*