### PR TITLE
🛡️ Sentinel: Fix [Information Leakage] in sync-status API

### DIFF
--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,35 +1,12 @@
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+
 export const runtime = "nodejs";
 
-import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
-
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
-        },
-        { status: 403 }
-      );
-    }
-
     console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
 
     await initializeFirebaseAdmin();
@@ -79,11 +56,8 @@ export async function GET() {
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN]);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `sync-status` administrative API route was using manual authentication logic that lacked the `email_verified` claim check and was leaking internal system details (`error.message`) in 500 error responses.
🎯 Impact: An attacker could potentially gain insights into the system's internal implementation or state by observing raw error messages. Additionally, users with unverified emails could access administrative sync metadata.
🔧 Fix: Refactored the route to use the project's `withAuth` HOC, which centralizes session verification, enforces the `ADMIN` role, checks for verified emails, and provides generic error responses.
✅ Verification: Ran `npm run check:dev` (lint/type-check) and `npm test`. Verified the source code of the refactored route.

---
*PR created automatically by Jules for task [17355749169440621902](https://jules.google.com/task/17355749169440621902) started by @omichalo*