### PR TITLE
feat(security): durcir disponibilités et listes clubRegistrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,115 +1,182 @@
-# TeamUp - Application de gestion d'équipes de ping-pong
+# TeamUp — Plateforme de gestion du club SQY Ping
 
-Application Next.js pour la gestion des équipes, joueurs, compositions et disponibilités du club SQY Ping.
+Application **Next.js** pour la gestion du club de tennis de table SQY Ping : championnat (équipes, joueurs, compositions, disponibilités), adhésions et paiements, intégration Discord et synchronisation FFTT.
 
-## 🚀 Démarrage rapide
+| Environnement | Branche | Hébergement |
+|---------------|---------|-------------|
+| Staging | `staging` | Firebase App Hosting (`sqyping-teamup-dev`) |
+| Production | `main` | Firebase App Hosting (`sqyping-teamup`) → [teamup.sqyping.fr](https://teamup.sqyping.fr) |
+
+## Fonctionnalités
+
+### Championnat
+
+- **Joueurs** : référentiel synchronisé avec l'API FFTT
+- **Équipes** : championnats par équipe, matchs, lieux de rencontre
+- **Disponibilités** : saisie des disponibilités des joueurs pour les journées
+- **Compositions** : montage des équipes par match, validation du brûlage, modèles par défaut
+- **Discord** : liaison licence ↔ compte Discord, envoi de messages, sondages de disponibilité
+
+### Adhésions club
+
+- **Inscription** : parcours guidé (wizard) pour les joueurs et responsables
+- **Suivi** : tableau de bord joueur (`/club/mes-inscriptions`), validation secrétariat (`/club/demandes-adhesion`)
+- **Tarification** : campagnes et grilles tarifaires configurables
+- **Paiements** : Stripe Checkout, webhooks, factures et suivi manuel
+- **Boîte à idées** : suggestions et commentaires des adhérents
+
+### Administration
+
+- Synchronisation manuelle FFTT (joueurs, équipes, matchs)
+- Gestion des utilisateurs et des rôles
+- Configuration des sondages Discord de disponibilité
+- API documentée via OpenAPI (`/swagger`)
+
+## Rôles
+
+| Rôle | Accès principal |
+|------|-----------------|
+| **Joueur** | Accueil joueur, nouvelle adhésion, suivi de ses dossiers |
+| **Coach** | Compositions, disponibilités, championnat |
+| **Secrétaire** | Validation des dossiers, tableau des adhésions, campagnes & tarifs |
+| **Admin** | Tout le secrétariat + administration, sync FFTT, paramétrage global |
+
+Les contrôles d'accès sont appliqués côté client (`AuthGuard`) et côté serveur (routes API).
+
+## Stack technique
+
+- **Frontend** : Next.js 15 (App Router), React 19, MUI 7, Tailwind CSS 4
+- **Backend** : Route handlers Next.js (runtime Node.js), Firebase Admin SDK
+- **Données** : Firestore, Firebase Auth, Firebase Storage
+- **Intégrations** : API FFTT, Discord.js, Stripe, SMTP (Nodemailer)
+- **Cloud** : Firebase App Hosting, Firebase Functions (sync FFTT planifiée)
+- **Qualité** : TypeScript strict, ESLint, Jest, plafonds de taille de fichiers
+
+## Démarrage rapide
 
 ### Prérequis
 
-- Node.js 18+ et npm
-- Compte Firebase
-- Compte Discord (pour l'intégration Discord)
+- Node.js 20+ et npm
+- Projet Firebase (voir [Configuration Firebase Dev](./docs/SETUP_DEV_FIREBASE.md))
+- Variables optionnelles selon les fonctionnalités testées : Discord, Stripe, SMTP, identifiants FFTT
 
 ### Installation
 
 ```bash
-# Cloner le dépôt
-git clone https://github.com/votre-org/teamup.git
+git clone git@github.com:omichalo/teamup.git
 cd teamup
-
-# Installer les dépendances
 npm install
-
-# Configurer les variables d'environnement
 cp .env.example .env.local
-# Éditer .env.local avec vos valeurs
-
-# Lancer le serveur de développement
+# Éditer .env.local (Firebase obligatoire ; voir .env.example pour le détail)
 npm run dev
 ```
 
-L'application sera accessible sur [http://localhost:3000](http://localhost:3000).
+L'application est accessible sur [http://localhost:3000](http://localhost:3000).
 
-## 📚 Documentation
+### Vérifications
 
-### Guides de configuration
+```bash
+npm run check:dev   # pendant le développement (lint + tailles + types)
+npm run check       # avant commit/push (lint + tailles + types + tests + build)
+```
 
-- **[Configuration Firebase Dev](./docs/SETUP_DEV_FIREBASE.md)** : Créer et configurer un projet Firebase pour le développement
-- **[Configuration Discord](./docs/DISCORD.md)** : Configuration complète de l'intégration Discord
-- **[Configuration GitHub Actions](./.github/workflows/SETUP.md)** : Configuration des workflows CI/CD
+## Documentation
 
-### Documentation technique
+### Configuration
 
-- **[Workflow Git/GitHub](./.github/GIT_WORKFLOW.md)** : Workflow de développement et déploiement
-- **[Stratégie de pull requests multi-tâches](./docs/technical/PR_STRATEGY.md)** : Recommandations pour regrouper un refactoring complet dans une seule PR
-- **[Règles de statut des matchs](./docs/technical/MATCH_STATUS_RULES.md)** : Règles de gestion de l'affichage du statut des matchs
-- **[Suppression de code mort](./docs/technical/DEAD_CODE_REMOVAL.md)** : Documentation des suppressions de code mort
-- **[Tests de non-régression](./docs/technical/TESTS_NON_REGRESSION.md)** : Checklist des tests de non-régression
+| Sujet | Document |
+|-------|----------|
+| Firebase (dev) | [docs/SETUP_DEV_FIREBASE.md](./docs/SETUP_DEV_FIREBASE.md) |
+| App Hosting staging | [docs/APP_HOSTING_STAGING_SETUP.md](./docs/APP_HOSTING_STAGING_SETUP.md) |
+| Discord | [docs/DISCORD.md](./docs/DISCORD.md) |
+| Stripe (adhésions) | [docs/STRIPE.md](./docs/STRIPE.md) |
+| Sécurité & secrets | [docs/SECURITY.md](./docs/SECURITY.md) |
+| GitHub Actions (CI) | [.github/workflows/SETUP.md](./.github/workflows/SETUP.md) |
 
-### Firebase Functions
+### Technique
 
-- **[README Functions](./functions/README.md)** : Documentation des Firebase Functions
+| Sujet | Document |
+|-------|----------|
+| Workflow Git (staging → main) | [.github/GIT_WORKFLOW.md](./.github/GIT_WORKFLOW.md) |
+| Quality gates | [docs/QUALITY_GATES.md](./docs/QUALITY_GATES.md) |
+| Sync FFTT (Cloud Functions) | [docs/technical/SYNC_CLOUD_FUNCTIONS.md](./docs/technical/SYNC_CLOUD_FUNCTIONS.md) |
+| Règles statut des matchs | [docs/technical/MATCH_STATUS_RULES.md](./docs/technical/MATCH_STATUS_RULES.md) |
+| Firebase Functions | [functions/README.md](./functions/README.md) |
+| Guide inscription club (PDF) | [docs/club-registration-guide/README.md](./docs/club-registration-guide/README.md) |
 
-## 🛠️ Scripts disponibles
+## Scripts utiles
 
 ```bash
 # Développement
-npm run dev              # Lancer le serveur de développement
-npm run check:dev        # Lint + type-check (sans build)
-npm run check            # Lint + type-check + build
+npm run dev                    # Serveur de dev (port 3000)
+npm run check:dev              # Lint + tailles + type-check
+npm run check                  # Lint + tailles + types + tests + build
+npm test                       # Tests Jest
+npm run test:watch             # Tests en mode watch
 
 # Discord
-npm run discord:register-command  # Enregistrer les commandes slash Discord
+npm run discord:register-command
 
-# Build
-npm run build            # Build de production
-npm run start            # Démarrer le serveur de production
+# Firebase Functions (sync FFTT)
+npm run functions:build
+npm run functions:deploy:dev   # sqyping-teamup-dev
+npm run functions:deploy:prod  # sqyping-teamup
+
+# Firestore (règles + index)
+npm run deploy:firestore:dev
+npm run deploy:firestore:prod
+
+# Smoke tests
+npm run smoke:web              # Build + /api/health
+npm run emulators:smoke        # Emulators Firebase Functions
 ```
 
-## 📁 Structure du projet
+## Structure du projet
 
 ```
 teamup/
 ├── src/
-│   ├── app/              # Pages Next.js (App Router)
+│   ├── app/              # Pages et routes API (App Router)
 │   ├── components/       # Composants React
-│   ├── lib/             # Utilitaires et services
-│   ├── hooks/           # Hooks React personnalisés
-│   └── types/           # Types TypeScript
-├── docs/                # Documentation
-│   ├── technical/       # Documentation technique
-│   └── ...
-├── functions/           # Firebase Functions
-├── .github/            # Configuration GitHub Actions
-│   └── workflows/      # Workflows CI/CD
-└── ...
+│   ├── hooks/            # Hooks personnalisés
+│   ├── lib/              # Logique métier, services, auth
+│   └── types/            # Types TypeScript
+├── docs/                 # Documentation
+├── functions/            # Firebase Functions (sync FFTT)
+├── scripts/              # Scripts utilitaires (deploy, smoke, guides…)
+├── .cursor/rules/        # Standards de code pour les agents Cursor
+└── .github/workflows/    # CI et déploiement Firestore
 ```
 
-## 🔐 Variables d'environnement
+## Variables d'environnement
 
-Voir `.env.example` pour la liste complète des variables d'environnement requises.
+Voir [`.env.example`](./.env.example) pour la liste complète.
 
-### ⚠️ Note importante sur la sécurité
+- **`NEXT_PUBLIC_*`** : configuration Firebase et URL publique de l'app (incluses dans le bundle client, sécurisées par restrictions de domaine Firebase — pas de secrets ici)
+- **Secrets serveur** : tokens Discord, clés Stripe, SMTP, identifiants FFTT, `CSRF_SECRET` — dans `.env.local` en dev, Firebase Secret Manager en production
 
-Les variables préfixées par `NEXT_PUBLIC_*` (comme `NEXT_PUBLIC_FIREBASE_API_KEY`) sont **intentionnellement publiques** et incluses dans le bundle JavaScript côté client. C'est le comportement normal pour la configuration Firebase, car ces valeurs sont sécurisées par des restrictions de domaine configurées dans Firebase Console. **Ne jamais y mettre de secrets.**
+Chaque commit et PR est scanné pour détecter les secrets accidentels (TruffleHog, Gitleaks). Voir [docs/SECURITY.md](./docs/SECURITY.md).
 
-Les secrets (tokens, mots de passe, clés privées) sont gérés via :
-- **Développement local** : fichier `.env.local` (non commité)
-- **Production** : Firebase App Hosting Secrets Manager
+## Déploiement
 
-**Audit de sécurité automatisé** : Chaque commit et pull request est automatiquement scanné pour détecter les secrets (TruffleHog, Gitleaks). Voir [docs/SECURITY.md](./docs/SECURITY.md) pour plus d'informations.
+Le déploiement de l'application se fait via **Firebase App Hosting** au merge sur la branche live :
 
-## 🚢 Déploiement
+1. **Développement** : branche `feature/*` ou `fix/*` → PR vers `staging` → rollout sur l'environnement dev
+2. **Production** : PR `staging` → `main` → rollout sur la production
 
-Le déploiement se fait automatiquement via GitHub Actions lors d'un merge sur `main`.
+La CI GitHub (`.github/workflows/ci.yml`) exécute lint, plafonds de taille, type-check, tests et build sur chaque PR. Le déploiement Firestore (règles et index) est géré par un workflow dédié lorsque ces fichiers changent.
 
-Voir [Configuration GitHub Actions](./.github/workflows/SETUP.md) pour plus de détails.
+Voir [.github/GIT_WORKFLOW.md](./.github/GIT_WORKFLOW.md) et [docs/APP_HOSTING_STAGING_SETUP.md](./docs/APP_HOSTING_STAGING_SETUP.md).
 
-## 📝 Contribution
+## Contribution
 
-Voir [Workflow Git/GitHub](./.github/GIT_WORKFLOW.md) pour les règles de contribution.
+1. Créer une branche depuis `staging` (`feature/*`, `fix/*`, …)
+2. Développer en passant `npm run check:dev` régulièrement
+3. Ouvrir une PR vers `staging` avec un message de commit [Conventional Commits](https://www.conventionalcommits.org/)
+4. Attendre la CI et une review avant merge
 
-## 📄 Licence
+Ne pas merger directement sur `staging` ou `main`.
+
+## Licence
 
 [À définir]
-

--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,16 @@ service cloud.firestore {
     function isClubRegistrationManager() {
       return isAdmin() || isSecretary();
     }
+
+    // Liste client : uniquement ses propres dossiers (requête filtrée + plafond).
+    // Les listes secrétariat passent par l'API (Admin SDK).
+    function isPersonalClubRegistrationListQuery() {
+      return request.query.limit <= 50
+             && request.query.filters.size() == 1
+             && request.query.filters[0].field.path == 'submitterUid'
+             && request.query.filters[0].op == '=='
+             && request.query.filters[0].value == request.auth.uid;
+    }
     
     // ============================================
     // Collection: users
@@ -135,11 +145,11 @@ service cloud.firestore {
     // ============================================
     // Collection: availabilities
     // ============================================
-    // Lecture pour tous les utilisateurs authentifiés
-    // Écriture pour tous les utilisateurs authentifiés (les joueurs peuvent mettre à jour leurs disponibilités)
+    // Lecture pour coach/admin (compositions, disponibilités)
+    // Écriture réservée au serveur (Admin SDK via /api/availabilities et Discord)
     match /availabilities/{availabilityId} {
-      allow read: if isAuthenticated();
-      allow write: if isAuthenticated();
+      allow read: if isCoach();
+      allow write: if false;
     }
     
     // ============================================
@@ -204,14 +214,18 @@ service cloud.firestore {
     // peut créer plusieurs dossiers (ex. inscription de 2 enfants). Le couplage 1 dossier ↔ 1 uid
     // est volontairement abandonné.
     //
-    // - read   : owner (submitterUid == uid), admin ou secrétariat
+    // - get    : owner (submitterUid == uid), admin ou secrétariat
+    // - list   : owner uniquement, requête where submitterUid == uid, limit <= 50
+    //            (listes secrétariat via API / Admin SDK)
     // - create : owner se déclare comme submitterUid, schemaVersion strict
     // - update : owner uniquement, tant que status != 'approved'
     // - delete : interdit côté client (l'admin gère via Admin SDK)
     match /clubRegistrations/{registrationId} {
-      allow read: if isAuthenticated()
-                  && (isClubRegistrationManager()
-                      || resource.data.submitterUid == request.auth.uid);
+      allow get: if isAuthenticated()
+                 && (isClubRegistrationManager()
+                     || resource.data.submitterUid == request.auth.uid);
+      allow list: if isAuthenticated()
+                  && isPersonalClubRegistrationListQuery();
       allow create: if isAuthenticated()
                     && request.resource.data.submitterUid == request.auth.uid
                     && request.resource.data.schemaVersion == 1;
@@ -220,11 +234,6 @@ service cloud.firestore {
                     && request.resource.data.submitterUid == request.auth.uid
                     && resource.data.get('status', 'draft') != 'approved';
       allow delete: if false;
-    }
-    // List queries : autorisées aux utilisateurs authentifiés. Les requêtes sont filtrées
-    // côté serveur API par submitterUid (admin SDK contourne les rules de toute façon).
-    match /clubRegistrations/{document=**} {
-      allow list: if isAuthenticated();
     }
 
     // ============================================

--- a/src/app/api/availabilities/route.ts
+++ b/src/app/api/availabilities/route.ts
@@ -1,0 +1,87 @@
+export const runtime = "nodejs";
+
+import { cookies } from "next/headers";
+import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { patchAvailabilitiesSchema, toPlayerAvailabilityUpdates } from "@/lib/availability/api-schema";
+import { applyPlayerAvailabilityUpdates } from "@/lib/availability/firestore-persistence";
+
+export async function PATCH(req: Request) {
+  if (!validateOrigin(req)) {
+    return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+  }
+
+  const sessionCookie = (await cookies()).get("__session")?.value;
+  if (!sessionCookie) {
+    return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+  }
+
+  let uid: string;
+  try {
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    if (!decoded.email_verified) {
+      return jsonNoStore({ error: "Email non vérifié" }, { status: 403 });
+    }
+
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, [USER_ROLES.ADMIN, USER_ROLES.COACH])) {
+      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    uid = decoded.uid;
+  } catch {
+    return jsonNoStore({ error: "Session invalide" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonNoStore({ error: "Corps de requête JSON invalide" }, { status: 400 });
+  }
+
+  const parsed = patchAvailabilitiesSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonNoStore(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { journee, phase, championshipType, idEpreuve, date, playerUpdates } =
+    parsed.data;
+
+  try {
+    await initializeFirebaseAdmin();
+    const db = getFirestoreAdmin();
+
+    await applyPlayerAvailabilityUpdates(db, {
+      journee,
+      phase,
+      championshipType,
+      ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+      ...(date !== undefined ? { date } : {}),
+      playerUpdates: toPlayerAvailabilityUpdates(playerUpdates),
+    });
+
+    if (process.env.NODE_ENV === "development" && process.env.DEBUG === "true") {
+      console.log("[api/availabilities] PATCH applied", {
+        uid,
+        journee,
+        phase,
+        championshipType,
+        playerCount: playerUpdates.length,
+      });
+    }
+
+    return jsonNoStore({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("[api/availabilities] PATCH error:", error);
+    return jsonNoStore(
+      { error: "Impossible de mettre à jour les disponibilités" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/disponibilites/page.tsx
+++ b/src/app/disponibilites/page.tsx
@@ -24,7 +24,6 @@ import { useAvailabilities } from "@/hooks/useAvailabilities";
 import { usePlayers } from "@/hooks/usePlayers";
 import {
   AvailabilityService,
-  DayAvailability,
 } from "@/lib/services/availability-service";
 import { CompositionService } from "@/lib/services/composition-service";
 import { Player } from "@/types/team-management";
@@ -35,7 +34,6 @@ import { AvailabilityResponse } from "@/lib/services/availability-service";
 import {
   AvailabilityState,
   sanitizeAvailabilityEntry,
-  buildPlayersPayload,
 } from "@/lib/availability/utils";
 import { useAvailabilityStore } from "@/stores/availabilityStore";
 import { usePhasePreselect } from "@/hooks/usePhasePreselect";
@@ -92,10 +90,11 @@ export default function DisponibilitesPage() {
     setAvailabilityWarning(null);
   }, []);
 
-  const persistAvailability = useCallback(
+  const persistPlayerAvailability = useCallback(
     async (
-      stateSnapshot: AvailabilityState,
-      championshipType: ChampionshipType
+      playerId: string,
+      championshipType: ChampionshipType,
+      entry: AvailabilityResponse | undefined
     ) => {
       if (
         selectedJournee === null ||
@@ -105,30 +104,17 @@ export default function DisponibilitesPage() {
         return;
       }
 
-      const payload = buildPlayersPayload(stateSnapshot, championshipType);
       const idEpreuve = getIdEpreuve(selectedEpreuve);
 
-      console.log("[Disponibilites] Persist availability", {
-        journee: selectedJournee,
-        phase: selectedPhase,
-        championshipType,
-        idEpreuve,
-        payload,
-      });
-
       try {
-        const availabilityData: DayAvailability = {
-          journee: selectedJournee,
-          phase: selectedPhase,
+        await availabilityService.updatePlayerAvailability(
+          selectedJournee,
+          selectedPhase,
           championshipType,
-          players: payload,
-        };
-
-        if (idEpreuve !== undefined) {
-          availabilityData.idEpreuve = idEpreuve;
-        }
-
-        await availabilityService.saveAvailability(availabilityData);
+          playerId,
+          entry ?? {},
+          idEpreuve
+        );
       } catch (error) {
         console.error(
           "Erreur lors de la sauvegarde de la disponibilité:",
@@ -630,11 +616,12 @@ export default function DisponibilitesPage() {
     );
 
     if (nextStateSnapshot) {
-      void persistAvailability(nextStateSnapshot, championshipType);
-
-      const resultingEntry = nextStateSnapshot[playerId]?.[championshipType] as
-        | AvailabilityResponse
-        | undefined;
+      const resultingEntry = nextStateSnapshot[playerId]?.[championshipType];
+      void persistPlayerAvailability(
+        playerId,
+        championshipType,
+        resultingEntry
+      );
       const isNowAvailable = resultingEntry?.available === true;
       const isPlayerAssigned =
         assignedPlayersByTypeRef.current[championshipType]?.has(playerId) ??
@@ -704,7 +691,8 @@ export default function DisponibilitesPage() {
       async () => {
         try {
           const snapshot = availabilitiesRef.current;
-          await persistAvailability(snapshot, championshipType);
+          const entry = snapshot[playerId]?.[championshipType];
+          await persistPlayerAvailability(playerId, championshipType, entry);
         } catch (error) {
           console.error("Erreur lors de la sauvegarde automatique:", error);
         }

--- a/src/lib/availability/api-client.ts
+++ b/src/lib/availability/api-client.ts
@@ -1,0 +1,31 @@
+import { ChampionshipType } from "@/types";
+import { AvailabilityResponse } from "@/lib/services/availability-service";
+
+export type PatchAvailabilitiesRequest = {
+  journee: number;
+  phase: "aller" | "retour";
+  championshipType: ChampionshipType;
+  idEpreuve?: number;
+  date?: string;
+  playerUpdates: Array<{
+    playerId: string;
+    response: AvailabilityResponse | null;
+  }>;
+};
+
+export async function patchAvailabilities(
+  body: PatchAvailabilitiesRequest
+): Promise<void> {
+  const response = await fetch("/api/availabilities", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { error?: string }
+      | null;
+    throw new Error(payload?.error ?? `Erreur HTTP ${response.status}`);
+  }
+}

--- a/src/lib/availability/api-schema.ts
+++ b/src/lib/availability/api-schema.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { AvailabilityResponse } from "@/lib/services/availability-service";
+import type { PlayerAvailabilityUpdate } from "@/lib/availability/firestore-persistence";
+
+const availabilityResponseSchema = z
+  .object({
+    available: z.boolean().optional(),
+    comment: z.string().optional(),
+    fridayAvailable: z.boolean().optional(),
+    saturdayAvailable: z.boolean().optional(),
+  })
+  .strict();
+
+const playerUpdateSchema = z
+  .object({
+    playerId: z.string().trim().min(1),
+    response: availabilityResponseSchema.nullable(),
+  })
+  .strict();
+
+export const patchAvailabilitiesSchema = z
+  .object({
+    journee: z.number().int().positive(),
+    phase: z.enum(["aller", "retour"]),
+    championshipType: z.enum(["masculin", "feminin"]),
+    idEpreuve: z.number().int().positive().optional(),
+    date: z.string().trim().min(1).optional(),
+    playerUpdates: z.array(playerUpdateSchema).min(1).max(100),
+  })
+  .strict();
+
+export type PatchAvailabilitiesInput = z.infer<typeof patchAvailabilitiesSchema>;
+
+function toAvailabilityResponse(
+  response: z.infer<typeof availabilityResponseSchema> | null
+): AvailabilityResponse | null {
+  if (response === null) {
+    return null;
+  }
+
+  const normalized: AvailabilityResponse = {};
+
+  if (response.available !== undefined) {
+    normalized.available = response.available;
+  }
+  if (response.comment !== undefined) {
+    normalized.comment = response.comment;
+  }
+  if (response.fridayAvailable !== undefined) {
+    normalized.fridayAvailable = response.fridayAvailable;
+  }
+  if (response.saturdayAvailable !== undefined) {
+    normalized.saturdayAvailable = response.saturdayAvailable;
+  }
+
+  return normalized;
+}
+
+export function toPlayerAvailabilityUpdates(
+  playerUpdates: PatchAvailabilitiesInput["playerUpdates"]
+): PlayerAvailabilityUpdate[] {
+  return playerUpdates.map(({ playerId, response }) => ({
+    playerId,
+    response: toAvailabilityResponse(response),
+  }));
+}

--- a/src/lib/availability/document-id.ts
+++ b/src/lib/availability/document-id.ts
@@ -1,0 +1,13 @@
+import { ChampionshipType } from "@/types";
+
+export function getAvailabilityDocumentId(
+  journee: number,
+  phase: "aller" | "retour",
+  championshipType: ChampionshipType,
+  idEpreuve?: number
+): string {
+  if (idEpreuve !== undefined) {
+    return `${phase}_${journee}_${championshipType}_${idEpreuve}`;
+  }
+  return `${phase}_${journee}_${championshipType}`;
+}

--- a/src/lib/availability/firestore-persistence.ts
+++ b/src/lib/availability/firestore-persistence.ts
@@ -1,0 +1,78 @@
+import { FieldValue, Firestore, Timestamp } from "firebase-admin/firestore";
+import { ChampionshipType } from "@/types";
+import { AvailabilityResponse } from "@/lib/services/availability-service";
+import { getAvailabilityDocumentId } from "@/lib/availability/document-id";
+import { sanitizeAvailabilityResponse } from "@/lib/availability/sanitize-response";
+
+export type PlayerAvailabilityUpdate = {
+  playerId: string;
+  response: AvailabilityResponse | null;
+};
+
+export type ApplyPlayerAvailabilityUpdatesParams = {
+  journee: number;
+  phase: "aller" | "retour";
+  championshipType: ChampionshipType;
+  idEpreuve?: number;
+  date?: string;
+  playerUpdates: PlayerAvailabilityUpdate[];
+};
+
+export async function applyPlayerAvailabilityUpdates(
+  db: Firestore,
+  params: ApplyPlayerAvailabilityUpdatesParams
+): Promise<void> {
+  if (params.playerUpdates.length === 0) {
+    return;
+  }
+
+  const docId = getAvailabilityDocumentId(
+    params.journee,
+    params.phase,
+    params.championshipType,
+    params.idEpreuve
+  );
+  const docRef = db.collection("availabilities").doc(docId);
+  const existingSnap = await docRef.get();
+
+  const dataToMerge: Record<string, unknown> = {
+    journee: params.journee,
+    phase: params.phase,
+    championshipType: params.championshipType,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+
+  if (!existingSnap.exists) {
+    dataToMerge.createdAt = FieldValue.serverTimestamp();
+  } else if (existingSnap.data()?.createdAt instanceof Timestamp) {
+    dataToMerge.createdAt = existingSnap.data()?.createdAt;
+  }
+
+  if (params.date !== undefined) {
+    dataToMerge.date = params.date;
+  } else if (existingSnap.data()?.date !== undefined) {
+    dataToMerge.date = existingSnap.data()?.date;
+  }
+
+  if (params.idEpreuve !== undefined) {
+    dataToMerge.idEpreuve = params.idEpreuve;
+  }
+
+  for (const { playerId, response } of params.playerUpdates) {
+    if (!playerId || typeof playerId !== "string" || playerId.trim().length === 0) {
+      continue;
+    }
+
+    const sanitized =
+      response === null ? undefined : sanitizeAvailabilityResponse(response);
+
+    if (!sanitized) {
+      dataToMerge[`players.${playerId}`] = FieldValue.delete();
+      continue;
+    }
+
+    dataToMerge[`players.${playerId}`] = sanitized;
+  }
+
+  await docRef.set(dataToMerge, { merge: true });
+}

--- a/src/lib/availability/sanitize-response.test.ts
+++ b/src/lib/availability/sanitize-response.test.ts
@@ -1,0 +1,33 @@
+import { sanitizeAvailabilityResponse } from "@/lib/availability/sanitize-response";
+
+describe("sanitizeAvailabilityResponse", () => {
+  it("returns undefined for empty payloads", () => {
+    expect(sanitizeAvailabilityResponse({})).toBeUndefined();
+    expect(sanitizeAvailabilityResponse(null)).toBeUndefined();
+  });
+
+  it("trims comments and keeps booleans", () => {
+    expect(
+      sanitizeAvailabilityResponse({
+        available: true,
+        comment: "  ok  ",
+        fridayAvailable: false,
+      })
+    ).toEqual({
+      available: true,
+      comment: "ok",
+      fridayAvailable: false,
+    });
+  });
+
+  it("drops blank comments", () => {
+    expect(
+      sanitizeAvailabilityResponse({
+        available: false,
+        comment: "   ",
+      })
+    ).toEqual({
+      available: false,
+    });
+  });
+});

--- a/src/lib/availability/sanitize-response.ts
+++ b/src/lib/availability/sanitize-response.ts
@@ -1,0 +1,41 @@
+import { AvailabilityResponse } from "@/lib/services/availability-service";
+
+export function sanitizeAvailabilityResponse(
+  response?: AvailabilityResponse | null
+): AvailabilityResponse | undefined {
+  if (!response) {
+    return undefined;
+  }
+
+  const sanitized: AvailabilityResponse = {};
+
+  if (typeof response.available === "boolean") {
+    sanitized.available = response.available;
+  }
+
+  if (typeof response.comment === "string") {
+    const trimmed = response.comment.trim();
+    if (trimmed.length > 0) {
+      sanitized.comment = trimmed;
+    }
+  }
+
+  if (typeof response.fridayAvailable === "boolean") {
+    sanitized.fridayAvailable = response.fridayAvailable;
+  }
+
+  if (typeof response.saturdayAvailable === "boolean") {
+    sanitized.saturdayAvailable = response.saturdayAvailable;
+  }
+
+  if (
+    sanitized.available === undefined &&
+    sanitized.comment === undefined &&
+    sanitized.fridayAvailable === undefined &&
+    sanitized.saturdayAvailable === undefined
+  ) {
+    return undefined;
+  }
+
+  return sanitized;
+}

--- a/src/lib/services/availability-service-admin.ts
+++ b/src/lib/services/availability-service-admin.ts
@@ -6,66 +6,27 @@ import {
   DayAvailability,
   PlayerAvailability,
 } from "@/lib/services/availability-service";
+import { getAvailabilityDocumentId } from "@/lib/availability/document-id";
+import { applyPlayerAvailabilityUpdates } from "@/lib/availability/firestore-persistence";
+import { sanitizeAvailabilityResponse } from "@/lib/availability/sanitize-response";
 
-const sanitizeResponse = (
-  response?: AvailabilityResponse | null
-): AvailabilityResponse | undefined => {
-  if (!response) {
-    return undefined;
-  }
-
-  const sanitized: AvailabilityResponse = {};
-
-  if (typeof response.available === "boolean") {
-    sanitized.available = response.available;
-  }
-
-  if (typeof response.comment === "string") {
-    const trimmed = response.comment.trim();
-    if (trimmed.length > 0) {
-      sanitized.comment = trimmed;
-    }
-  }
-
-  if (typeof response.fridayAvailable === "boolean") {
-    sanitized.fridayAvailable = response.fridayAvailable;
-  }
-
-  if (typeof response.saturdayAvailable === "boolean") {
-    sanitized.saturdayAvailable = response.saturdayAvailable;
-  }
-
-  if (
-    sanitized.available === undefined &&
-    sanitized.comment === undefined &&
-    sanitized.fridayAvailable === undefined &&
-    sanitized.saturdayAvailable === undefined
-  ) {
-    return undefined;
-  }
-
-  return sanitized;
-};
-
-const toTimestamp = (
-  value: unknown | Date | Timestamp | undefined
-): Timestamp => {
+const toDate = (value: unknown): Date => {
   if (value instanceof Timestamp) {
-    return value;
+    return value.toDate();
   }
 
   if (value instanceof Date) {
-    return Timestamp.fromDate(value);
+    return value;
   }
 
   if (typeof value === "string" || typeof value === "number") {
     const date = new Date(value);
     if (!Number.isNaN(date.getTime())) {
-      return Timestamp.fromDate(date);
+      return date;
     }
   }
 
-  return Timestamp.now();
+  return new Date();
 };
 
 export class AvailabilityServiceAdmin {
@@ -77,10 +38,7 @@ export class AvailabilityServiceAdmin {
     championshipType: ChampionshipType,
     idEpreuve?: number
   ): string {
-    if (idEpreuve !== undefined) {
-      return `${phase}_${journee}_${championshipType}_${idEpreuve}`;
-    }
-    return `${phase}_${journee}_${championshipType}`;
+    return getAvailabilityDocumentId(journee, phase, championshipType, idEpreuve);
   }
 
   async getAvailability(
@@ -91,14 +49,8 @@ export class AvailabilityServiceAdmin {
   ): Promise<DayAvailability | null> {
     try {
       const db = getFirestoreAdmin();
-      const docId = this.getDocumentId(
-        journee,
-        phase,
-        championshipType,
-        idEpreuve
-      );
-      const docRef = db.collection(this.collectionName).doc(docId);
-      const docSnap = await docRef.get();
+      const docId = this.getDocumentId(journee, phase, championshipType, idEpreuve);
+      const docSnap = await db.collection(this.collectionName).doc(docId).get();
 
       if (!docSnap.exists) {
         return null;
@@ -115,15 +67,9 @@ export class AvailabilityServiceAdmin {
         championshipType: data.championshipType,
         idEpreuve: data.idEpreuve,
         date: data.date,
-        players: data.players || {},
-        createdAt:
-          data.createdAt instanceof Timestamp
-            ? data.createdAt.toDate()
-            : data.createdAt?.toDate?.() || new Date(),
-        updatedAt:
-          data.updatedAt instanceof Timestamp
-            ? data.updatedAt.toDate()
-            : data.updatedAt?.toDate?.() || new Date(),
+        players: (data.players as PlayerAvailability) || {},
+        createdAt: toDate(data.createdAt),
+        updatedAt: toDate(data.updatedAt),
       };
     } catch (error) {
       console.error(
@@ -135,58 +81,28 @@ export class AvailabilityServiceAdmin {
   }
 
   async saveAvailability(availability: DayAvailability): Promise<void> {
-    try {
-      const db = getFirestoreAdmin();
-      const docId = this.getDocumentId(
-        availability.journee,
-        availability.phase,
-        availability.championshipType,
-        availability.idEpreuve
-      );
-      const docRef = db.collection(this.collectionName).doc(docId);
+    const playerUpdates = Object.entries(availability.players).map(
+      ([playerId, response]) => ({
+        playerId,
+        response: sanitizeAvailabilityResponse(response) ?? null,
+      })
+    );
 
-      const existingSnap = await docRef.get();
-      const existingData = existingSnap.exists ? existingSnap.data() : null;
-
-      const sanitizedPlayers: PlayerAvailability = {};
-
-      Object.entries(availability.players).forEach(([playerId, response]) => {
-        const sanitized = sanitizeResponse(response);
-        if (sanitized) {
-          sanitizedPlayers[playerId] = sanitized;
-        }
-      });
-
-      const createdAtTimestamp = availability.createdAt
-        ? toTimestamp(availability.createdAt)
-        : existingData?.createdAt
-        ? toTimestamp(existingData.createdAt)
-        : Timestamp.now();
-
-      const dataToSave: Record<string, unknown> = {
-        journee: availability.journee,
-        phase: availability.phase,
-        championshipType: availability.championshipType,
-        players: sanitizedPlayers,
-        updatedAt: Timestamp.now(),
-        createdAt: createdAtTimestamp,
-      };
-
-      if (availability.date !== undefined) {
-        dataToSave.date = availability.date;
-      } else if (existingData?.date !== undefined) {
-        dataToSave.date = existingData.date;
-      }
-
-      if (availability.idEpreuve !== undefined) {
-        dataToSave.idEpreuve = availability.idEpreuve;
-      }
-
-      await docRef.set(dataToSave);
-    } catch (error) {
-      console.error("Erreur lors de la sauvegarde de la disponibilité:", error);
-      throw error;
+    if (playerUpdates.length === 0) {
+      return;
     }
+
+    const db = getFirestoreAdmin();
+    await applyPlayerAvailabilityUpdates(db, {
+      journee: availability.journee,
+      phase: availability.phase,
+      championshipType: availability.championshipType,
+      ...(availability.idEpreuve !== undefined
+        ? { idEpreuve: availability.idEpreuve }
+        : {}),
+      ...(availability.date !== undefined ? { date: availability.date } : {}),
+      playerUpdates,
+    });
   }
 
   async updatePlayerAvailability(
@@ -198,26 +114,21 @@ export class AvailabilityServiceAdmin {
     idEpreuve?: number
   ): Promise<void> {
     try {
-      const availability = await this.getAvailability(
-        journee,
-        phase,
-        championshipType,
-        idEpreuve
-      );
+      const db = getFirestoreAdmin();
+      const sanitized = sanitizeAvailabilityResponse(response);
 
-      const updatedAvailability: DayAvailability = {
+      await applyPlayerAvailabilityUpdates(db, {
         journee,
         phase,
         championshipType,
         ...(idEpreuve !== undefined ? { idEpreuve } : {}),
-        players: {
-          ...(availability?.players || {}),
-          [playerId]: response,
-        },
-        createdAt: availability?.createdAt || new Date(),
-      };
-
-      await this.saveAvailability(updatedAvailability);
+        playerUpdates: [
+          {
+            playerId,
+            response: sanitized ?? null,
+          },
+        ],
+      });
     } catch (error) {
       console.error(
         "Erreur lors de la mise à jour de la disponibilité:",

--- a/src/lib/services/availability-service.ts
+++ b/src/lib/services/availability-service.ts
@@ -1,6 +1,9 @@
-import { doc, getDoc, setDoc, Timestamp, onSnapshot, Unsubscribe } from "firebase/firestore";
+import { doc, getDoc, Timestamp, onSnapshot, Unsubscribe } from "firebase/firestore";
 import { getDbInstanceDirect } from "@/lib/firebase";
 import { ChampionshipType } from "@/types";
+import { getAvailabilityDocumentId } from "@/lib/availability/document-id";
+import { patchAvailabilities } from "@/lib/availability/api-client";
+import { sanitizeAvailabilityResponse } from "@/lib/availability/sanitize-response";
 
 export interface AvailabilityResponse {
   available?: boolean;
@@ -9,65 +12,6 @@ export interface AvailabilityResponse {
   fridayAvailable?: boolean;
   saturdayAvailable?: boolean;
 }
-
-const sanitizeResponse = (
-  response?: AvailabilityResponse | null
-): AvailabilityResponse | undefined => {
-  if (!response) {
-    return undefined;
-  }
-
-  const sanitized: AvailabilityResponse = {};
-
-  if (typeof response.available === "boolean") {
-    sanitized.available = response.available;
-  }
-
-  if (typeof response.comment === "string") {
-    const trimmed = response.comment.trim();
-    if (trimmed.length > 0) {
-      sanitized.comment = trimmed;
-    }
-  }
-
-  if (typeof response.fridayAvailable === "boolean") {
-    sanitized.fridayAvailable = response.fridayAvailable;
-  }
-
-  if (typeof response.saturdayAvailable === "boolean") {
-    sanitized.saturdayAvailable = response.saturdayAvailable;
-  }
-
-  if (
-    sanitized.available === undefined &&
-    sanitized.comment === undefined &&
-    sanitized.fridayAvailable === undefined &&
-    sanitized.saturdayAvailable === undefined
-  ) {
-    return undefined;
-  }
-
-  return sanitized;
-};
-
-const toTimestamp = (value: unknown | Date | Timestamp | undefined): Timestamp => {
-  if (value instanceof Timestamp) {
-    return value;
-  }
-
-  if (value instanceof Date) {
-    return Timestamp.fromDate(value);
-  }
-
-  if (typeof value === "string" || typeof value === "number") {
-    const date = new Date(value);
-    if (!Number.isNaN(date.getTime())) {
-      return Timestamp.fromDate(date);
-    }
-  }
-
-  return Timestamp.fromDate(new Date());
-};
 
 export interface PlayerAvailability {
   [playerId: string]: AvailabilityResponse;
@@ -93,12 +37,7 @@ export class AvailabilityService {
     championshipType: ChampionshipType,
     idEpreuve?: number
   ): string {
-    // Si idEpreuve est fourni, l'inclure dans l'ID pour différencier les calendriers
-    // Sinon, utiliser l'ancien format pour la rétrocompatibilité
-    if (idEpreuve !== undefined) {
-      return `${phase}_${journee}_${championshipType}_${idEpreuve}`;
-    }
-    return `${phase}_${journee}_${championshipType}`;
+    return getAvailabilityDocumentId(journee, phase, championshipType, idEpreuve);
   }
 
   async getAvailability(
@@ -140,72 +79,27 @@ export class AvailabilityService {
   }
 
   async saveAvailability(availability: DayAvailability): Promise<void> {
-    try {
-      const docId = this.getDocumentId(
-        availability.journee,
-        availability.phase,
-        availability.championshipType,
-        availability.idEpreuve
-      );
-      const docRef = doc(getDbInstanceDirect(), this.collectionName, docId);
+    const playerUpdates = Object.entries(availability.players).map(
+      ([playerId, response]) => ({
+        playerId,
+        response: sanitizeAvailabilityResponse(response) ?? null,
+      })
+    );
 
-      const existingSnap = await getDoc(docRef);
-      const existingData = existingSnap.exists() ? existingSnap.data() : null;
-
-      console.log("[AvailabilityService] saveAvailability input", {
-        docId,
-        incomingPlayers: availability.players,
-      });
-
-      const sanitizedPlayers: PlayerAvailability = {};
-
-      Object.entries(availability.players).forEach(([playerId, response]) => {
-        const sanitized = sanitizeResponse(response);
-        if (sanitized) {
-          sanitizedPlayers[playerId] = sanitized;
-        }
-      });
-
-      const createdAtTimestamp = availability.createdAt
-        ? toTimestamp(availability.createdAt)
-        : existingData?.createdAt
-        ? toTimestamp(existingData.createdAt)
-        : Timestamp.fromDate(new Date());
-
-      const dataToSave: Record<string, unknown> = {
-        journee: availability.journee,
-        phase: availability.phase,
-        championshipType: availability.championshipType,
-        players: sanitizedPlayers,
-        updatedAt: Timestamp.fromDate(new Date()),
-        createdAt: createdAtTimestamp,
-      };
-
-      if (availability.date !== undefined) {
-        dataToSave.date = availability.date;
-      } else if (existingData?.date !== undefined) {
-        dataToSave.date = existingData.date;
-      }
-
-      if (availability.idEpreuve !== undefined) {
-        dataToSave.idEpreuve = availability.idEpreuve;
-      }
-
-      console.log("[AvailabilityService] sanitized players", {
-        docId,
-        players: sanitizedPlayers,
-      });
-
-      await setDoc(docRef, dataToSave);
-      console.log("[AvailabilityService] Saved availability document", {
-        docId,
-        dataToSave,
-        playersKeys: Object.keys(sanitizedPlayers),
-      });
-    } catch (error) {
-      console.error("Erreur lors de la sauvegarde de la disponibilité:", error);
-      throw error;
+    if (playerUpdates.length === 0) {
+      return;
     }
+
+    await patchAvailabilities({
+      journee: availability.journee,
+      phase: availability.phase,
+      championshipType: availability.championshipType,
+      ...(availability.idEpreuve !== undefined
+        ? { idEpreuve: availability.idEpreuve }
+        : {}),
+      ...(availability.date !== undefined ? { date: availability.date } : {}),
+      playerUpdates,
+    });
   }
 
   async updatePlayerAvailability(
@@ -213,23 +107,24 @@ export class AvailabilityService {
     phase: "aller" | "retour",
     championshipType: ChampionshipType,
     playerId: string,
-    response: AvailabilityResponse
+    response: AvailabilityResponse,
+    idEpreuve?: number
   ): Promise<void> {
     try {
-      const availability = await this.getAvailability(journee, phase, championshipType);
+      const sanitized = sanitizeAvailabilityResponse(response);
 
-      const updatedAvailability: DayAvailability = {
+      await patchAvailabilities({
         journee,
         phase,
         championshipType,
-        players: {
-          ...(availability?.players || {}),
-          [playerId]: response,
-        },
-        createdAt: availability?.createdAt || new Date(),
-      };
-
-      await this.saveAvailability(updatedAvailability);
+        ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+        playerUpdates: [
+          {
+            playerId,
+            response: sanitized ?? null,
+          },
+        ],
+      });
     } catch (error) {
       console.error("Erreur lors de la mise à jour de la disponibilité:", error);
       throw error;


### PR DESCRIPTION
## Summary
- Écritures de disponibilité via `PATCH /api/availabilities` (mise à jour atomique par joueur)
- Rules Firestore `availabilities` : lecture coach/admin, écriture client interdite
- Rules `clubRegistrations` : list client limitée à `where submitterUid == uid` + `limit <= 50`
- Mise à jour README

## Test plan
- [ ] Coach peut modifier une disponibilité sur `/disponibilites` (staging)
- [ ] Temps réel compositions/disponibilités toujours OK
- [ ] `Mes inscriptions` et file secrétariat inchangés (API Admin SDK)
- [ ] Workflow Deploy Firestore passe sur push staging/main

Made with [Cursor](https://cursor.com)