### PR TITLE
🛡️ Sentinel: Harden sync-status API and fix info leakage

### DIFF
--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,38 +1,14 @@
-export const runtime = "nodejs";
-
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
+export const GET = withAuth(async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
+    console.log(
+      "🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe..."
+    );
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
-        },
-        { status: 403 }
-      );
-    }
-
-    console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
-
-    await initializeFirebaseAdmin();
     const db = getFirestoreAdmin();
 
     const [metadataDoc, playersSnapshot, teamsSnapshot] = await Promise.all([
@@ -74,16 +50,18 @@ export async function GET() {
       { status: 200 }
     );
   } catch (error) {
-    console.error("❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:", error);
+    console.error(
+      "❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:",
+      error
+    );
     return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
+}, [USER_ROLES.ADMIN]);
 
-
+export const runtime = "nodejs";


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The `/api/admin/sync-status` endpoint was using manual authentication logic and leaking internal `error.message` details in its 500 error responses.
🎯 **Impact**: Raw error messages could expose internal system architecture or Firestore configuration to potential attackers. Additionally, the manual auth check did not explicitly enforce the `email_verified` claim, which is a project requirement for administrative access.
🔧 **Fix**: 
- Wrapped the GET handler with the `withAuth` HOC to standardize authorization.
- Explicitly required the `ADMIN` role.
- Removed `details: error.message` from the catch block to prevent information disclosure.
- Created the Sentinel security journal at `.jules/sentinel.md` to document this pattern.
✅ **Verification**: 
- Successfully ran `npm run check:dev` (linting/type-check).
- Successfully ran `npm run check` (full production build and Jest test suite).
- Manually verified that the code uses the centralized authorization utility.

---
*PR created automatically by Jules for task [8450407566011641944](https://jules.google.com/task/8450407566011641944) started by @omichalo*