### PR TITLE
fix(build): inclure les PDF club-registration dans l'artefact standalone

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -107,7 +107,7 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, icon.png, icon.svg, apple-icon.png, apple-icon.svg (favicon files)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico|icon.png|icon.svg|apple-icon.png|apple-icon.svg).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|icon.png|icon.svg|apple-icon.png|apple-icon.svg|club-registration/).*)",
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "next dev",
     "dev:no-turbo": "next dev",
     "build": "next build",
+    "postbuild": "node scripts/prepare-standalone.mjs",
     "deploy:firestore:prod": "firebase deploy --only firestore:rules,firestore:indexes --project sqyping-teamup",
     "deploy:firestore:dev": "firebase deploy --only firestore:rules,firestore:indexes --project sqyping-teamup-dev",
     "build:strict": "tsc --noEmit && next build",

--- a/scripts/prepare-standalone.mjs
+++ b/scripts/prepare-standalone.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Complète l'artefact Next.js standalone pour App Hosting / Docker.
+ *
+ * En mode `output: "standalone"`, Next.js ne trace que les fichiers `public/`
+ * référencés au build (ex. logo). Les PDF et autres assets statiques non
+ * importés doivent être recopiés explicitement — cf. doc Next.js standalone.
+ */
+
+import { cpSync, existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+const REPO_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const STANDALONE_DIR = join(REPO_ROOT, ".next", "standalone");
+
+if (!existsSync(STANDALONE_DIR)) {
+  console.log("[prepare-standalone] Pas de dossier standalone — skip.");
+  process.exit(0);
+}
+
+const copies = [
+  {
+    from: join(REPO_ROOT, "public"),
+    to: join(STANDALONE_DIR, "public"),
+    label: "public/",
+  },
+  {
+    from: join(REPO_ROOT, ".next", "static"),
+    to: join(STANDALONE_DIR, ".next", "static"),
+    label: ".next/static/",
+  },
+];
+
+for (const { from, to, label } of copies) {
+  if (!existsSync(from)) {
+    throw new Error(`[prepare-standalone] Source introuvable: ${from}`);
+  }
+  cpSync(from, to, { recursive: true });
+  console.log(`[prepare-standalone] Copié ${label} → ${to.replace(REPO_ROOT, ".")}`);
+}
+
+const requiredPublicAssets = [
+  "club-registration/questionnaire-medical-majeur.pdf",
+  "club-registration/questionnaire-medical-mineur.pdf",
+  "club-registration/reglement-interieur-sqy-ping-2019.pdf",
+];
+
+for (const asset of requiredPublicAssets) {
+  const target = join(STANDALONE_DIR, "public", asset);
+  if (!existsSync(target)) {
+    throw new Error(`[prepare-standalone] Asset manquant après copie: ${asset}`);
+  }
+}
+
+console.log("[prepare-standalone] Artefact standalone prêt.");


### PR DESCRIPTION
## Summary
- Ajoute `scripts/prepare-standalone.mjs` exécuté en `postbuild` pour recopier `public/` et `.next/static/` dans l'artefact Next.js standalone.
- Corrige les 404 sur `/club-registration/*.pdf` en prod/staging (App Hosting ne déployait que les assets public référencés au build, ex. le logo).
- Exclut `/club-registration/` du middleware pour servir les PDF sans passage auth.

## Test plan
- [x] `npm run check` (lint, file-sizes, type-check, tests, build + postbuild)
- [x] Serveur standalone local : `curl -I http://localhost:3998/club-registration/questionnaire-medical-majeur.pdf` → 200 + `application/pdf`
- [ ] Après déploiement staging : vérifier les 3 PDF (`questionnaire-medical-majeur.pdf`, `questionnaire-medical-mineur.pdf`, `reglement-interieur-sqy-ping-2019.pdf`)
- [ ] Après release main : même vérification sur https://teamup.sqyping.fr


Made with [Cursor](https://cursor.com)