### PR TITLE
release: fix boucle requêtes boîte à idées

### DIFF
--- a/src/components/app-suggestions/SuggestionsClient.tsx
+++ b/src/components/app-suggestions/SuggestionsClient.tsx
@@ -74,15 +74,12 @@ export function SuggestionsClient() {
     setDetail,
   } = useSuggestionDetail();
 
-  const [selectedId, setSelectedId] = useState<string | null>(
-    () => searchParams.get("id")
-  );
+  const selectedId = searchParams.get("id");
   const [createOpen, setCreateOpen] = useState(false);
   const mobileDetailRef = useRef<HTMLDivElement>(null);
 
   const updateSelectedId = useCallback(
     (id: string | null) => {
-      setSelectedId(id);
       const params = new URLSearchParams(searchParams.toString());
       if (id) {
         params.set("id", id);
@@ -94,13 +91,6 @@ export function SuggestionsClient() {
     },
     [pathname, router, searchParams]
   );
-
-  useEffect(() => {
-    const idFromUrl = searchParams.get("id");
-    if (idFromUrl && idFromUrl !== selectedId) {
-      setSelectedId(idFromUrl);
-    }
-  }, [searchParams, selectedId]);
 
   useEffect(() => {
     void loadSuggestions();

--- a/src/components/app-suggestions/useSuggestions.ts
+++ b/src/components/app-suggestions/useSuggestions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { readJsonResponse } from "@/lib/http/read-json-response";
 import type {
   AppSuggestionDetail,
@@ -119,8 +119,11 @@ export function useSuggestionDetail() {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const detailRequestRef = useRef(0);
 
   const loadDetail = useCallback(async (id: string, options?: { silent?: boolean }) => {
+    const requestSeq = ++detailRequestRef.current;
+
     if (!options?.silent) {
       setLoading(true);
       setDetail(null);
@@ -135,6 +138,10 @@ export function useSuggestionDetail() {
         SuggestionDetailResponse & { error?: string }
       >(response);
 
+      if (requestSeq !== detailRequestRef.current) {
+        return;
+      }
+
       if (!response.ok) {
         throw new Error(payload.error || "Impossible de charger l'idée");
       }
@@ -142,6 +149,9 @@ export function useSuggestionDetail() {
       setDetail(payload.suggestion);
       setViewer(payload.viewer);
     } catch (loadError) {
+      if (requestSeq !== detailRequestRef.current) {
+        return;
+      }
       setError(
         loadError instanceof Error
           ? loadError.message
@@ -151,7 +161,7 @@ export function useSuggestionDetail() {
         setDetail(null);
       }
     } finally {
-      if (!options?.silent) {
+      if (requestSeq === detailRequestRef.current && !options?.silent) {
         setLoading(false);
       }
     }


### PR DESCRIPTION
## Summary
- Release du correctif `fix(suggestions)` : stoppe la boucle de requêtes `ERR_INSUFFICIENT_RESOURCES` sur `/club/idees`.

## Test plan
- [ ] Vérifier `/club/idees` en prod après déploiement : pas d'erreurs réseau en boucle dans la console.
- [ ] Sélection / filtres / détail d'une idée fonctionnent normalement.


Made with [Cursor](https://cursor.com)