### PR TITLE
merge(staging): intégrer justificatif paiement non-Stripe (#351)

### DIFF
--- a/src/app/api/club/registration/[id]/invoice/route.ts
+++ b/src/app/api/club/registration/[id]/invoice/route.ts
@@ -5,12 +5,40 @@ import { jsonNoStore } from "@/lib/http/cache-headers";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
 import { resolveRole } from "@/lib/auth/roles";
 import { canAccessClubRegistration } from "@/lib/club-registration/registration-access";
+import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
+import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
 import {
+  createPaidOutOfBandInvoice,
   pickInvoiceDownloadUrl,
   retrieveStripeInvoiceLinks,
 } from "@/lib/club-registration/stripe";
 
 const COLLECTION = "clubRegistrations";
+
+function resolveInvoiceEmail(data: Record<string, unknown>): string | null {
+  const adherentEmail =
+    typeof data.adherentEmail === "string" ? data.adherentEmail.trim() : "";
+  if (adherentEmail.includes("@")) return adherentEmail;
+
+  const submitterEmail =
+    typeof data.submitterAccountEmail === "string"
+      ? data.submitterAccountEmail.trim()
+      : "";
+  if (submitterEmail.includes("@")) return submitterEmail;
+
+  return null;
+}
+
+function resolveInvoiceAmountCents(data: Record<string, unknown>): number {
+  if (typeof data.paymentAmountCents === "number" && data.paymentAmountCents > 0) {
+    return data.paymentAmountCents;
+  }
+  const payment = normalizeRegistrationPayment(data);
+  if (payment?.amountToPayCents && payment.amountToPayCents > 0) {
+    return payment.amountToPayCents;
+  }
+  return 0;
+}
 
 /**
  * GET /api/club/registration/[id]/invoice
@@ -45,26 +73,57 @@ export async function GET(
       return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
     }
 
-    const invoiceId =
+    let invoiceId =
       typeof data.stripeInvoiceId === "string" ? data.stripeInvoiceId : null;
-    if (!invoiceId) {
-      return jsonNoStore(
-        {
-          error:
-            "Aucune facture n’est encore disponible pour ce dossier. Réessayez dans quelques minutes ou contactez le secrétariat.",
-        },
-        { status: 404 }
-      );
-    }
-
-    const isPaid =
-      data.status === "paid" ||
-      data.paymentStatus === "paid" ||
-      data.paymentStatus === "complete";
+    const isPaid = isRegistrationPaidRecord(data);
     if (!isPaid) {
       return jsonNoStore(
         { error: "La facture est disponible après confirmation du paiement." },
         { status: 403 }
+      );
+    }
+
+    if (!invoiceId) {
+      const email = resolveInvoiceEmail(data);
+      if (!email) {
+        return jsonNoStore(
+          { error: "Aucun e-mail de contact pour générer la facture Stripe." },
+          { status: 400 }
+        );
+      }
+
+      const amountCents = resolveInvoiceAmountCents(data);
+      if (amountCents <= 0) {
+        return jsonNoStore(
+          { error: "Montant invalide pour générer la facture Stripe." },
+          { status: 400 }
+        );
+      }
+
+      const adherentName =
+        `${typeof data.firstName === "string" ? data.firstName : ""} ${
+          typeof data.lastName === "string" ? data.lastName : ""
+        }`.trim() || "adhérent";
+
+      const created = await createPaidOutOfBandInvoice({
+        registrationId: id,
+        customerEmail: email,
+        amountCents,
+        description: `Adhésion SQY Ping — ${adherentName}`,
+      });
+      invoiceId = created.invoiceId;
+      await db.collection(COLLECTION).doc(id).set(
+        {
+          stripeInvoiceId: invoiceId,
+        },
+        { merge: true }
+      );
+    }
+
+    if (!invoiceId) {
+      return jsonNoStore(
+        { error: "La facture Stripe n'a pas pu être générée." },
+        { status: 502 }
       );
     }
 

--- a/src/app/api/club/registrations/route.ts
+++ b/src/app/api/club/registrations/route.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
 import { normalizeMedicalCertificateStatus } from "@/lib/club-registration/medical-certificate";
+import { hasPaymentProofAvailable } from "@/lib/club-registration/payment-proof";
 
 const COLLECTION = "clubRegistrations";
 const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
@@ -94,8 +95,7 @@ export async function GET(req: Request) {
         summary.paymentRequestedAt =
           data.paymentRequestedAt?.toDate?.()?.toISOString?.() ?? null;
         summary.paidAt = data.paidAt?.toDate?.()?.toISOString?.() ?? null;
-        summary.invoiceAvailable =
-          typeof data.stripeInvoiceId === "string" && data.stripeInvoiceId.length > 0;
+        summary.invoiceAvailable = hasPaymentProofAvailable(data);
         return { summary, submittedAtMs };
       })
       .sort((a, b) => b.submittedAtMs - a.submittedAtMs)

--- a/src/app/joueur/page.tsx
+++ b/src/app/joueur/page.tsx
@@ -1,203 +1,93 @@
 "use client";
 
-import React, { useState } from "react";
 import {
   Box,
   Typography,
   Card,
   CardContent,
   Button,
-  Alert,
-  TextField,
   Stack,
-  CircularProgress,
-  Chip,
-  Divider,
+  CardActions,
 } from "@mui/material";
+import Grid from "@mui/material/GridLegacy";
+import {
+  Description as DescriptionIcon,
+  EventAvailable as EventAvailableIcon,
+  SportsTennis as SportsTennisIcon,
+} from "@mui/icons-material";
+import Link from "next/link";
 import { AuthGuard } from "@/components/AuthGuard";
-import { useAuth } from "@/hooks/useAuth";
-import { USER_ROLES, COACH_REQUEST_STATUS } from "@/lib/auth/roles";
+import { USER_ROLES } from "@/lib/auth/roles";
 
 export default function PlayerHomePage() {
-  const { user, refreshUser } = useAuth();
-  const [message, setMessage] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-
-  const handleRequestCoach = async () => {
-    if (!user) {
-      return;
-    }
-
-    setSubmitting(true);
-    setError(null);
-    setSuccess(null);
-
-    try {
-      const response = await fetch("/api/coach/request", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ message }),
-      });
-
-      if (!response.ok) {
-        const payload = await response.json().catch(() => null);
-        throw new Error(payload?.error || "Impossible d'envoyer la demande");
-      }
-
-      setSuccess("Votre demande a bien été enregistrée.");
-      setMessage("");
-      await refreshUser();
-    } catch (err) {
-      setError(
-        err instanceof Error
-          ? err.message
-          : "Une erreur est survenue. Veuillez réessayer."
-      );
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const isPending = user?.coachRequestStatus === COACH_REQUEST_STATUS.PENDING;
-  const isApproved =
-    user?.coachRequestStatus === COACH_REQUEST_STATUS.APPROVED ||
-    user?.role === USER_ROLES.COACH;
-  const isRejected = user?.coachRequestStatus === COACH_REQUEST_STATUS.REJECTED;
-  const hasRequest = user?.coachRequestStatus && user.coachRequestStatus !== COACH_REQUEST_STATUS.NONE;
+  const quickActions = [
+    {
+      title: "Nouvelle inscription",
+      description:
+        "Créer un nouveau dossier d'adhésion pour vous ou un membre de votre foyer.",
+      href: "/club/inscription",
+      cta: "Démarrer une inscription",
+      icon: <DescriptionIcon color="primary" />,
+    },
+    {
+      title: "Mes inscriptions",
+      description:
+        "Suivre l'avancement de vos dossiers et vérifier les informations transmises.",
+      href: "/club/mes-inscriptions",
+      cta: "Voir mes dossiers",
+      icon: <EventAvailableIcon color="primary" />,
+    },
+  ] as const;
 
   return (
-    <AuthGuard allowedRoles={[USER_ROLES.PLAYER, USER_ROLES.COACH, USER_ROLES.ADMIN]}>
-      <Box sx={{ p: 5, maxWidth: 720, mx: "auto" }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Bienvenue sur l&apos;espace joueur
-          </Typography>
-
-          <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-            Depuis cette page, vous pouvez suivre l&apos;actualité du club et, si
-            vous souhaitez participer à l&apos;organisation, demander des droits
-            d&apos;entraîneur.
-          </Typography>
-
-          <Card sx={{ mb: 3 }}>
-            <CardContent>
-              <Stack spacing={2}>
-                <Typography variant="subtitle1">
-                  Demander les droits d&apos;entraîneur
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Les droits coach permettent de gérer les compositions,
-                  disponibilités et l&apos;organisation des rencontres. Un
-                  administrateur examinera votre demande.
-                </Typography>
-
-                {hasRequest && (
-                  <>
-                    <Divider />
-                    <Box>
-                      <Typography variant="subtitle2" gutterBottom>
-                        Statut de votre demande
-                      </Typography>
-                      <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
-                        <Chip
-                          label={
-                            isPending
-                              ? "En attente"
-                              : isApproved
-                              ? "Acceptée"
-                              : isRejected
-                              ? "Refusée"
-                              : "Aucune demande"
-                          }
-                          color={
-                            isPending
-                              ? "warning"
-                              : isApproved
-                              ? "success"
-                              : isRejected
-                              ? "error"
-                              : "default"
-                          }
-                          variant="outlined"
-                        />
-                        {user?.coachRequestUpdatedAt && (
-                          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: "center" }}>
-                            {new Date(user.coachRequestUpdatedAt).toLocaleDateString("fr-FR", {
-                              day: "numeric",
-                              month: "long",
-                              year: "numeric",
-                            })}
-                          </Typography>
-                        )}
-                      </Box>
-                      {user?.coachRequestMessage && (
-                        <Box sx={{ mt: 1, p: 2, bgcolor: "action.hover", borderRadius: 1 }}>
-                          <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
-                            Votre message :
-                          </Typography>
-                          <Typography variant="body2">{user.coachRequestMessage}</Typography>
-                        </Box>
-                      )}
-                    </Box>
-                    <Divider />
-                  </>
-                )}
-
-                {isApproved ? (
-                  <Alert severity="success">
-                    Votre demande de droits coach a été acceptée. Veuillez vous
-                    reconnecter pour accéder aux fonctionnalités avancées.
-                  </Alert>
-                ) : (
-                  <>
-                    {error && <Alert severity="error">{error}</Alert>}
-                    {success && <Alert severity="success">{success}</Alert>}
-
-                    <TextField
-                      label="Message (optionnel)"
-                      placeholder="Expliquez pourquoi vous souhaitez obtenir les droits coach"
-                      multiline
-                      minRows={3}
-                      value={message}
-                      onChange={(event) => setMessage(event.target.value)}
-                      disabled={submitting || isPending}
-                    />
-
-                    <Button
-                      variant="contained"
-                      onClick={handleRequestCoach}
-                      disabled={submitting || isPending || isApproved}
-                      startIcon={submitting ? <CircularProgress size={20} color="inherit" /> : null}
-                    >
-                      {submitting
-                        ? "Envoi en cours..."
-                        : isPending
-                        ? "Demande en cours de traitement"
-                        : "Demander les droits coach"}
-                    </Button>
-                  </>
-                )}
-              </Stack>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Que puis-je faire en tant que joueur ?
+    <AuthGuard
+      allowedRoles={[
+        USER_ROLES.PLAYER,
+        USER_ROLES.SECRETARY,
+        USER_ROLES.COACH,
+        USER_ROLES.ADMIN,
+      ]}
+    >
+      <Box sx={{ p: { xs: 3, sm: 4 }, maxWidth: 980, mx: "auto" }}>
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1.5 }}>
+              <SportsTennisIcon color="primary" />
+              <Typography variant="h4" component="h1">
+                Bienvenue sur TeamUp
               </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Pour le moment, l&apos;espace joueur est limité. Vous pouvez demander
-                des droits supplémentaires via le formulaire ci-dessus pour
-                accéder à l&apos;outil de préparation des compositions et suivre les
-                disponibilités.
-              </Typography>
-            </CardContent>
-          </Card>
-        </Box>
+            </Stack>
+            <Typography variant="body1" color="text.secondary">
+              Cet espace est votre point d&apos;entrée pour la vie du club. Vous pouvez
+              lancer une inscription, suivre vos dossiers et retrouver rapidement vos
+              démarches administratives.
+            </Typography>
+          </CardContent>
+        </Card>
+
+        <Grid container spacing={2}>
+          {quickActions.map((action) => (
+            <Grid item xs={12} md={6} key={action.title}>
+              <Card sx={{ height: "100%" }}>
+                <CardContent>
+                  <Stack spacing={1.5}>
+                    {action.icon}
+                    <Typography variant="h6">{action.title}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {action.description}
+                    </Typography>
+                  </Stack>
+                </CardContent>
+                <CardActions sx={{ px: 2, pb: 2 }}>
+                  <Button component={Link} href={action.href} variant="contained">
+                    {action.cta}
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
     </AuthGuard>
   );
 }

--- a/src/lib/auth/resolve-app-origin.test.ts
+++ b/src/lib/auth/resolve-app-origin.test.ts
@@ -115,6 +115,7 @@ describe("resolveAppOrigin", () => {
   it("keeps localhost when env is localhost and request is local", () => {
     process.env.APP_URL = "http://localhost:3000";
     process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "sqyping-teamup-dev";
+    delete process.env.NEXT_PUBLIC_APP_URL;
 
     expect(
       resolveAppOrigin(

--- a/src/lib/club-registration/payment-proof.test.ts
+++ b/src/lib/club-registration/payment-proof.test.ts
@@ -1,0 +1,18 @@
+import {
+  hasPaymentProofAvailable,
+  isRegistrationPaidRecord,
+} from "@/lib/club-registration/payment-proof";
+
+describe("payment-proof", () => {
+  it("considère une preuve disponible avec facture Stripe", () => {
+    expect(hasPaymentProofAvailable({ stripeInvoiceId: "in_123" })).toBe(true);
+  });
+
+  it("considère une preuve disponible pour un dossier payé sans Stripe", () => {
+    expect(hasPaymentProofAvailable({ status: "paid" })).toBe(true);
+  });
+
+  it("refuse une preuve si le dossier n'est pas payé", () => {
+    expect(isRegistrationPaidRecord({ status: "payment_requested" })).toBe(false);
+  });
+});

--- a/src/lib/club-registration/payment-proof.ts
+++ b/src/lib/club-registration/payment-proof.ts
@@ -1,0 +1,19 @@
+type RegistrationRecord = Record<string, unknown>;
+
+export function isRegistrationPaidRecord(data: RegistrationRecord): boolean {
+  return (
+    data.status === "paid" ||
+    data.paymentStatus === "paid" ||
+    data.paymentStatus === "complete"
+  );
+}
+
+export function hasStripeInvoiceId(data: RegistrationRecord): boolean {
+  return (
+    typeof data.stripeInvoiceId === "string" && data.stripeInvoiceId.trim().length > 0
+  );
+}
+
+export function hasPaymentProofAvailable(data: RegistrationRecord): boolean {
+  return hasStripeInvoiceId(data) || isRegistrationPaidRecord(data);
+}

--- a/src/lib/club-registration/stripe.ts
+++ b/src/lib/club-registration/stripe.ts
@@ -125,6 +125,34 @@ export type StripeInvoiceLinks = {
   invoicePdf: string | null;
 };
 
+type StripeInvoice = {
+  id: string;
+  hosted_invoice_url?: string | null;
+  invoice_pdf?: string | null;
+  error?: { message?: string };
+};
+
+async function postStripeForm<T>(
+  path: string,
+  body: URLSearchParams
+): Promise<T & { error?: { message?: string } }> {
+  const response = await fetch(`https://api.stripe.com${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${requireEnv("STRIPE_SECRET_KEY")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+    cache: "no-store",
+  });
+
+  const json = (await response.json()) as T & { error?: { message?: string } };
+  if (!response.ok) {
+    throw new Error(json.error?.message ?? "Erreur Stripe");
+  }
+  return json;
+}
+
 /** Récupère les URLs publiques Stripe pour consulter / télécharger une facture. */
 export async function retrieveStripeInvoiceLinks(
   invoiceId: string
@@ -153,6 +181,55 @@ export async function retrieveStripeInvoiceLinks(
     hostedInvoiceUrl: json.hosted_invoice_url ?? null,
     invoicePdf: json.invoice_pdf ?? null,
   };
+}
+
+/**
+ * Crée une facture Stripe "payée hors ligne" pour les encaissements manuels.
+ * Permet d'avoir un format de facture homogène (Checkout + hors Checkout).
+ */
+export async function createPaidOutOfBandInvoice(params: {
+  registrationId: string;
+  customerEmail: string;
+  amountCents: number;
+  description: string;
+}): Promise<{ invoiceId: string }> {
+  if (params.amountCents <= 0) {
+    throw new Error("Montant de facture invalide");
+  }
+
+  const customerBody = new URLSearchParams();
+  customerBody.set("email", params.customerEmail);
+  customerBody.set("metadata[registrationId]", params.registrationId);
+  const customer = await postStripeForm<{ id: string }>("/v1/customers", customerBody);
+
+  const invoiceItemBody = new URLSearchParams();
+  invoiceItemBody.set("customer", customer.id);
+  invoiceItemBody.set("currency", "eur");
+  invoiceItemBody.set("amount", String(params.amountCents));
+  invoiceItemBody.set("description", `Adhésion SQY Ping — dossier ${params.registrationId}`);
+  await postStripeForm<{ id: string }>("/v1/invoiceitems", invoiceItemBody);
+
+  const invoiceBody = new URLSearchParams();
+  invoiceBody.set("customer", customer.id);
+  invoiceBody.set("description", params.description);
+  invoiceBody.set("collection_method", "send_invoice");
+  invoiceBody.set("auto_advance", "false");
+  invoiceBody.set("metadata[registrationId]", params.registrationId);
+  const draftInvoice = await postStripeForm<StripeInvoice>("/v1/invoices", invoiceBody);
+
+  const finalizedInvoice = await postStripeForm<StripeInvoice>(
+    `/v1/invoices/${encodeURIComponent(draftInvoice.id)}/finalize`,
+    new URLSearchParams()
+  );
+
+  const payBody = new URLSearchParams();
+  payBody.set("paid_out_of_band", "true");
+  const paidInvoice = await postStripeForm<StripeInvoice>(
+    `/v1/invoices/${encodeURIComponent(finalizedInvoice.id)}/pay`,
+    payBody
+  );
+
+  return { invoiceId: paidInvoice.id };
 }
 
 /** URL à ouvrir côté adhérent : PDF si disponible, sinon page hébergée Stripe. */


### PR DESCRIPTION
## Summary
- Résout les conflits de #351 après merge de #349 sur `staging`.
- Conserve `list-registrations` et branche `invoiceAvailable` sur `hasPaymentProofAvailable`.

## Test plan
- [x] `npm run check:dev`
- [ ] Vérifier téléchargement justificatif sur dossier payé sans invoice Stripe.

Made with [Cursor](https://cursor.com)