### PR TITLE
release: dispositif école et alignement config adhésion

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -27,7 +27,8 @@ import { normalizeApplicantNotes } from "@/lib/club-registration/applicant-notes
 import { scrollToFormTarget } from "@/lib/club-registration/scroll-to-form-target";
 import type { ClubRegistrationPayload } from "@/lib/club-registration/schema";
 import { buildRegistrationPayloadSchema } from "@/lib/club-registration/schema";
-import { useRegistrationConfigValue } from "@/hooks/useRegistrationConfig";
+import { useRegistrationConfig } from "@/hooks/useRegistrationConfig";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
 import { isAtLeast40At, isMinorAt } from "@/lib/club-registration/age";
 import {
   shouldAutofillAdherentEmailFromAccount,
@@ -52,7 +53,7 @@ import {
   logRegistrationWizardDebug,
   summarizeRepresentativesForDebug,
 } from "@/lib/club-registration/registration-wizard-debug";
-import { sanitizeSchoolPickupSlotIds } from "@/lib/club-registration/school-pickup";
+import { sanitizeSchoolPickupSlotIdsFromConfig } from "@/lib/club-registration-config/helpers";
 import { AudienceStep } from "./AudienceStep";
 import { AdherentStep } from "./AdherentStep";
 import { RepresentativesStep } from "./RepresentativesStep";
@@ -66,6 +67,7 @@ import { validateStep, validateStepById } from "./step-validation";
 import { useRegistrationStickyOffsets } from "./useRegistrationStickyOffsets";
 import { useRegistrationDraft } from "./useRegistrationDraft";
 import { useRegistrationDraftStorage } from "./useRegistrationDraftStorage";
+import { useRegistrationWizardHydration } from "./useRegistrationWizardHydration";
 import { DraftStorageDisclosure } from "./DraftStorageDisclosure";
 import { AccountEmailTransparencyBanner } from "./AccountEmailTransparencyBanner";
 import { AuthDialog } from "@/components/auth/AuthDialog";
@@ -88,11 +90,17 @@ export function ClubRegistrationWizard({
   accountEmail,
   isRegistrationManager = false,
 }: Props) {
-  const config = useRegistrationConfigValue();
+  const { config: loadedConfig, loading: configLoading } = useRegistrationConfig();
+  const config = loadedConfig ?? getDefaultRegistrationConfig();
   const { draft, actions } = useRegistrationDraft();
   const storage = useRegistrationDraftStorage();
   const [activeStep, setActiveStep] = useState(0);
-  const [hydrating, setHydrating] = useState(true);
+  const hydrating = useRegistrationWizardHydration({
+    config,
+    configLoading,
+    storage,
+    hydrate: actions.hydrate,
+  });
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<
     Record<string, string[] | undefined> | null
@@ -100,7 +108,6 @@ export function ClubRegistrationWizard({
   const [submitting, setSubmitting] = useState(false);
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const pendingPayloadRef = useRef<ClubRegistrationPayload | null>(null);
-  const hasHydratedRef = useRef(false);
   const accountEmailAutofillRef = useRef<{
     selfContact?: string;
     representativeContact?: string;
@@ -112,17 +119,6 @@ export function ClubRegistrationWizard({
   const scrollPositionsRef = useRef<Map<number, number>>(new Map());
   const navStickyRef = useRef<HTMLDivElement | null>(null);
   const stickyOffsets = useRegistrationStickyOffsets(navStickyRef, activeStep);
-
-  /* Hydratation au mount : local-first, fallback éventuel sur le draft serveur. */
-  const storageLoad = storage.load;
-  const hydrate = actions.hydrate;
-  useEffect(() => {
-    if (hasHydratedRef.current) return;
-    hasHydratedRef.current = true;
-    const local = storageLoad();
-    if (local) hydrate(local);
-    setHydrating(false);
-  }, [hydrate, storageLoad]);
 
   /* Séquence d'étapes dynamique (5 étapes pour un majeur, 6 pour un mineur,
      toutes hors récap). La séquence est reconstruite à chaque changement de
@@ -136,7 +132,7 @@ export function ClubRegistrationWizard({
 
   const revealStepValidationError = useCallback(
     (stepId: RegistrationStepId) => {
-      const result = validateStep(stepId, draft);
+      const result = validateStep(stepId, draft, config);
       if (result.valid) return true;
       setSubmitError(result.message);
       scrollToFormTarget(result.focusSelector, {
@@ -149,7 +145,7 @@ export function ClubRegistrationWizard({
       });
       return false;
     },
-    [draft]
+    [draft, config]
   );
 
   /* Si la séquence vient de raccourcir (passage mineur → majeur après coup) et
@@ -162,8 +158,8 @@ export function ClubRegistrationWizard({
   }, [activeStep, sequence.length]);
 
   const stepValidity = useMemo<(string | null)[]>(
-    () => sequence.map((id) => validateStepById(id, draft)),
-    [draft, sequence]
+    () => sequence.map((id) => validateStepById(id, draft, config)),
+    [config, draft, sequence]
   );
 
   const completedStepsCount = useMemo(
@@ -363,7 +359,7 @@ export function ClubRegistrationWizard({
       }
       for (let s = activeStep; s < to; s++) {
         const stepId = sequence[s];
-        const result = validateStep(stepId, draft);
+        const result = validateStep(stepId, draft, config);
         if (!result.valid) {
           setActiveStep(s);
           setSubmitError(result.message);
@@ -380,7 +376,7 @@ export function ClubRegistrationWizard({
       }
       setActiveStep(to);
     },
-    [activeStep, draft, sequence]
+    [activeStep, config, draft, sequence]
   );
 
   /** Navigation vers une étape par son identifiant symbolique (utilisée par
@@ -483,7 +479,8 @@ export function ClubRegistrationWizard({
           ? draft.optionalJerseySize
           : undefined,
       competitionIds: effectiveCompetitorExtras ? draft.competitionIds : [],
-      schoolPickupSlotIds: sanitizeSchoolPickupSlotIds(
+      schoolPickupSlotIds: sanitizeSchoolPickupSlotIdsFromConfig(
+        config,
         draft.slotIds,
         draft.schoolPickupSlotIds
       ),
@@ -557,7 +554,7 @@ export function ClubRegistrationWizard({
        les cas de navigation libre via le stepper. */
     for (let i = 0; i < sequence.length - 1; i++) {
       const stepId = sequence[i];
-      const result = validateStep(stepId, draft);
+      const result = validateStep(stepId, draft, config);
       if (!result.valid) {
         logRegistrationWizardDebug("handleSubmit: validateStep échoué", {
           stepIndex: i,
@@ -694,7 +691,13 @@ export function ClubRegistrationWizard({
                     <StepButton
                       color="inherit"
                       disabled={
-                        !canNavigateToRegistrationStep(index, activeStep, sequence, draft)
+                        !canNavigateToRegistrationStep(
+                          index,
+                          activeStep,
+                          sequence,
+                          draft,
+                          config
+                        )
                       }
                       onClick={() => handleGoToStep(index)}
                       icon={
@@ -733,7 +736,13 @@ export function ClubRegistrationWizard({
                     color={isPast && stepInvalid ? "error" : "primary"}
                     variant={activeStep === index ? "contained" : "outlined"}
                     disabled={
-                      !canNavigateToRegistrationStep(index, activeStep, sequence, draft)
+                      !canNavigateToRegistrationStep(
+                        index,
+                        activeStep,
+                        sequence,
+                        draft,
+                        config
+                      )
                     }
                     onClick={() => handleGoToStep(index)}
                     aria-current={activeStep === index ? "step" : undefined}

--- a/src/components/club-registration/SchoolPickupAdminFields.tsx
+++ b/src/components/club-registration/SchoolPickupAdminFields.tsx
@@ -2,13 +2,14 @@
 
 import type { ComponentType } from "react";
 import { Grid } from "@mui/material";
-import { SCHOOL_PICKUP_SLOT_IDS } from "@/lib/club-registration/school-pickup";
 
 type Option = { value: string; label: string };
 
 type Props = {
   slotIds: string[];
   schoolPickupSlotIds: string[];
+  /** Créneaux éligibles au dispositif école (config Firestore active). */
+  eligibleSchoolPickupSlotIds: ReadonlySet<string>;
   allSlotOptions: Option[];
   onSlotIdsChange: (slotIds: string[]) => void;
   onSchoolPickupSlotIdsChange: (schoolPickupSlotIds: string[]) => void;
@@ -23,6 +24,7 @@ type Props = {
 export function SchoolPickupAdminFields({
   slotIds,
   schoolPickupSlotIds,
+  eligibleSchoolPickupSlotIds,
   allSlotOptions,
   onSlotIdsChange,
   onSchoolPickupSlotIdsChange,
@@ -49,7 +51,8 @@ export function SchoolPickupAdminFields({
           value={schoolPickupSlotIds.filter((id) => slotIds.includes(id))}
           options={allSlotOptions.filter(
             (option) =>
-              slotIds.includes(option.value) && SCHOOL_PICKUP_SLOT_IDS.has(option.value)
+              slotIds.includes(option.value) &&
+              eligibleSchoolPickupSlotIds.has(option.value)
           )}
           onChange={onSchoolPickupSlotIdsChange}
         />

--- a/src/components/club-registration/club-registration-wizard-steps.ts
+++ b/src/components/club-registration/club-registration-wizard-steps.ts
@@ -1,4 +1,6 @@
 import { isMinorAt } from "@/lib/club-registration/age";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationStepId } from "@/lib/club-registration/field-to-step";
 import type { RegistrationDraft } from "./registration-defaults";
 import { validateStepById } from "./step-validation";
@@ -64,11 +66,12 @@ export function canNavigateToRegistrationStep(
   targetIndex: number,
   activeStep: number,
   sequence: ReadonlyArray<RegistrationStepId>,
-  draft: RegistrationDraft
+  draft: RegistrationDraft,
+  config: RegistrationConfigV1 = getDefaultRegistrationConfig()
 ): boolean {
   if (targetIndex <= activeStep) return true;
   for (let s = activeStep; s < targetIndex; s++) {
-    if (validateStepById(sequence[s], draft) !== null) return false;
+    if (validateStepById(sequence[s], draft, config) !== null) return false;
   }
   return true;
 }

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFormPrimary.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFormPrimary.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
 } from "@mui/material";
 import { Add as AddIcon, Delete as DeleteIcon } from "@mui/icons-material";
-import { getEnabledSections } from "@/lib/club-registration-config/helpers";
+import { getEnabledSections, getSchoolPickupSlotIds } from "@/lib/club-registration-config/helpers";
 import type { Representative } from "@/lib/club-registration/schema";
 import {
   formatPersonDisplayName,
@@ -383,6 +383,7 @@ export function MembershipRequestDetailFormPrimary({ detail, hideTitleHeader = f
         <SchoolPickupAdminFields
           slotIds={form.slotIds}
           schoolPickupSlotIds={form.schoolPickupSlotIds}
+          eligibleSchoolPickupSlotIds={getSchoolPickupSlotIds(config)}
           allSlotOptions={allSlotOptions}
           onSlotIdsChange={(value) => updateField("slotIds", value)}
           onSchoolPickupSlotIdsChange={(value) => updateField("schoolPickupSlotIds", value)}

--- a/src/components/club-registration/membership-requests/to-editable-registration.ts
+++ b/src/components/club-registration/membership-requests/to-editable-registration.ts
@@ -4,7 +4,7 @@ import {
   normalizeMedicalCertificateStatus,
 } from "@/lib/club-registration/medical-certificate";
 import { normalizeReductionReferenceCodes } from "@/lib/club-registration/reduction-reference-codes";
-import { expandCompetitionIdsForForm } from "@/lib/club-registration/competition-ids";
+import { expandCompetitionIdsForFormFromConfig } from "@/lib/club-registration-config/helpers";
 import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
 import type { PaymentAid, RegistrationPayment } from "@/lib/club-registration/payment/types";
 import type { EditableRegistration, RegistrationDetail } from "./types";
@@ -80,7 +80,10 @@ export function toEditableRegistration(
     competitionJerseySize: registration.competitionJerseySize ?? "",
     wantsOptionalJersey: registration.wantsOptionalJersey ?? false,
     optionalJerseySize: registration.optionalJerseySize ?? "",
-    competitionIds: expandCompetitionIdsForForm(registration.competitionIds ?? []),
+    competitionIds: expandCompetitionIdsForFormFromConfig(
+      config,
+      registration.competitionIds ?? []
+    ),
     applicantNotes: registration.applicantNotes ?? "",
     reviewNotes: registration.reviewNotes ?? "",
     amountEuros:

--- a/src/components/club-registration/step-validation.ts
+++ b/src/components/club-registration/step-validation.ts
@@ -1,4 +1,6 @@
 import { isAtLeast40At, isMinorAt } from "@/lib/club-registration/age";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationStepId } from "@/lib/club-registration/field-to-step";
 import {
   effectiveHadFfttLicense,
@@ -54,7 +56,8 @@ function getMedicalFocusSelector(draft: RegistrationDraft): string {
 
 export function validateStep(
   stepId: RegistrationStepId,
-  draft: RegistrationDraft
+  draft: RegistrationDraft,
+  config: RegistrationConfigV1 = getDefaultRegistrationConfig()
 ): StepValidationResult {
   if (stepId === "audience") {
     if (!draft.birthDate) {
@@ -264,7 +267,7 @@ export function validateStep(
         "#medical-dossier-section"
       );
     }
-    const aidIssue = validateAdminAids(draft);
+    const aidIssue = validateAdminAids(draft, config);
     if (aidIssue) {
       return invalid(aidIssue.message, aidIssue.focusSelector);
     }
@@ -324,8 +327,9 @@ export function validateStep(
 /** Message d’erreur uniquement (compatibilité). */
 export function validateStepById(
   stepId: RegistrationStepId,
-  draft: RegistrationDraft
+  draft: RegistrationDraft,
+  config: RegistrationConfigV1 = getDefaultRegistrationConfig()
 ): string | null {
-  const result = validateStep(stepId, draft);
+  const result = validateStep(stepId, draft, config);
   return result.valid ? null : result.message;
 }

--- a/src/components/club-registration/useRegistrationDraft.test.ts
+++ b/src/components/club-registration/useRegistrationDraft.test.ts
@@ -1,5 +1,8 @@
 import { registrationDraftReducer } from "./useRegistrationDraft";
+import { buildDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
 import { createEmptyDraft, createEmptyRepresentative } from "./registration-defaults";
+
+const defaultConfig = buildDefaultRegistrationConfig();
 
 describe("registrationDraftReducer", () => {
   it("PATCH_FIELDS fusionne les champs", () => {
@@ -151,7 +154,11 @@ describe("registrationDraftReducer", () => {
         },
       ],
     };
-    const next = registrationDraftReducer(s, { type: "HYDRATE", draft: hydrated });
+    const next = registrationDraftReducer(s, {
+      type: "HYDRATE",
+      draft: hydrated,
+      config: defaultConfig,
+    });
     expect(next.representatives[0].phone).toBe("");
   });
 
@@ -172,7 +179,11 @@ describe("registrationDraftReducer", () => {
   it("HYDRATE remplace tout l'état par le draft fourni", () => {
     const s = createEmptyDraft();
     const hydrated = { ...createEmptyDraft(), firstName: "Camille" };
-    const next = registrationDraftReducer(s, { type: "HYDRATE", draft: hydrated });
+    const next = registrationDraftReducer(s, {
+      type: "HYDRATE",
+      draft: hydrated,
+      config: defaultConfig,
+    });
     expect(next.firstName).toBe("Camille");
   });
 

--- a/src/components/club-registration/useRegistrationDraft.ts
+++ b/src/components/club-registration/useRegistrationDraft.ts
@@ -6,7 +6,8 @@ import {
   inferMedicalDossierFromDeclaration,
   syncMedicalCertificateDeclaration,
 } from "@/lib/club-registration/medical-dossier";
-import { expandCompetitionIdsForForm } from "@/lib/club-registration/competition-ids";
+import { expandCompetitionIdsForFormFromConfig } from "@/lib/club-registration-config/helpers";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import {
   normalizeReductionReferenceCodes,
 } from "@/lib/club-registration/reduction-reference-codes";
@@ -35,7 +36,7 @@ export type RegistrationDraftAction =
   | { type: "ADD_REPRESENTATIVE"; representative?: Representative }
   | { type: "UPDATE_REPRESENTATIVE"; index: number; patch: Partial<Representative> }
   | { type: "REMOVE_REPRESENTATIVE"; index: number }
-  | { type: "HYDRATE"; draft: RegistrationDraft }
+  | { type: "HYDRATE"; draft: RegistrationDraft; config: RegistrationConfigV1 }
   | { type: "RESET" };
 
 export function registrationDraftReducer(
@@ -123,7 +124,10 @@ export function registrationDraftReducer(
         merged.medicalQuestionnaire = inferred.questionnaire;
         merged.medicalVeteranPath = inferred.veteranPath;
       }
-      merged.competitionIds = expandCompetitionIdsForForm(merged.competitionIds);
+      merged.competitionIds = expandCompetitionIdsForFormFromConfig(
+        action.config,
+        merged.competitionIds
+      );
       merged.representatives = normalizeRepresentatives(merged.representatives);
       merged.reductionReferenceCodes = normalizeReductionReferenceCodes(
         merged.reductionReferenceCodes,
@@ -147,7 +151,7 @@ export type RegistrationDraftActions = {
   addRepresentative: (rep?: Representative) => void;
   updateRepresentative: (index: number, patch: Partial<Representative>) => void;
   removeRepresentative: (index: number) => void;
-  hydrate: (draft: RegistrationDraft) => void;
+  hydrate: (draft: RegistrationDraft, config: RegistrationConfigV1) => void;
   reset: () => void;
 };
 
@@ -192,7 +196,8 @@ export function useRegistrationDraft(initial?: RegistrationDraft): {
     []
   );
   const hydrate = useCallback(
-    (next: RegistrationDraft) => dispatch({ type: "HYDRATE", draft: next }),
+    (next: RegistrationDraft, config: RegistrationConfigV1) =>
+      dispatch({ type: "HYDRATE", draft: next, config }),
     []
   );
   const reset = useCallback(() => dispatch({ type: "RESET" }), []);

--- a/src/components/club-registration/useRegistrationWizardHydration.ts
+++ b/src/components/club-registration/useRegistrationWizardHydration.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import type { RegistrationDraftActions } from "./useRegistrationDraft";
+import type { UseRegistrationDraftStorage } from "./useRegistrationDraftStorage";
+
+type Params = {
+  config: RegistrationConfigV1;
+  configLoading: boolean;
+  storage: UseRegistrationDraftStorage;
+  hydrate: RegistrationDraftActions["hydrate"];
+};
+
+/** Charge le brouillon local une fois la config active disponible. */
+export function useRegistrationWizardHydration({
+  config,
+  configLoading,
+  storage,
+  hydrate,
+}: Params): boolean {
+  const [hydrating, setHydrating] = useState(true);
+  const hasHydratedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasHydratedRef.current || configLoading) return;
+    hasHydratedRef.current = true;
+    const local = storage.load();
+    if (local) hydrate(local, config);
+    setHydrating(false);
+  }, [config, configLoading, hydrate, storage]);
+
+  return hydrating;
+}

--- a/src/lib/club-registration-config/school-pickup-config.test.ts
+++ b/src/lib/club-registration-config/school-pickup-config.test.ts
@@ -1,0 +1,58 @@
+import { sanitizeSchoolPickupSlotIds } from "@/lib/club-registration/school-pickup";
+import { expandCompetitionIdsForForm } from "@/lib/club-registration/competition-ids";
+import { buildDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import {
+  expandCompetitionIdsForFormFromConfig,
+  getSchoolPickupSlotIds,
+  sanitizeSchoolPickupSlotIdsFromConfig,
+} from "@/lib/club-registration-config/helpers";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+
+const DYNAMIC_PICKUP_SLOT_ID = "slot-1782454814153";
+
+function configWithDynamicPickupSlot(): RegistrationConfigV1 {
+  const config = buildDefaultRegistrationConfig();
+  const voisins = config.sites.find((site) => site.id === "voisins");
+  if (!voisins) {
+    throw new Error("site voisins manquant");
+  }
+  voisins.slots.push({
+    id: DYNAMIC_PICKUP_SLOT_ID,
+    label: "Jeudi / 17h00 - 18h00 / Baby Ping (à partir de 4 ans)",
+    enabled: true,
+    sortOrder: 99,
+    schoolPickupSchool: "École des Pépinières",
+  });
+  return config;
+}
+
+describe("school pickup config vs constants", () => {
+  it("conserve un créneau paramétré en Firestore absent des constantes legacy", () => {
+    const config = configWithDynamicPickupSlot();
+    const slotIds = [DYNAMIC_PICKUP_SLOT_ID];
+    const pickupIds = [DYNAMIC_PICKUP_SLOT_ID];
+
+    expect(getSchoolPickupSlotIds(config).has(DYNAMIC_PICKUP_SLOT_ID)).toBe(true);
+    expect(
+      sanitizeSchoolPickupSlotIdsFromConfig(config, slotIds, pickupIds)
+    ).toEqual(pickupIds);
+    expect(sanitizeSchoolPickupSlotIds(slotIds, pickupIds)).toEqual([]);
+  });
+
+  it("déplie un bundle compétitions paramétré absent des constantes legacy", () => {
+    const config = buildDefaultRegistrationConfig();
+    config.competitionBundles.push({
+      billingId: "custom_youth_bundle",
+      sourceIds: ["custom_comp_a", "custom_comp_b"],
+      priceCents: 3_000,
+      formLabel: "Forfait jeunes custom",
+    });
+
+    const stored = ["custom_youth_bundle"];
+    expect(expandCompetitionIdsForFormFromConfig(config, stored)).toEqual([
+      "custom_comp_a",
+      "custom_comp_b",
+    ]);
+    expect(expandCompetitionIdsForForm(stored)).toEqual(["custom_youth_bundle"]);
+  });
+});

--- a/src/lib/club-registration/competition-ids.ts
+++ b/src/lib/club-registration/competition-ids.ts
@@ -31,6 +31,9 @@ export function isYouthCompetitionId(id: string): boolean {
  * Déplie l’id de facturation historique vers les deux options formulaire
  * (dossiers créés avant la séparation des compétitions jeunes).
  */
+/**
+ * @deprecated Préférer `expandCompetitionIdsForFormFromConfig(config, ids)`.
+ */
 export function expandCompetitionIdsForForm(ids: string[]): string[] {
   const expanded: string[] = [];
 
@@ -54,6 +57,9 @@ export function expandCompetitionIdsForForm(ids: string[]): string[] {
 /**
  * Une seule ligne « Compétitions jeunes » à 25 € pour la facturation,
  * même si une ou les deux compétitions jeunes sont cochées.
+ */
+/**
+ * @deprecated Préférer `normalizeCompetitionIdsFromConfig(config, ids)`.
  */
 export function normalizeCompetitionIds(ids: string[]): string[] {
   const normalized: string[] = [];

--- a/src/lib/club-registration/school-pickup.ts
+++ b/src/lib/club-registration/school-pickup.ts
@@ -15,12 +15,14 @@ export const SCHOOL_PICKUP_SERVICE = {
     "Je souhaite bénéficier de la récupération à la sortie de l’école pour ce créneau",
 } as const;
 
+/** @deprecated Préférer `getSchoolPickupSlotIds(config)` — liste figée dans `constants.ts`. */
 export const SCHOOL_PICKUP_SLOT_IDS: ReadonlySet<string> = new Set(
   CLUB_REGISTRATION_SITES.flatMap((site) =>
     site.slots.filter((slot) => slot.schoolPickupSchool).map((slot) => slot.id)
   )
 );
 
+/** @deprecated Préférer `getSlotSchoolPickupSchool(config, slotId)`. */
 export function getSlotSchoolPickupSchool(slotId: string): string | undefined {
   for (const site of CLUB_REGISTRATION_SITES) {
     const slot = site.slots.find((s) => s.id === slotId);
@@ -29,6 +31,10 @@ export function getSlotSchoolPickupSchool(slotId: string): string | undefined {
   return undefined;
 }
 
+/**
+ * @deprecated Préférer `sanitizeSchoolPickupSlotIdsFromConfig(config, slotIds, schoolPickupSlotIds)`.
+ * Cette variante ignore les créneaux ajoutés via le paramétrage Firestore.
+ */
 export function sanitizeSchoolPickupSlotIds(
   slotIds: readonly string[],
   schoolPickupSlotIds: readonly string[]

--- a/src/lib/club-registration/validate-admin-aids.test.ts
+++ b/src/lib/club-registration/validate-admin-aids.test.ts
@@ -1,5 +1,7 @@
 import { validateAdminAids } from "./validate-admin-aids";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
 
+const config = getDefaultRegistrationConfig();
 const baseDraft = {
   birthDate: "2000-04-12",
   mainSectionId: "voisins",
@@ -13,21 +15,27 @@ const baseDraft = {
 
 describe("validateAdminAids", () => {
   it("exige une entrée de paiement pour chaque aide cochée", () => {
-    const issue = validateAdminAids({
-      ...baseDraft,
-      reductionTypes: ["pass_sport"],
-      paymentAids: [],
-    });
+    const issue = validateAdminAids(
+      {
+        ...baseDraft,
+        reductionTypes: ["pass_sport"],
+        paymentAids: [],
+      },
+      config
+    );
     expect(issue?.message).toMatch(/0 €/);
     expect(issue?.focusSelector).toBe('[data-field="paymentAid.pass_sport"]');
   });
 
   it("refuse un montant nul pour une aide cochée", () => {
-    const issue = validateAdminAids({
-      ...baseDraft,
-      reductionTypes: ["pass_sport"],
-      paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 0 }],
-    });
+    const issue = validateAdminAids(
+      {
+        ...baseDraft,
+        reductionTypes: ["pass_sport"],
+        paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 0 }],
+      },
+      config
+    );
     expect(issue?.message).toMatch(/0 €/);
   });
 });

--- a/src/lib/club-registration/validate-admin-aids.ts
+++ b/src/lib/club-registration/validate-admin-aids.ts
@@ -1,4 +1,4 @@
-import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { buildPricingContext, calculateQuote, formatCentsAsEuros } from "@/lib/pricing";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
 import { findPaymentAid, normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
@@ -23,7 +23,10 @@ type DraftSlice = Pick<
   | "paymentAids"
 >;
 
-function quoteTotalCents(draft: DraftSlice): number | null {
+function quoteTotalCents(
+  draft: DraftSlice,
+  config: RegistrationConfigV1
+): number | null {
   if (!draft.birthDate) return null;
   const sex = draft.sex === "" ? ("other" as const) : draft.sex;
   const quote = calculateQuote(
@@ -38,13 +41,16 @@ function quoteTotalCents(draft: DraftSlice): number | null {
       firstFemaleRegistrationSqy: draft.firstFemaleRegistrationSqy,
       reductionTypes: draft.reductionTypes,
     }),
-    getDefaultRegistrationConfig()
+    config
   );
   return quote.totalCents;
 }
 
 /** Valide les montants d’aides saisis à l’étape dossier administratif. */
-export function validateAdminAids(draft: DraftSlice): AdminAidValidationIssue | null {
+export function validateAdminAids(
+  draft: DraftSlice,
+  config: RegistrationConfigV1
+): AdminAidValidationIssue | null {
   const aids = normalizePaymentAidList(draft.paymentAids);
 
   for (const reductionId of draft.reductionTypes) {
@@ -58,7 +64,7 @@ export function validateAdminAids(draft: DraftSlice): AdminAidValidationIssue | 
     }
   }
 
-  const totalCents = quoteTotalCents(draft);
+  const totalCents = quoteTotalCents(draft, config);
   if (totalCents !== null) {
     const summary = calculatePaymentSummary({
       totalAmountCents: totalCents,


### PR DESCRIPTION
## Summary
- Release staging → production : correction de la perte silencieuse de l’opt-in « sortie école » pour les créneaux paramétrés via Firestore.
- Alignement validation aides admin, bundles compétitions et affichage secrétariat sur la config active.

## Test plan
- [ ] Vérifier une nouvelle inscription avec opt-in sortie école (créneau Baby Ping ou équivalent).
- [ ] Contrôler en prod qu’un dossier existant peut être corrigé manuellement côté secrétariat.


Made with [Cursor](https://cursor.com)