### PR TITLE
feat(suggestions): exploiter la priorité avec tri et backfill

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -51,32 +51,8 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "createdAt",
+          "fieldPath": "priorityRank",
           "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "submitterUid",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "category",
-          "order": "ASCENDING"
         },
         {
           "fieldPath": "createdAt",
@@ -93,8 +69,8 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "status",
-          "order": "ASCENDING"
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
         },
         {
           "fieldPath": "createdAt",
@@ -107,30 +83,12 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "submitterUid",
-          "order": "ASCENDING"
-        },
-        {
           "fieldPath": "category",
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "createdAt",
+          "fieldPath": "priorityRank",
           "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "category",
-          "order": "ASCENDING"
         },
         {
           "fieldPath": "createdAt",
@@ -151,98 +109,8 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "category",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
+          "fieldPath": "priorityRank",
           "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "submitterUid",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "category",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "appSuggestions",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "submitterUid",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
         },
         {
           "fieldPath": "createdAt",
@@ -263,8 +131,8 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
         },
         {
           "fieldPath": "createdAt",
@@ -285,8 +153,8 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "kind",
-          "order": "ASCENDING"
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
         },
         {
           "fieldPath": "createdAt",
@@ -311,8 +179,214 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "kind",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "submitterUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "submitterUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "submitterUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "submitterUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "kind",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "appSuggestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "priorityRank",
+          "order": "DESCENDING"
         },
         {
           "fieldPath": "createdAt",

--- a/scripts/backfill-suggestion-priority-rank.ts
+++ b/scripts/backfill-suggestion-priority-rank.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Renseigne priority + priorityRank sur les retours existants (tri Firestore).
+ *
+ * Usage :
+ *   # Staging (depuis .env.local)
+ *   TS_NODE_TRANSPILE_ONLY=1 npx ts-node scripts/backfill-suggestion-priority-rank.ts
+ *
+ *   # Production
+ *   NEXT_PUBLIC_FIREBASE_PROJECT_ID=sqyping-teamup TS_NODE_TRANSPILE_ONLY=1 npx ts-node scripts/backfill-suggestion-priority-rank.ts
+ *
+ *   # Simulation
+ *   ... --dry-run
+ */
+import { initializeApp, applicationDefault, cert, getApps } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const COLLECTION = "appSuggestions";
+const BATCH_SIZE = 400;
+const PRIORITIES = ["low", "medium", "high"] as const;
+type SuggestionPriority = (typeof PRIORITIES)[number];
+
+const PRIORITY_RANK: Record<SuggestionPriority, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+const {
+  GOOGLE_APPLICATION_CREDENTIALS,
+  FIREBASE_PRIVATE_KEY,
+  FIREBASE_CLIENT_EMAIL,
+  FB_CLIENT_EMAIL,
+  FB_PRIVATE_KEY,
+  FB_PROJECT_ID,
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+} = process.env;
+
+const dryRun = process.argv.includes("--dry-run");
+
+function resolveProjectId(): string {
+  return (
+    FB_PROJECT_ID?.trim() ||
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID?.trim() ||
+    "sqyping-teamup-dev"
+  );
+}
+
+function initFirebaseAdmin(projectId: string): void {
+  if (getApps().length > 0) {
+    return;
+  }
+
+  const privateKey = FB_PRIVATE_KEY || FIREBASE_PRIVATE_KEY;
+  const clientEmail = FB_CLIENT_EMAIL || FIREBASE_CLIENT_EMAIL;
+
+  if (GOOGLE_APPLICATION_CREDENTIALS || (!privateKey && !clientEmail)) {
+    initializeApp({
+      credential: applicationDefault(),
+      projectId,
+    });
+    return;
+  }
+
+  if (!privateKey || !clientEmail) {
+    throw new Error(
+      "Credentials Firebase non configurés. Fournissez GOOGLE_APPLICATION_CREDENTIALS ou FIREBASE_PRIVATE_KEY/FIREBASE_CLIENT_EMAIL."
+    );
+  }
+
+  initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey: privateKey.replace(/\\n/g, "\n"),
+    }),
+  });
+}
+
+function resolveStoredPriority(value: unknown): SuggestionPriority {
+  if (
+    typeof value === "string" &&
+    (PRIORITIES as readonly string[]).includes(value)
+  ) {
+    return value as SuggestionPriority;
+  }
+  return "medium";
+}
+
+function buildPriorityFields(priority: SuggestionPriority): {
+  priority: SuggestionPriority;
+  priorityRank: number;
+} {
+  return {
+    priority,
+    priorityRank: PRIORITY_RANK[priority],
+  };
+}
+
+function needsPriorityBackfill(
+  priority: unknown,
+  priorityRank: unknown
+): { priority: SuggestionPriority; priorityRank: number } | null {
+  const resolvedPriority = resolveStoredPriority(priority);
+  const expectedRank = PRIORITY_RANK[resolvedPriority];
+  const currentRank =
+    typeof priorityRank === "number" && Number.isFinite(priorityRank)
+      ? priorityRank
+      : null;
+
+  if (priority === resolvedPriority && currentRank === expectedRank) {
+    return null;
+  }
+
+  return buildPriorityFields(resolvedPriority);
+}
+
+async function commitBatch(
+  batch: FirebaseFirestore.WriteBatch,
+  pending: number
+): Promise<void> {
+  if (pending === 0 || dryRun) {
+    return;
+  }
+  await batch.commit();
+}
+
+async function main(): Promise<void> {
+  const projectId = resolveProjectId();
+  initFirebaseAdmin(projectId);
+  const db = getFirestore();
+
+  console.log(
+    `[backfill-priority-rank] Projet=${projectId} dryRun=${dryRun ? "oui" : "non"}`
+  );
+
+  const snapshot = await db.collection(COLLECTION).get();
+  let updated = 0;
+  let skipped = 0;
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const docSnap of snapshot.docs) {
+    const patch = needsPriorityBackfill(
+      docSnap.get("priority"),
+      docSnap.get("priorityRank")
+    );
+
+    if (!patch) {
+      skipped += 1;
+      continue;
+    }
+
+    console.log(
+      `[backfill] ${docSnap.id} -> priority=${patch.priority}, priorityRank=${patch.priorityRank}`
+    );
+
+    if (!dryRun) {
+      batch.update(docSnap.ref, patch);
+      batchCount += 1;
+
+      if (batchCount >= BATCH_SIZE) {
+        await commitBatch(batch, batchCount);
+        batch = db.batch();
+        batchCount = 0;
+      }
+    }
+
+    updated += 1;
+  }
+
+  await commitBatch(batch, batchCount);
+
+  console.log(
+    `[backfill-priority-rank] Terminé : ${updated} mis à jour, ${skipped} déjà OK, ${snapshot.size} retour(s) au total.`
+  );
+}
+
+main().catch((error) => {
+  console.error("[backfill-priority-rank] Échec :", error);
+  process.exit(1);
+});

--- a/src/components/app-suggestions/SuggestionCreateDialog.tsx
+++ b/src/components/app-suggestions/SuggestionCreateDialog.tsx
@@ -12,10 +12,11 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import type { SuggestionCategory, SuggestionKind } from "@/lib/app-suggestions/types";
+import type { SuggestionCategory, SuggestionKind, SuggestionPriority } from "@/lib/app-suggestions/types";
 import { isValidSuggestionCategory } from "@/lib/app-suggestions/categories";
 import { stripSuggestionHtmlText } from "@/lib/app-suggestions/rich-text";
 import { SuggestionCategoryField } from "@/components/app-suggestions/SuggestionCategoryField";
+import { SuggestionPriorityField } from "@/components/app-suggestions/SuggestionPriorityField";
 import { SuggestionRichTextEditor } from "@/components/app-suggestions/rich-text/SuggestionRichTextEditor";
 import { cleanupAllDraftSuggestionImages } from "@/components/app-suggestions/rich-text/draft-image-cleanup";
 
@@ -28,6 +29,7 @@ type SuggestionCreateDialogProps = {
     description: string;
     kind: SuggestionKind;
     category: SuggestionCategory;
+    priority: SuggestionPriority;
   }) => Promise<void>;
 };
 
@@ -68,6 +70,7 @@ export function SuggestionCreateDialog({
   const [title, setTitle] = useState("");
   const [descriptionHtml, setDescriptionHtml] = useState("<p></p>");
   const [category, setCategory] = useState("");
+  const [priority, setPriority] = useState<SuggestionPriority>("medium");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -77,6 +80,7 @@ export function SuggestionCreateDialog({
     setTitle("");
     setDescriptionHtml("<p></p>");
     setCategory("");
+    setPriority("medium");
     setError(null);
   };
 
@@ -116,6 +120,7 @@ export function SuggestionCreateDialog({
         description: descriptionHtml,
         kind,
         category,
+        priority,
       });
       reset();
       onClose();
@@ -152,6 +157,13 @@ export function SuggestionCreateDialog({
             onChange={setCategory}
             required
             disabled={submitting}
+          />
+
+          <SuggestionPriorityField
+            value={priority}
+            onChange={setPriority}
+            disabled={submitting}
+            required
           />
 
           <Stack spacing={0.75}>

--- a/src/components/app-suggestions/SuggestionDetailPanel.tsx
+++ b/src/components/app-suggestions/SuggestionDetailPanel.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import { OpenInNew as OpenInNewIcon } from "@mui/icons-material";
-import type { AppSuggestionDetail, SuggestionCategory } from "@/lib/app-suggestions/types";
+import type { AppSuggestionDetail, SuggestionCategory, SuggestionPriority } from "@/lib/app-suggestions/types";
 import {
   formatSuggestionCategoryLabel,
   SUGGESTION_KIND_COLORS,
@@ -25,6 +25,8 @@ import {
 } from "@/lib/app-suggestions/status";
 import { isValidSuggestionCategory } from "@/lib/app-suggestions/categories";
 import { SuggestionCategoryField } from "@/components/app-suggestions/SuggestionCategoryField";
+import { SuggestionPriorityChip } from "@/components/app-suggestions/SuggestionPriorityChip";
+import { SuggestionPriorityField } from "@/components/app-suggestions/SuggestionPriorityField";
 import { formatSuggestionDate } from "@/components/app-suggestions/format-utils";
 import { SuggestionDetailEmptyState } from "@/components/app-suggestions/SuggestionDetailEmptyState";
 import { SuggestionDetailCommentsSection } from "@/components/app-suggestions/SuggestionDetailCommentsSection";
@@ -49,6 +51,7 @@ type SuggestionDetailPanelProps = {
       title: string;
       description: string;
       category: SuggestionCategory;
+      priority: SuggestionPriority;
     }>
   ) => Promise<void>;
   onPatchMaintainer: (
@@ -76,6 +79,7 @@ export function SuggestionDetailPanel({
   const [editTitle, setEditTitle] = useState("");
   const [editDescriptionHtml, setEditDescriptionHtml] = useState("<p></p>");
   const [editCategory, setEditCategory] = useState("");
+  const [editPriority, setEditPriority] = useState<SuggestionPriority>("medium");
   const [authorSubmitting, setAuthorSubmitting] = useState(false);
   const [authorError, setAuthorError] = useState<string | null>(null);
   const [authorSuccess, setAuthorSuccess] = useState<string | null>(null);
@@ -88,6 +92,7 @@ export function SuggestionDetailPanel({
     setEditTitle(detail.title);
     setEditDescriptionHtml(detail.description || "<p></p>");
     setEditCategory(detail.category);
+    setEditPriority(detail.priority);
   }, [detail, isEditing]);
 
   useEffect(() => {
@@ -127,6 +132,7 @@ export function SuggestionDetailPanel({
         title: editTitle,
         description: editDescriptionHtml,
         category: editCategory,
+        priority: editPriority,
       });
       setIsEditing(false);
       setAuthorSuccess("Modifications enregistrées.");
@@ -150,6 +156,7 @@ export function SuggestionDetailPanel({
     setEditTitle(detail.title);
     setEditDescriptionHtml(referenceHtml);
     setEditCategory(detail.category);
+    setEditPriority(detail.priority);
     setAuthorError(null);
     setIsEditing(false);
     void cleanupDraftSuggestionImages(draftHtml, referenceHtml).catch(() => undefined);
@@ -205,12 +212,20 @@ export function SuggestionDetailPanel({
           </Stack>
         </Stack>
         {isEditing ? (
-          <SuggestionCategoryField
-            value={editCategory}
-            onChange={setEditCategory}
-            required
-            disabled={authorSubmitting}
-          />
+          <>
+            <SuggestionCategoryField
+              value={editCategory}
+              onChange={setEditCategory}
+              required
+              disabled={authorSubmitting}
+            />
+            <SuggestionPriorityField
+              value={editPriority}
+              onChange={setEditPriority}
+              disabled={authorSubmitting}
+              required
+            />
+          </>
         ) : (
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap alignItems="center">
             <Chip
@@ -223,6 +238,7 @@ export function SuggestionDetailPanel({
               size="small"
               variant="outlined"
             />
+            <SuggestionPriorityChip priority={detail.priority} />
             <Typography variant="body2" color="text.secondary">
               {detail.submitterDisplayName || "Utilisateur"} ·{" "}
               {formatSuggestionDate(detail.createdAt)}
@@ -234,8 +250,8 @@ export function SuggestionDetailPanel({
       {isEditing ? (
         <Stack spacing={1.5}>
           <Alert severity="info">
-            Modifiez le titre, la catégorie ou la description puis cliquez sur
-            « Enregistrer ». « Annuler » restaure la version affichée.
+            Modifiez le titre, la catégorie, la priorité ou la description puis
+            cliquez sur « Enregistrer ». « Annuler » restaure la version affichée.
           </Alert>
           <Typography variant="subtitle2" fontWeight={600}>
             Description

--- a/src/components/app-suggestions/SuggestionMaintainerTriageSection.tsx
+++ b/src/components/app-suggestions/SuggestionMaintainerTriageSection.tsx
@@ -13,10 +13,8 @@ import {
 } from "@mui/material";
 import type { AppSuggestionDetail } from "@/lib/app-suggestions/types";
 import { SUGGESTION_STATUSES } from "@/lib/app-suggestions/types";
-import {
-  SUGGESTION_PRIORITY_LABELS,
-  SUGGESTION_STATUS_LABELS,
-} from "@/lib/app-suggestions/status";
+import { SUGGESTION_STATUS_LABELS } from "@/lib/app-suggestions/status";
+import { SuggestionPriorityField } from "@/components/app-suggestions/SuggestionPriorityField";
 
 type Props = {
   detail: AppSuggestionDetail;
@@ -97,19 +95,11 @@ export function SuggestionMaintainerTriageSection({
               </MenuItem>
             ))}
           </TextField>
-          <TextField
-            select
-            label="Priorité"
+          <SuggestionPriorityField
             value={priority}
-            onChange={(event) =>
-              setPriority(event.target.value as AppSuggestionDetail["priority"])
-            }
-            fullWidth
-          >
-            <MenuItem value="low">{SUGGESTION_PRIORITY_LABELS.low}</MenuItem>
-            <MenuItem value="medium">{SUGGESTION_PRIORITY_LABELS.medium}</MenuItem>
-            <MenuItem value="high">{SUGGESTION_PRIORITY_LABELS.high}</MenuItem>
-          </TextField>
+            onChange={setPriority}
+            disabled={submitting}
+          />
         </Stack>
         <TextField
           label="Note officielle (équipe technique)"

--- a/src/components/app-suggestions/SuggestionPriorityChip.tsx
+++ b/src/components/app-suggestions/SuggestionPriorityChip.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Chip } from "@mui/material";
+import type { SuggestionPriority } from "@/lib/app-suggestions/types";
+import {
+  SUGGESTION_PRIORITY_COLORS,
+  SUGGESTION_PRIORITY_LABELS,
+} from "@/lib/app-suggestions/status";
+
+type SuggestionPriorityChipProps = {
+  priority: SuggestionPriority;
+  size?: "small" | "medium";
+};
+
+export function SuggestionPriorityChip({
+  priority,
+  size = "small",
+}: SuggestionPriorityChipProps) {
+  return (
+    <Chip
+      label={SUGGESTION_PRIORITY_LABELS[priority]}
+      size={size}
+      color={SUGGESTION_PRIORITY_COLORS[priority]}
+      variant={priority === "low" ? "outlined" : "filled"}
+      sx={
+        size === "small"
+          ? { height: 22, fontSize: "0.7rem", fontWeight: 600 }
+          : { fontWeight: 600 }
+      }
+    />
+  );
+}

--- a/src/components/app-suggestions/SuggestionPriorityField.tsx
+++ b/src/components/app-suggestions/SuggestionPriorityField.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material/Select";
+import type { SuggestionPriority } from "@/lib/app-suggestions/types";
+import { SUGGESTION_PRIORITIES } from "@/lib/app-suggestions/types";
+import { SUGGESTION_PRIORITY_LABELS } from "@/lib/app-suggestions/status";
+
+type SuggestionPriorityFieldProps = {
+  value: SuggestionPriority;
+  onChange: (value: SuggestionPriority) => void;
+  disabled?: boolean;
+  required?: boolean;
+  fullWidth?: boolean;
+};
+
+export function SuggestionPriorityField({
+  value,
+  onChange,
+  disabled = false,
+  required = false,
+  fullWidth = true,
+}: SuggestionPriorityFieldProps) {
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    onChange(event.target.value as SuggestionPriority);
+  };
+
+  return (
+    <FormControl fullWidth={fullWidth} required={required} disabled={disabled}>
+      <InputLabel id="suggestion-priority-label">Priorité</InputLabel>
+      <Select
+        labelId="suggestion-priority-label"
+        label="Priorité"
+        value={value}
+        onChange={handleChange}
+      >
+        {SUGGESTION_PRIORITIES.map((priority) => (
+          <MenuItem key={priority} value={priority}>
+            {SUGGESTION_PRIORITY_LABELS[priority]}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/components/app-suggestions/SuggestionsListPanel.tsx
+++ b/src/components/app-suggestions/SuggestionsListPanel.tsx
@@ -18,6 +18,7 @@ import {
   SUGGESTION_STATUS_LABELS,
 } from "@/lib/app-suggestions/status";
 import { formatSuggestionDate } from "@/components/app-suggestions/format-utils";
+import { SuggestionPriorityChip } from "@/components/app-suggestions/SuggestionPriorityChip";
 import { suggestionListItemSx } from "@/components/app-suggestions/suggestions-surface-styles";
 
 type SuggestionsListPanelProps = {
@@ -130,6 +131,7 @@ export function SuggestionsListPanel({
                     variant="outlined"
                     sx={{ height: 22, fontSize: "0.7rem" }}
                   />
+                  <SuggestionPriorityChip priority={suggestion.priority} />
                   <Typography variant="caption" color="text.secondary" sx={{ alignSelf: "center" }}>
                     {suggestion.submitterDisplayName || "Utilisateur"} ·{" "}
                     {formatSuggestionDate(suggestion.createdAt)}

--- a/src/components/app-suggestions/useSuggestions.ts
+++ b/src/components/app-suggestions/useSuggestions.ts
@@ -7,6 +7,7 @@ import type {
   AppSuggestionSummary,
   SuggestionCategory,
   SuggestionKind,
+  SuggestionPriority,
 } from "@/lib/app-suggestions/types";
 
 export type SuggestionsPageInfo = {
@@ -180,6 +181,7 @@ export function useSuggestionDetail() {
       description: string;
       kind: SuggestionKind;
       category: SuggestionCategory;
+      priority: SuggestionPriority;
     }) => {
       const response = await fetch("/api/club/suggestions", {
         method: "POST",
@@ -226,6 +228,7 @@ export function useSuggestionDetail() {
         title: string;
         description: string;
         category: SuggestionCategory;
+        priority: SuggestionPriority;
       }>
     ) => {
       const response = await fetch(`/api/club/suggestions/${id}`, {

--- a/src/lib/app-suggestions/priority-fields.test.ts
+++ b/src/lib/app-suggestions/priority-fields.test.ts
@@ -1,0 +1,20 @@
+import {
+  buildSuggestionPriorityFields,
+  resolveStoredSuggestionPriority,
+} from "@/lib/app-suggestions/priority-fields";
+import { SUGGESTION_PRIORITY_RANK } from "@/lib/app-suggestions/status";
+
+describe("buildSuggestionPriorityFields", () => {
+  it("associe le rang numérique à la priorité", () => {
+    expect(buildSuggestionPriorityFields("high")).toEqual({
+      priority: "high",
+      priorityRank: SUGGESTION_PRIORITY_RANK.high,
+    });
+  });
+});
+
+describe("resolveStoredSuggestionPriority", () => {
+  it("retombe sur moyenne si absent", () => {
+    expect(resolveStoredSuggestionPriority(undefined)).toBe("medium");
+  });
+});

--- a/src/lib/app-suggestions/priority-fields.ts
+++ b/src/lib/app-suggestions/priority-fields.ts
@@ -1,0 +1,18 @@
+import type { SuggestionPriority } from "@/lib/app-suggestions/types";
+import { SUGGESTION_PRIORITY_RANK } from "@/lib/app-suggestions/status";
+
+export function resolveStoredSuggestionPriority(
+  priority: SuggestionPriority | undefined
+): SuggestionPriority {
+  return priority ?? "medium";
+}
+
+export function buildSuggestionPriorityFields(priority: SuggestionPriority): {
+  priority: SuggestionPriority;
+  priorityRank: number;
+} {
+  return {
+    priority,
+    priorityRank: SUGGESTION_PRIORITY_RANK[priority],
+  };
+}

--- a/src/lib/app-suggestions/schema.ts
+++ b/src/lib/app-suggestions/schema.ts
@@ -89,6 +89,7 @@ export const suggestionCreateSchema = z.object({
   description: richDescriptionSchema,
   kind: kindSchema,
   category: categorySchema,
+  priority: z.enum(SUGGESTION_PRIORITIES).default("medium"),
 });
 
 export type SuggestionCreateInput = z.infer<typeof suggestionCreateSchema>;
@@ -98,12 +99,14 @@ export const suggestionAuthorPatchSchema = z
     title: titleSchema.optional(),
     description: richDescriptionSchema.optional(),
     category: categorySchema.optional(),
+    priority: z.enum(SUGGESTION_PRIORITIES).optional(),
   })
   .refine(
     (value) =>
       value.title !== undefined ||
       value.description !== undefined ||
-      value.category !== undefined,
+      value.category !== undefined ||
+      value.priority !== undefined,
     { message: "Aucune modification fournie" }
   );
 

--- a/src/lib/app-suggestions/serialize.ts
+++ b/src/lib/app-suggestions/serialize.ts
@@ -1,5 +1,6 @@
 import type { Timestamp } from "firebase-admin/firestore";
 import { getSuggestionDescriptionExcerpt } from "@/lib/app-suggestions/rich-text";
+import { resolveStoredSuggestionPriority } from "@/lib/app-suggestions/priority-fields";
 import type {
   AppSuggestionComment,
   AppSuggestionCommentRecord,
@@ -65,7 +66,7 @@ export function serializeSuggestionSummary(
     ),
     kind: resolveSuggestionKind(data.kind),
     category: data.category,
-    priority: data.priority,
+    priority: resolveStoredSuggestionPriority(data.priority),
     status: data.status,
     submitterUid: data.submitterUid,
     submitterDisplayName: data.submitterDisplayName,

--- a/src/lib/app-suggestions/status.test.ts
+++ b/src/lib/app-suggestions/status.test.ts
@@ -2,6 +2,8 @@ import {
   matchesSuggestionStatusFilter,
   resolveSuggestionStatusFilter,
   SUGGESTION_OPEN_STATUSES,
+  SUGGESTION_PRIORITY_RANK,
+  compareSuggestionsByPriority,
 } from "@/lib/app-suggestions/status";
 
 describe("resolveSuggestionStatusFilter", () => {
@@ -30,5 +32,33 @@ describe("matchesSuggestionStatusFilter", () => {
     for (const status of SUGGESTION_OPEN_STATUSES) {
       expect(matchesSuggestionStatusFilter(status, "open")).toBe(true);
     }
+  });
+});
+
+describe("compareSuggestionsByPriority", () => {
+  it("classe la haute priorité avant la basse", () => {
+    const sorted = [
+      { priority: "low" as const, createdAt: "2026-01-02T00:00:00.000Z" },
+      { priority: "high" as const, createdAt: "2026-01-01T00:00:00.000Z" },
+      { priority: "medium" as const, createdAt: "2026-01-03T00:00:00.000Z" },
+    ].sort(compareSuggestionsByPriority);
+
+    expect(sorted.map((item) => item.priority)).toEqual(["high", "medium", "low"]);
+  });
+
+  it("départage à date égale de priorité", () => {
+    expect(
+      compareSuggestionsByPriority(
+        { priority: "medium", createdAt: "2026-01-01T00:00:00.000Z" },
+        { priority: "medium", createdAt: "2026-01-02T00:00:00.000Z" }
+      )
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("SUGGESTION_PRIORITY_RANK", () => {
+  it("ordonne haute > moyenne > basse", () => {
+    expect(SUGGESTION_PRIORITY_RANK.high).toBeGreaterThan(SUGGESTION_PRIORITY_RANK.medium);
+    expect(SUGGESTION_PRIORITY_RANK.medium).toBeGreaterThan(SUGGESTION_PRIORITY_RANK.low);
   });
 });

--- a/src/lib/app-suggestions/status.ts
+++ b/src/lib/app-suggestions/status.ts
@@ -1,4 +1,8 @@
-import type { SuggestionKind, SuggestionStatus } from "@/lib/app-suggestions/types";
+import type {
+  SuggestionKind,
+  SuggestionPriority,
+  SuggestionStatus,
+} from "@/lib/app-suggestions/types";
 import { formatSuggestionCategoryLabel } from "@/lib/app-suggestions/categories";
 
 export { formatSuggestionCategoryLabel };
@@ -37,11 +41,39 @@ export const SUGGESTION_KIND_COLORS: Record<
   problem: "warning",
 };
 
-export const SUGGESTION_PRIORITY_LABELS = {
+export const SUGGESTION_PRIORITY_LABELS: Record<SuggestionPriority, string> = {
   low: "Basse",
   medium: "Moyenne",
   high: "Haute",
-} as const;
+};
+
+export const SUGGESTION_PRIORITY_COLORS: Record<
+  SuggestionPriority,
+  "default" | "warning" | "error"
+> = {
+  low: "default",
+  medium: "warning",
+  high: "error",
+};
+
+export const SUGGESTION_PRIORITY_RANK: Record<SuggestionPriority, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+export function compareSuggestionsByPriority(
+  left: { priority: SuggestionPriority; createdAt: string },
+  right: { priority: SuggestionPriority; createdAt: string }
+): number {
+  const rankDiff =
+    SUGGESTION_PRIORITY_RANK[right.priority] -
+    SUGGESTION_PRIORITY_RANK[left.priority];
+  if (rankDiff !== 0) {
+    return rankDiff;
+  }
+  return new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime();
+}
 
 /** Retours encore en suivi (hors livrés ou classés sans suite). */
 export const SUGGESTION_OPEN_STATUSES = [

--- a/src/lib/app-suggestions/store.ts
+++ b/src/lib/app-suggestions/store.ts
@@ -21,6 +21,7 @@ import type {
 import { SUGGESTION_SCHEMA_VERSION } from "@/lib/app-suggestions/types";
 import {
   SUGGESTION_OPEN_STATUSES,
+  compareSuggestionsByPriority,
   type SuggestionStatusFilter,
 } from "@/lib/app-suggestions/status";
 import { resolveStoredCommentCount } from "@/lib/app-suggestions/resolve-comment-count";
@@ -37,6 +38,7 @@ import {
   isValidSuggestionCategory,
   normalizeSuggestionCategory,
 } from "@/lib/app-suggestions/categories";
+import { buildSuggestionPriorityFields } from "@/lib/app-suggestions/priority-fields";
 
 const COLLECTION = "appSuggestions";
 
@@ -63,7 +65,7 @@ export async function createSuggestion(
     descriptionFormat: "html",
     kind: input.kind,
     category: input.category,
-    priority: "medium",
+    ...buildSuggestionPriorityFields(input.priority),
     status: "received",
     submitterUid: submitter.uid,
     submitterDisplayName: submitter.displayName,
@@ -96,7 +98,8 @@ function buildSuggestionsListQuery(
     kindFilter: SuggestionKind | "all";
     mineOnly: boolean;
     submitterUid?: string;
-  }
+  },
+  sortMode: "priority" | "createdAt" = "priority"
 ): FirebaseFirestore.Query {
   let query: FirebaseFirestore.Query = suggestionsCollection(db);
 
@@ -115,7 +118,93 @@ function buildSuggestionsListQuery(
     query = query.where("category", "==", filters.categoryFilter);
   }
 
+  if (sortMode === "priority") {
+    return query.orderBy("priorityRank", "desc").orderBy("createdAt", "desc");
+  }
+
   return query.orderBy("createdAt", "desc");
+}
+
+function isMissingOrBuildingIndexError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = (error as { code?: number }).code;
+  const message = String((error as { message?: string }).message ?? "");
+
+  return (
+    code === 9 &&
+    (message.includes("requires an index") ||
+      message.includes("index is currently building"))
+  );
+}
+
+async function fetchSuggestionsPageDocs(
+  db: Firestore,
+  filters: {
+    statusFilter: SuggestionStatusFilter;
+    categoryFilter: SuggestionCategory | "all";
+    kindFilter: SuggestionKind | "all";
+    mineOnly: boolean;
+    submitterUid?: string;
+  },
+  options: {
+    pageSize: number;
+    cursor?: string | null;
+  }
+): Promise<{
+  docs: FirebaseFirestore.QueryDocumentSnapshot[];
+  sortedInMemory: boolean;
+}> {
+  const runQuery = async (sortMode: "priority" | "createdAt") => {
+    let query = buildSuggestionsListQuery(db, filters, sortMode);
+
+    if (options.cursor) {
+      const cursorDoc = await suggestionsCollection(db).doc(options.cursor).get();
+      if (cursorDoc.exists) {
+        query = query.startAfter(cursorDoc);
+      }
+    }
+
+    return query.limit(options.pageSize).get();
+  };
+
+  try {
+    const snapshot = await runQuery("priority");
+    return { docs: snapshot.docs, sortedInMemory: false };
+  } catch (error) {
+    if (!isMissingOrBuildingIndexError(error)) {
+      throw error;
+    }
+
+    const snapshot = await runQuery("createdAt");
+    return { docs: snapshot.docs, sortedInMemory: true };
+  }
+}
+
+async function finalizeSuggestionPage(
+  db: Firestore,
+  docs: FirebaseFirestore.QueryDocumentSnapshot[],
+  pageSize: number,
+  sortedInMemory: boolean
+): Promise<{
+  suggestions: AppSuggestionSummary[];
+  hasNextPage: boolean;
+  nextCursor: string | null;
+}> {
+  const hasNextPage = docs.length > pageSize;
+  const pageDocs = hasNextPage ? docs.slice(0, pageSize) : docs;
+  let suggestions = await mapSuggestionDocs(db, pageDocs);
+
+  if (sortedInMemory) {
+    suggestions = [...suggestions].sort(compareSuggestionsByPriority);
+  }
+
+  const lastDoc = pageDocs.at(-1);
+  const nextCursor = hasNextPage && lastDoc ? lastDoc.id : null;
+
+  return { suggestions, hasNextPage, nextCursor };
 }
 
 async function mapSuggestionDocs(
@@ -181,38 +270,35 @@ export async function listSuggestions(
     let cursor = options.cursor ?? null;
 
     while (matched.length < pageSize + 1) {
-      let query = buildSuggestionsListQuery(db, {
-        ...options,
-        kindFilter: "all",
-      });
+      const page = await fetchSuggestionsPageDocs(
+        db,
+        { ...options, kindFilter: "all" },
+        { pageSize: pageSize + 1, cursor }
+      );
 
-      if (cursor) {
-        const cursorDoc = await suggestionsCollection(db).doc(cursor).get();
-        if (cursorDoc.exists) {
-          query = query.startAfter(cursorDoc);
-        }
-      }
-
-      const snapshot = await query.limit(pageSize + 1).get();
-      if (snapshot.empty) {
+      if (page.docs.length === 0) {
         break;
       }
 
-      const suggestions = await mapSuggestionDocs(db, snapshot.docs);
-      matched.push(...suggestions.filter((suggestion) => suggestion.kind === "improvement"));
+      const suggestions = await mapSuggestionDocs(db, page.docs);
+      matched.push(
+        ...suggestions.filter((suggestion) => suggestion.kind === "improvement")
+      );
 
-      if (snapshot.docs.length <= pageSize) {
+      if (page.docs.length <= pageSize) {
         break;
       }
 
-      cursor = snapshot.docs[snapshot.docs.length - 1]?.id ?? null;
+      cursor = page.docs[page.docs.length - 1]?.id ?? null;
       if (!cursor) {
         break;
       }
     }
 
     const hasNextPage = matched.length > pageSize;
-    const suggestions = matched.slice(0, pageSize);
+    const suggestions = matched
+      .slice(0, pageSize)
+      .sort(compareSuggestionsByPriority);
     const nextCursor =
       hasNextPage && suggestions.length > 0
         ? (suggestions[suggestions.length - 1]?.id ?? null)
@@ -221,27 +307,12 @@ export async function listSuggestions(
     return { suggestions, hasNextPage, nextCursor };
   }
 
-  let query = buildSuggestionsListQuery(db, options);
+  const page = await fetchSuggestionsPageDocs(db, options, {
+    pageSize: pageSize + 1,
+    ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
+  });
 
-  if (options.cursor) {
-    const cursorDoc = await suggestionsCollection(db).doc(options.cursor).get();
-    if (cursorDoc.exists) {
-      query = query.startAfter(cursorDoc);
-    }
-  }
-
-  const snapshot = await query.limit(pageSize + 1).get();
-  const docs = snapshot.docs;
-  const hasNextPage = docs.length > pageSize;
-  const pageDocs = hasNextPage ? docs.slice(0, pageSize) : docs;
-  const lastDoc = pageDocs.at(-1);
-  const nextCursor = hasNextPage && lastDoc ? lastDoc.id : null;
-
-  return {
-    suggestions: await mapSuggestionDocs(db, pageDocs),
-    hasNextPage,
-    nextCursor,
-  };
+  return finalizeSuggestionPage(db, page.docs, pageSize, page.sortedInMemory);
 }
 
 export async function getSuggestionDetail(
@@ -302,6 +373,9 @@ export async function patchSuggestionAsAuthor(
     updates.descriptionFormat = "html";
   }
   if (patch.category !== undefined) updates.category = patch.category;
+  if (patch.priority !== undefined) {
+    Object.assign(updates, buildSuggestionPriorityFields(patch.priority));
+  }
 
   await docRef.update(updates);
 
@@ -352,7 +426,9 @@ export async function patchSuggestionAsMaintainer(
     updates.statusUpdatedByDisplayName = maintainer.displayName;
     updates.statusHistory = [...(current.statusHistory ?? []), historyEntry];
   }
-  if (patch.priority !== undefined) updates.priority = patch.priority;
+  if (patch.priority !== undefined) {
+    Object.assign(updates, buildSuggestionPriorityFields(patch.priority));
+  }
   if (patch.maintainerNote !== undefined) {
     updates.maintainerNote = patch.maintainerNote;
   }

--- a/src/lib/app-suggestions/types.ts
+++ b/src/lib/app-suggestions/types.ts
@@ -60,6 +60,8 @@ export interface AppSuggestionRecord {
   kind?: SuggestionKind;
   category: SuggestionCategory;
   priority: SuggestionPriority;
+  /** Tri Firestore (3 = haute, 2 = moyenne, 1 = basse). */
+  priorityRank?: number;
   status: SuggestionStatus;
   submitterUid: string;
   submitterDisplayName: string | null;


### PR DESCRIPTION
## Summary
- Priorité visible pour tous (badge liste + détail)
- Choix/modification par le déclarant et le mainteneur
- Tri Firestore par `priorityRank` avec repli si index en construction
- Index Firestore mis à jour + script de backfill

## Test plan
- [x] `npm run check`
- [x] Backfill prod/staging exécuté manuellement
- [ ] Vérifier tri haute → basse sur la boîte à idées
- [ ] Vérifier création avec priorité


Made with [Cursor](https://cursor.com)