### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden admin set-role API

### DIFF
--- a/src/app/api/admin/users/set-role/route.ts
+++ b/src/app/api/admin/users/set-role/route.ts
@@ -1,8 +1,6 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import {
   initializeFirebaseAdmin,
@@ -11,7 +9,6 @@ import {
 } from "@/lib/firebase-admin";
 import {
   COACH_REQUEST_STATUS,
-  hasAnyRole,
   resolveCoachRequestStatus,
   resolveRole,
   USER_ROLES,
@@ -19,6 +16,8 @@ import {
 import type { CoachRequestStatus, UserRole } from "@/types";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import { withAuth } from "@/lib/auth/api-utils";
+import type { DecodedIdToken } from "firebase-admin/auth";
 
 interface SetRolePayload {
   userId?: string;
@@ -28,7 +27,6 @@ interface SetRolePayload {
   playerId?: string | null;
 }
 
-const ADMIN_ONLY_ROLES: readonly UserRole[] = [USER_ROLES.ADMIN];
 const MANAGED_ROLES: readonly UserRole[] = [
   USER_ROLES.ADMIN,
   USER_ROLES.SECRETARY,
@@ -51,53 +49,37 @@ const resolveCoachStatusForRole = (
   return COACH_REQUEST_STATUS.NONE;
 };
 
-export async function POST(req: NextRequest) {
-  try {
-    // Valider l'origine de la requête pour prévenir les attaques CSRF
-    if (!validateOrigin(req)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Invalid origin",
-          message: "Requête non autorisée",
-        },
-        { status: 403 }
-      );
-    }
+export const POST = withAuth(
+  async (req, context) => {
+    try {
+      // Valider l'origine de la requête pour prévenir les attaques CSRF
+      if (!validateOrigin(req)) {
+        return jsonNoStore(
+          {
+            success: false,
+            error: "Invalid origin",
+          },
+          { status: 403 }
+        );
+      }
 
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
+      const decoded = (context as { decoded: DecodedIdToken }).decoded;
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const requesterRole = resolveRole(decoded.role as string | undefined);
+      const body = (await req.json()) as SetRolePayload;
 
-    if (!hasAnyRole(requesterRole, ADMIN_ONLY_ROLES)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Seuls les administrateurs peuvent modifier les rôles",
-        },
-        { status: 403 }
-      );
-    }
-
-    const body = (await req.json()) as SetRolePayload;
-
-    const { userId, role, coachRequestStatus, coachRequestMessage, playerId } =
-      body ?? {};
+      const {
+        userId,
+        role,
+        coachRequestStatus,
+        coachRequestMessage,
+        playerId,
+      } = body ?? {};
 
     if (!userId || typeof userId !== "string") {
       return jsonNoStore(
         {
           success: false,
-          error: "Paramètre 'userId' invalide",
+          error: "Invalid userId",
         },
         { status: 400 }
       );
@@ -109,8 +91,7 @@ export async function POST(req: NextRequest) {
       return jsonNoStore(
         {
           success: false,
-          error: "Rôle invalide",
-          details: `Le rôle '${role}' n'est pas supporté`,
+          error: "Invalid role",
         },
         { status: 400 }
       );
@@ -167,44 +148,40 @@ export async function POST(req: NextRequest) {
       success: true,
     });
 
-    return jsonNoStore(
-      {
-        success: true,
-        data: {
-          userId,
-          role: resolvedRole,
-          coachRequestStatus: resolvedCoachStatus,
+      return jsonNoStore(
+        {
+          success: true,
+          data: {
+            userId,
+            role: resolvedRole,
+            coachRequestStatus: resolvedCoachStatus,
+          },
         },
-      },
-      { status: 200 }
-    );
-  } catch (error) {
-    console.error("[app/api/admin/users/set-role] error", error);
-    
-    // Log d'audit pour l'échec
-    try {
-      const cookieStore = await cookies();
-      const sessionCookie = cookieStore.get("__session")?.value;
-      if (sessionCookie) {
-        const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+        { status: 200 }
+      );
+    } catch (error) {
+      console.error("[app/api/admin/users/set-role] error", error);
+
+      // Log d'audit pour l'échec
+      try {
+        const decoded = (context as { decoded: DecodedIdToken }).decoded;
         logAuditAction(AUDIT_ACTIONS.USER_ROLE_CHANGED, decoded.uid, {
           resource: "user",
           success: false,
-          details: { error: error instanceof Error ? error.message : "Unknown error" },
         });
+      } catch {
+        // Ignorer les erreurs de logging d'audit
       }
-    } catch {
-      // Ignorer les erreurs de logging d'audit
-    }
 
-    return jsonNoStore(
-      {
-        success: false,
-        error: "Erreur lors de la mise à jour du rôle",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 }
-    );
-  }
-}
+      return jsonNoStore(
+        {
+          success: false,
+          error: "Internal Server Error",
+        },
+        { status: 500 }
+      );
+    }
+  },
+  [USER_ROLES.ADMIN]
+);
 


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The \`/api/admin/users/set-role\` endpoint used manual authentication logic that failed to enforce the \`email_verified\` claim and leaked internal implementation details via \`error.message\` in failure responses.
🎯 **Impact**: Potential unauthorized access by unverified users (if they had the role claim but hadn't verified email) and information disclosure of server-side internals.
🔧 **Fix**: 
- Refactored the POST handler to use the project-standard \`withAuth\` HOC.
- Enforced \`USER_ROLES.ADMIN\` and the mandatory \`email_verified\` claim.
- Replaced verbose error responses with generic English messages (e.g., "Internal Server Error", "Invalid role").
- Cleaned up redundant manual session verification logic.
✅ **Verification**: 
- Verified refactor manually via \`read_file\`.
- Ran full test suite (\`npm test\`): 368/368 passed.
- Ran quality gate (\`npm run check:dev\`): Linting and type-checking passed.

---
*PR created automatically by Jules for task [18436266570689139409](https://jules.google.com/task/18436266570689139409) started by @omichalo*