### PR TITLE
🛡️ Sentinel: [security enhancement] Harden admin users API route with withAuth HOC

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,32 +1,18 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { DocumentData, QueryDocumentSnapshot, Query } from "firebase-admin/firestore";
+import type {
+  DocumentData,
+  QueryDocumentSnapshot,
+  Query,
+} from "firebase-admin/firestore";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
+import { USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
 import type { User } from "@/types";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        { success: false, error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
     const firestore = getFirestoreAdmin();
 
     // Récupérer tous les utilisateurs avec pagination
@@ -173,6 +159,6 @@ export async function GET() {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN]);
 
 


### PR DESCRIPTION
I have refactored the administrative user listing API route (`src/app/api/admin/users/route.ts`) to use the `withAuth` higher-order function. This change aligns the endpoint with the project's security standards, ensuring that only authenticated administrators with verified emails can access the user list. It also simplifies the codebase by removing manual session verification and role-checking logic.

Verification:
- `npm run check:dev` passed (linting, type-checking, file-size check).
- `npm test` passed (all 321 tests).
- Manual code review confirmed the refactor correctly preserves existing functionality while improving security.

---
*PR created automatically by Jules for task [7504171696368062207](https://jules.google.com/task/7504171696368062207) started by @omichalo*