### PR TITLE
🛡️ Sentinel: harden Firestore rules with mandatory email verification

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,11 @@ service cloud.firestore {
     function isAuthenticated() {
       return request.auth != null;
     }
+
+    // Vérifie si l'utilisateur a un email vérifié
+    function isVerified() {
+      return isAuthenticated() && request.auth.token.email_verified == true;
+    }
     
     // Récupère le rôle de l'utilisateur depuis les custom claims
     function authRole() {
@@ -19,21 +24,21 @@ service cloud.firestore {
     
     // Vérifie si l'utilisateur est admin
     function isAdmin() {
-      return authRole() == "admin";
+      return isVerified() && authRole() == "admin";
     }
     
     // Vérifie si l'utilisateur est coach ou admin
     function isCoach() {
-      return isAdmin() || authRole() == "coach";
+      return isAdmin() || (isVerified() && authRole() == "coach");
     }
 
     // Secrétariat (gestion des dossiers d'inscription côté client limitée ; API Admin SDK en prod)
     function isSecretary() {
-      return authRole() == "secretary";
+      return isVerified() && authRole() == "secretary";
     }
 
     function isClubRegistrationManager() {
-      return isAdmin() || isSecretary();
+      return isVerified() && (isAdmin() || isSecretary());
     }
     
     // ============================================


### PR DESCRIPTION
Hardened Firestore security rules by requiring mandatory email verification for all privileged roles (Admin, Coach, Secretary, and Club Registration Manager). Added a journal entry in `.jules/sentinel.md` documenting this security enhancement.

---
*PR created automatically by Jules for task [13744045329067967928](https://jules.google.com/task/13744045329067967928) started by @omichalo*