### PR TITLE
release: club-registration, PDF standalone et correctifs staging

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -107,7 +107,7 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, icon.png, icon.svg, apple-icon.png, apple-icon.svg (favicon files)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico|icon.png|icon.svg|apple-icon.png|apple-icon.svg).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|icon.png|icon.svg|apple-icon.png|apple-icon.svg|club-registration/).*)",
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "next dev",
     "dev:no-turbo": "next dev",
     "build": "next build",
+    "postbuild": "node scripts/prepare-standalone.mjs",
     "deploy:firestore:prod": "firebase deploy --only firestore:rules,firestore:indexes --project sqyping-teamup",
     "deploy:firestore:dev": "firebase deploy --only firestore:rules,firestore:indexes --project sqyping-teamup-dev",
     "build:strict": "tsc --noEmit && next build",

--- a/scripts/prepare-standalone.mjs
+++ b/scripts/prepare-standalone.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Complète l'artefact Next.js standalone pour App Hosting / Docker.
+ *
+ * En mode `output: "standalone"`, Next.js ne trace que les fichiers `public/`
+ * référencés au build (ex. logo). Les PDF et autres assets statiques non
+ * importés doivent être recopiés explicitement — cf. doc Next.js standalone.
+ */
+
+import { cpSync, existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+const REPO_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const STANDALONE_DIR = join(REPO_ROOT, ".next", "standalone");
+
+if (!existsSync(STANDALONE_DIR)) {
+  console.log("[prepare-standalone] Pas de dossier standalone — skip.");
+  process.exit(0);
+}
+
+const copies = [
+  {
+    from: join(REPO_ROOT, "public"),
+    to: join(STANDALONE_DIR, "public"),
+    label: "public/",
+  },
+  {
+    from: join(REPO_ROOT, ".next", "static"),
+    to: join(STANDALONE_DIR, ".next", "static"),
+    label: ".next/static/",
+  },
+];
+
+for (const { from, to, label } of copies) {
+  if (!existsSync(from)) {
+    throw new Error(`[prepare-standalone] Source introuvable: ${from}`);
+  }
+  cpSync(from, to, { recursive: true });
+  console.log(`[prepare-standalone] Copié ${label} → ${to.replace(REPO_ROOT, ".")}`);
+}
+
+const requiredPublicAssets = [
+  "club-registration/questionnaire-medical-majeur.pdf",
+  "club-registration/questionnaire-medical-mineur.pdf",
+  "club-registration/reglement-interieur-sqy-ping-2019.pdf",
+];
+
+for (const asset of requiredPublicAssets) {
+  const target = join(STANDALONE_DIR, "public", asset);
+  if (!existsSync(target)) {
+    throw new Error(`[prepare-standalone] Asset manquant après copie: ${asset}`);
+  }
+}
+
+console.log("[prepare-standalone] Artefact standalone prêt.");


### PR DESCRIPTION
## Summary
- Release staging → main incluant le parcours d'inscription club (emails, paiements, liste dossiers, justificatif non-Stripe).
- **Fix PDF** : recopie explicite de `public/` dans l'artefact Next.js standalone (`postbuild`) pour servir les questionnaires médicaux et le règlement intérieur.
- Correctifs auth (liens email directs) et tests CI (`resolve-app-origin`).

## Test plan
- [ ] Déploiement App Hosting prod terminé
- [ ] `https://teamup.sqyping.fr/club-registration/questionnaire-medical-majeur.pdf` → 200
- [ ] `https://teamup.sqyping.fr/club-registration/questionnaire-medical-mineur.pdf` → 200
- [ ] `https://teamup.sqyping.fr/club-registration/reglement-interieur-sqy-ping-2019.pdf` → 200
- [ ] Parcours `/club/inscription` fonctionnel (soumission, paiement)


Made with [Cursor](https://cursor.com)