### PR TITLE
🛡️ Sentinel: harden administrative users list API route

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,32 +1,14 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
 import type { DocumentData, QueryDocumentSnapshot, Query } from "firebase-admin/firestore";
-import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
+import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { USER_ROLES, resolveRole, resolveCoachRequestStatus } from "@/lib/auth/roles";
 import type { User } from "@/types";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        { success: false, error: "Accès refusé" },
-        { status: 403 }
-      );
-    }
-
     const firestore = getFirestoreAdmin();
 
     // Récupérer tous les utilisateurs avec pagination
@@ -173,6 +155,6 @@ export async function GET() {
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN]);
 
 


### PR DESCRIPTION
🛡️ **Sentinel: [MEDIUM] Harden administrative users list API route**

**💡 Vulnerability:**
The administrative user list API route (`src/app/api/admin/users/route.ts`) was using manual authentication and role checking logic. It lacked an explicit check for the `email_verified` claim, which is a project requirement for privileged access.

**🎯 Impact:**
Inconsistent security implementation across administrative endpoints and potential access by users with unverified emails if session verification was flawed.

**🔧 Fix:**
Refactored the endpoint to use the centralized `withAuth` HOC. This:
- Enforces session verification via Firebase Admin.
- Mandates the `email_verified` claim check.
- Enforces the `ADMIN` role.
- Simplifies the code by removing redundant boilerplate.
- Standardizes error responses.

**✅ Verification:**
- Ran `npm run check:dev` (linting + type-checking): PASS
- Ran `npm test`: PASS
- Ran `npm run build`: PASS
- Verified that all user mapping logic remains intact.

---
*PR created automatically by Jules for task [903233929514491965](https://jules.google.com/task/903233929514491965) started by @omichalo*