### PR TITLE
🛡️ Sentinel: Harden sync-teams API and prevent info leakage

### DIFF
--- a/src/app/api/admin/sync-teams/route.ts
+++ b/src/app/api/admin/sync-teams/route.ts
@@ -1,42 +1,25 @@
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import { syncTeams } from "@/lib/shared/sync-utils";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
 import {
   enforceRateLimit,
   RATE_LIMIT_ADMIN_SYNC_PER_UID,
 } from "@/lib/auth/rate-limit-http";
+import { withAuth } from "@/lib/auth/api-utils";
+import type { DecodedIdToken } from "firebase-admin/auth";
 
 export const runtime = "nodejs";
 
-export async function POST(req: NextRequest) {
+export const POST = withAuth(async (req: Request, context: unknown) => {
+  const { decoded } = context as { decoded: DecodedIdToken };
+
   try {
     if (!validateOrigin(req)) {
       return jsonNoStore(
         { error: "Invalid origin", message: "Requête non autorisée" },
-        { status: 403 }
-      );
-    }
-
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Token d'authentification requis", message: "Cette API nécessite une authentification valide" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        { error: "Accès refusé", message: "Cette opération est réservée aux administrateurs" },
         { status: 403 }
       );
     }
@@ -82,9 +65,8 @@ export async function POST(req: NextRequest) {
       {
         success: false,
         error: "Erreur lors de la synchronisation des équipes",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN]);


### PR DESCRIPTION
This PR hardens the `/api/admin/sync-teams` endpoint by refactoring it to use the centralized `withAuth` higher-order function. This ensures that only users with the `ADMIN` role and a verified email can access the endpoint. Additionally, internal error details are no longer leaked in the API response, preventing potential information disclosure.

🚨 Severity: MEDIUM
💡 Vulnerability: Information Leakage & Inconsistent Auth Logic
🎯 Impact: Attackers could potentially gain insights into system internals from error messages.
🔧 Fix: Implemented `withAuth` and sanitized error responses.
✅ Verification: Ran `npm run check:dev` and `npm test`. Verified file content manually.

---
*PR created automatically by Jules for task [11982854328743219367](https://jules.google.com/task/11982854328743219367) started by @omichalo*