### PR TITLE
🛡️ Sentinel: secure set-role admin API route

### DIFF
--- a/src/app/api/admin/users/set-role/route.ts
+++ b/src/app/api/admin/users/set-role/route.ts
@@ -1,8 +1,4 @@
-export const runtime = "nodejs";
-
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import {
   initializeFirebaseAdmin,
@@ -11,7 +7,6 @@ import {
 } from "@/lib/firebase-admin";
 import {
   COACH_REQUEST_STATUS,
-  hasAnyRole,
   resolveCoachRequestStatus,
   resolveRole,
   USER_ROLES,
@@ -19,6 +14,10 @@ import {
 import type { CoachRequestStatus, UserRole } from "@/types";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import { withAuth } from "@/lib/auth/api-utils";
+import type { DecodedIdToken } from "firebase-admin/auth";
+
+export const runtime = "nodejs";
 
 interface SetRolePayload {
   userId?: string;
@@ -28,7 +27,6 @@ interface SetRolePayload {
   playerId?: string | null;
 }
 
-const ADMIN_ONLY_ROLES: readonly UserRole[] = [USER_ROLES.ADMIN];
 const MANAGED_ROLES: readonly UserRole[] = [
   USER_ROLES.ADMIN,
   USER_ROLES.SECRETARY,
@@ -51,44 +49,24 @@ const resolveCoachStatusForRole = (
   return COACH_REQUEST_STATUS.NONE;
 };
 
-export async function POST(req: NextRequest) {
-  try {
-    // Valider l'origine de la requête pour prévenir les attaques CSRF
-    if (!validateOrigin(req)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Invalid origin",
-          message: "Requête non autorisée",
-        },
-        { status: 403 }
-      );
-    }
+export const POST = withAuth(
+  async (req: Request, context: unknown) => {
+    try {
+      const { decoded } = context as { decoded: DecodedIdToken };
 
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
+      // Valider l'origine de la requête pour prévenir les attaques CSRF
+      if (!validateOrigin(req)) {
+        return jsonNoStore(
+          {
+            success: false,
+            error: "Invalid origin",
+            message: "Requête non autorisée",
+          },
+          { status: 403 }
+        );
+      }
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const requesterRole = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(requesterRole, ADMIN_ONLY_ROLES)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Seuls les administrateurs peuvent modifier les rôles",
-        },
-        { status: 403 }
-      );
-    }
-
-    const body = (await req.json()) as SetRolePayload;
+      const body = (await req.json()) as SetRolePayload;
 
     const { userId, role, coachRequestStatus, coachRequestMessage, playerId } =
       body ?? {};
@@ -167,44 +145,43 @@ export async function POST(req: NextRequest) {
       success: true,
     });
 
-    return jsonNoStore(
-      {
-        success: true,
-        data: {
-          userId,
-          role: resolvedRole,
-          coachRequestStatus: resolvedCoachStatus,
+      return jsonNoStore(
+        {
+          success: true,
+          data: {
+            userId,
+            role: resolvedRole,
+            coachRequestStatus: resolvedCoachStatus,
+          },
         },
-      },
-      { status: 200 }
-    );
-  } catch (error) {
-    console.error("[app/api/admin/users/set-role] error", error);
-    
-    // Log d'audit pour l'échec
-    try {
-      const cookieStore = await cookies();
-      const sessionCookie = cookieStore.get("__session")?.value;
-      if (sessionCookie) {
-        const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+        { status: 200 }
+      );
+    } catch (error) {
+      console.error("[app/api/admin/users/set-role] error", error);
+
+      // Log d'audit pour l'échec
+      try {
+        const { decoded } = context as { decoded: DecodedIdToken };
         logAuditAction(AUDIT_ACTIONS.USER_ROLE_CHANGED, decoded.uid, {
           resource: "user",
           success: false,
-          details: { error: error instanceof Error ? error.message : "Unknown error" },
+          details: {
+            error: error instanceof Error ? error.message : "Unknown error",
+          },
         });
+      } catch {
+        // Ignorer les erreurs de logging d'audit
       }
-    } catch {
-      // Ignorer les erreurs de logging d'audit
-    }
 
-    return jsonNoStore(
-      {
-        success: false,
-        error: "Erreur lors de la mise à jour du rôle",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 }
-    );
-  }
-}
+      return jsonNoStore(
+        {
+          success: false,
+          error: "Erreur lors de la mise à jour du rôle",
+        },
+        { status: 500 }
+      );
+    }
+  },
+  [USER_ROLES.ADMIN]
+);
 


### PR DESCRIPTION
This PR hardens the `set-role` administrative API route by standardizing its authentication and authorization logic.

### 🚨 Severity: HIGH

### 💡 Vulnerability
The endpoint was previously using manual authentication logic that lacked a check for the `email_verified` claim. Additionally, it was leaking internal `error.message` details in the response body when a server error occurred.

### 🎯 Impact
- **Auth Bypass:** Users with unverified emails but possessing an admin role (though unlikely in this system's flow, it's a defense-in-depth gap) could have accessed the endpoint.
- **Info Leakage:** Internal implementation details or database errors could be exposed to potential attackers, aiding in further exploitation.

### 🔧 Fix
1.  **Standardization:** Wrapped the POST handler with the `withAuth` HOC, which automatically enforces session verification, email verification, and the `ADMIN` role.
2.  **Sanitization:** Removed the `details` field from the 500 error response to prevent information leakage.
3.  **Audit Log:** Improved the robustness of audit logging by using the decoded token context.
4.  **Documentation:** Created a security journal at `.jules/sentinel.md` to document this pattern and prevent future regressions.

### ✅ Verification
- Ran `npm run check` (Linting, Type-checking, Vitest/Jest, Next.js Build).
- Manual verification of the code structure ensures it follows the project's established security standards.

---
*PR created automatically by Jules for task [11834015184457657795](https://jules.google.com/task/11834015184457657795) started by @omichalo*