### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden sync-status API route

### DIFF
--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,35 +1,18 @@
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+
 export const runtime = "nodejs";
 
-import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
-
-export async function GET() {
+/**
+ * GET /api/admin/sync-status
+ *
+ * Returns the last synchronization status for players, teams and matches.
+ * Restricted to ADMIN role.
+ */
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
-        },
-        { status: 403 }
-      );
-    }
-
     console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
 
     await initializeFirebaseAdmin();
@@ -75,15 +58,13 @@ export async function GET() {
     );
   } catch (error) {
     console.error("❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:", error);
+    // Secure error response: do not leak internal error message details
     return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN]);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure and manual auth logic. The `sync-status` API was leaking internal error details (`error.message`) and using manual authentication/authorization boilerplate.
🎯 Impact: Attackers could gain insights into the server's internal state or database structure through error messages. Manual auth logic is more prone to implementation errors.
🔧 Fix: Refactored the route to use the `withAuth` HOC, which enforces session verification, the `email_verified` claim, and the `ADMIN` role while sanitizing error responses.
✅ Verification: Verified via `read_file` that the HOC is correctly implemented and error details are removed. Ran `npm run check:dev` and `npm test` to ensure no regressions.

---
*PR created automatically by Jules for task [6934068885505157016](https://jules.google.com/task/6934068885505157016) started by @omichalo*