### PR TITLE
🛡️ Sentinel: Harden sync-status admin API route

### DIFF
--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,38 +1,12 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { withAuth } from "@/lib/auth/api-utils";
+import { USER_ROLES } from "@/lib/auth/roles";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
-        },
-        { status: 403 }
-      );
-    }
-
-    console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
-
-    await initializeFirebaseAdmin();
     const db = getFirestoreAdmin();
 
     const [metadataDoc, playersSnapshot, teamsSnapshot] = await Promise.all([
@@ -45,10 +19,6 @@ export async function GET() {
     const playersCount = playersSnapshot.size;
     const teamsCount = teamsSnapshot.size;
     const teamMatchesCount = metadata?.teamMatchesCount || 0;
-
-    console.log(
-      `✅ Statut récupéré: ${playersCount} joueurs, ${teamsCount} équipes, ${teamMatchesCount} matchs par équipe`
-    );
 
     return jsonNoStore(
       {
@@ -74,16 +44,13 @@ export async function GET() {
       { status: 200 }
     );
   } catch (error) {
-    console.error("❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:", error);
+    console.error("❌ [app/api/admin/sync-status] Erreur:", error);
     return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN]);


### PR DESCRIPTION
This PR hardens the `sync-status` administrative API route.

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The endpoint used manual authentication logic that bypassed the project's standard `email_verified` check and leaked internal error details (`error.message`) in 500 responses.
🎯 **Impact:** Unverified users with administrative roles could access sync metadata, and attackers could use leaked error details for reconnaissance.
🔧 **Fix:** Refactored the route to use the `withAuth` higher-order function, which enforces centralized authentication, the `email_verified` claim, and the `ADMIN` role while ensuring sanitized error responses.
✅ **Verification:** Verified the file content with `read_file`, and confirmed that `npm run check:dev` and `npm test` pass successfully.

---
*PR created automatically by Jules for task [14299640793278529465](https://jules.google.com/task/14299640793278529465) started by @omichalo*