### PR TITLE
🛡️ Sentinel: Harden sync-status API and sanitize error responses

### DIFF
--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,38 +1,14 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
-        },
-        { status: 403 }
-      );
-    }
-
     console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
 
-    await initializeFirebaseAdmin();
     const db = getFirestoreAdmin();
 
     const [metadataDoc, playersSnapshot, teamsSnapshot] = await Promise.all([
@@ -79,11 +55,8 @@ export async function GET() {
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
-
-
+}, [USER_ROLES.ADMIN]);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/admin/sync-status` endpoint lacked an `email_verified` claim check and leaked internal error details (`error.message`) in its 500 response.
🎯 Impact: Unauthorized users with a valid session cookie but unverified email could access sync status. Error details could expose internal system information to attackers.
🔧 Fix: Refactored the route to use the `withAuth` HOC, which enforces the `ADMIN` role and `email_verified` claim. Sanitized the error response to remove sensitive details.
✅ Verification: Ran `npm run check:dev` and `npm test`. Verified file content.

---
*PR created automatically by Jules for task [8053667314000995933](https://jules.google.com/task/8053667314000995933) started by @omichalo*