### PR TITLE
feat(club-registration): paramétrer texte et plafond par aide

### DIFF
--- a/src/components/club-registration-config/AidRulesEditor.tsx
+++ b/src/components/club-registration-config/AidRulesEditor.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { InputAdornment, MenuItem, Stack, TextField, Typography } from "@mui/material";
 import type {
   AidRule,
   AidRuleFormPresentation,
   RegistrationConfigV1,
 } from "@/lib/club-registration-config/types";
 import { moveArrayItem } from "@/lib/club-registration-config/sort-order";
-import { generateConfigItemId } from "./config-editor-utils";
+import { getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
+import { generateConfigItemId, centsToEuroInput, euroInputToCents } from "./config-editor-utils";
 import {
   ConfigEditorAddButton,
   ConfigEditorCollapsibleItem,
@@ -33,9 +34,14 @@ function defaultAidForm(): AidRuleFormPresentation {
   return { style: "checkbox" };
 }
 
-function aidSummaryMeta(form: AidRuleFormPresentation): string | undefined {
-  if (form.style === "toggle") return "Interrupteur avec code de référence";
-  return undefined;
+function aidSummaryMeta(rule: AidRule, form: AidRuleFormPresentation): string | undefined {
+  const parts: string[] = [];
+  if (form.style === "toggle") parts.push("Interrupteur avec code de référence");
+  const maxCents = getAidRuleMaxAmountCents(rule);
+  if (maxCents !== undefined) {
+    parts.push(`Plafond ${centsToEuroInput(maxCents)} €`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : undefined;
 }
 
 export function AidRulesEditor({ config, onChange }: Props) {
@@ -83,7 +89,7 @@ export function AidRulesEditor({ config, onChange }: Props) {
                   onExpandedChange={(open) => expansion.setExpanded(rule.id, open)}
                   title={rule.label}
                   itemLabel={rule.label}
-                  meta={aidSummaryMeta(form)}
+                  meta={aidSummaryMeta(rule, form)}
                   decor={aidRuleDecor}
                   dragHandleProps={dragHandleProps}
                   isDragging={isDragging}
@@ -102,6 +108,42 @@ export function AidRulesEditor({ config, onChange }: Props) {
               value={rule.label}
               onChange={(e) => updateRule(index, { label: e.target.value })}
               fullWidth
+            />
+            <TextField
+              label="Texte d'accompagnement (facultatif)"
+              size="small"
+              value={rule.helperText ?? ""}
+              onChange={(e) =>
+                updateRule(index, {
+                  helperText: e.target.value.trim() ? e.target.value : undefined,
+                })
+              }
+              fullWidth
+              multiline
+              minRows={2}
+              helperText="Affiché aux familles à côté de l'aide (conditions, montant indicatif, etc.)."
+            />
+            <TextField
+              label="Montant maximum (facultatif)"
+              size="small"
+              type="number"
+              value={
+                rule.maxAmountCents !== undefined ? centsToEuroInput(rule.maxAmountCents) : ""
+              }
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (!raw.trim()) {
+                  updateRule(index, { maxAmountCents: undefined });
+                  return;
+                }
+                updateRule(index, { maxAmountCents: euroInputToCents(raw) });
+              }}
+              fullWidth
+              inputProps={{ min: 0, step: 0.01 }}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">€</InputAdornment>,
+              }}
+              helperText="Plafond du montant saisi par la famille. Laisser vide pour aucune limite."
             />
             <Typography variant="caption" color="text.secondary" display="block">
               Identifiant technique : <strong>{rule.id}</strong>

--- a/src/components/club-registration/AidEuroAmountField.tsx
+++ b/src/components/club-registration/AidEuroAmountField.tsx
@@ -17,6 +17,7 @@ type Props = {
   size?: "small" | "medium";
   sx?: SxProps<Theme>;
   dataField: string;
+  helperText?: string;
 };
 
 /**
@@ -32,6 +33,7 @@ export function AidEuroAmountField({
   size = "small",
   sx,
   dataField,
+  helperText,
 }: Props) {
   const [text, setText] = useState(() => centsToEurosInput(amountCents));
   const focusedRef = useRef(false);
@@ -68,6 +70,7 @@ export function AidEuroAmountField({
         autoComplete: "off",
       }}
       placeholder="0,00"
+      {...(helperText !== undefined ? { helperText } : {})}
     />
   );
 }

--- a/src/components/club-registration/AidReductionFields.tsx
+++ b/src/components/club-registration/AidReductionFields.tsx
@@ -12,11 +12,14 @@ import {
   Typography,
 } from "@mui/material";
 import {
+  getAidRuleHelperText,
+  getAidRuleMaxAmountCents,
   getCheckboxAidRules,
   getToggleAidRules,
   isToggleAidWithReferenceCode,
 } from "@/lib/club-registration-config/aid-rules";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import { formatCentsAsEuros } from "@/lib/pricing";
 import { AidEuroAmountField } from "./AidEuroAmountField";
 import {
   findPaymentAid,
@@ -49,6 +52,11 @@ const AID_AMOUNT_FIELD_SX = {
   width: "100%",
   maxWidth: 220,
 } as const;
+
+function aidAmountHelperText(ruleMaxCents: number | undefined): string | undefined {
+  if (ruleMaxCents === undefined) return undefined;
+  return `Montant maximum : ${formatCentsAsEuros(ruleMaxCents)}`;
+}
 
 export function AidReductionFields({ config, draft, onChange }: Props) {
   const toggleAidRules = getToggleAidRules(config);
@@ -166,6 +174,8 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
         if (!isToggleAidWithReferenceCode(rule)) return null;
         const selected = draft.reductionTypes.includes(rule.id);
         const aid = findPaymentAid(paymentAids, rule.id);
+        const accompaniment = getAidRuleHelperText(rule);
+        const amountHelperText = aidAmountHelperText(getAidRuleMaxAmountCents(rule));
         return (
           <Stack key={rule.id} spacing={1}>
             <FormControlLabel
@@ -177,6 +187,11 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
               }
               label={rule.form.toggleLabel}
             />
+            {accompaniment ? (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: -0.5 }}>
+                {accompaniment}
+              </Typography>
+            ) : null}
             <Collapse in={selected} timeout={{ enter: 300, exit: 200 }}>
               <Stack spacing={1.5} alignItems="flex-start">
                 <TextField
@@ -197,6 +212,7 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
                   required
                   sx={AID_AMOUNT_FIELD_SX}
                   dataField={`paymentAid.${rule.id}`}
+                  {...(amountHelperText ? { helperText: amountHelperText } : {})}
                 />
               </Stack>
             </Collapse>
@@ -213,6 +229,8 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
             {checkboxAidRules.map((rule) => {
               const selected = draft.reductionTypes.includes(rule.id);
               const aid = findPaymentAid(paymentAids, rule.id);
+              const accompaniment = getAidRuleHelperText(rule);
+              const amountHelperText = aidAmountHelperText(getAidRuleMaxAmountCents(rule));
               return (
                 <Stack key={rule.id} spacing={1} sx={{ mb: selected ? 1.5 : 0 }}>
                   <FormControlLabel
@@ -224,6 +242,15 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
                     }
                     label={rule.label}
                   />
+                  {accompaniment ? (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ pl: 4, mt: -0.5 }}
+                    >
+                      {accompaniment}
+                    </Typography>
+                  ) : null}
                   {selected ? (
                     <Box sx={{ pl: 4 }}>
                       <AidEuroAmountField
@@ -233,6 +260,7 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
                         required
                         sx={AID_AMOUNT_FIELD_SX}
                         dataField={`paymentAid.${rule.id}`}
+                        {...(amountHelperText ? { helperText: amountHelperText } : {})}
                       />
                     </Box>
                   ) : null}

--- a/src/lib/club-registration-config/aid-rules.test.ts
+++ b/src/lib/club-registration-config/aid-rules.test.ts
@@ -1,6 +1,8 @@
 import { getDefaultRegistrationConfig } from "./default-config";
 import {
   DEFAULT_PASS_SPORT_FORM,
+  getAidRuleHelperText,
+  getAidRuleMaxAmountCents,
   getCheckboxAidRules,
   getToggleAidRules,
   repairAidRuleForm,
@@ -26,5 +28,19 @@ describe("aid-rules helpers", () => {
         effect: { type: "admin_review" },
       }).form
     ).toEqual(DEFAULT_PASS_SPORT_FORM);
+  });
+
+  it("normalise helperText et plafond de montant", () => {
+    const rule = {
+      id: "pass_sport",
+      label: "Pass Sport",
+      effect: { type: "admin_review" as const },
+      helperText: "  Jusqu'à 50 €  ",
+      maxAmountCents: 5_000,
+    };
+    expect(getAidRuleHelperText(rule)).toBe("Jusqu'à 50 €");
+    expect(getAidRuleMaxAmountCents(rule)).toBe(5_000);
+    expect(getAidRuleMaxAmountCents({ ...rule, maxAmountCents: 0 })).toBeUndefined();
+    expect(getAidRuleHelperText({ ...rule, helperText: "   " })).toBeUndefined();
   });
 });

--- a/src/lib/club-registration-config/aid-rules.ts
+++ b/src/lib/club-registration-config/aid-rules.ts
@@ -44,3 +44,21 @@ export function repairAidRulesForm(config: RegistrationConfigV1): RegistrationCo
     aidRules: config.aidRules.map(repairAidRuleForm),
   };
 }
+
+export function getAidRuleHelperText(rule: AidRule): string | undefined {
+  const text = rule.helperText?.trim();
+  return text && text.length > 0 ? text : undefined;
+}
+
+export function getAidRuleMaxAmountCents(rule: AidRule): number | undefined {
+  const max = rule.maxAmountCents;
+  if (max === undefined || max <= 0) return undefined;
+  return max;
+}
+
+export function findAidRuleById(
+  config: RegistrationConfigV1,
+  aidId: string
+): AidRule | undefined {
+  return config.aidRules.find((rule) => rule.id === aidId);
+}

--- a/src/lib/club-registration-config/schema.ts
+++ b/src/lib/club-registration-config/schema.ts
@@ -136,6 +136,13 @@ const aidRuleSchema = z.object({
   label: z.string().trim().min(1).max(200),
   effect: aidRuleEffectSchema,
   form: aidRuleFormPresentationSchema.optional(),
+  helperText: optionalTrimmedLabelSchema(500),
+  maxAmountCents: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .transform((value) => (value !== undefined && value > 0 ? value : undefined)),
 });
 
 const stripePresentationSchema = z.object({

--- a/src/lib/club-registration-config/types.ts
+++ b/src/lib/club-registration-config/types.ts
@@ -134,6 +134,10 @@ export type AidRule = {
   label: string;
   effect: AidRuleEffect;
   form?: AidRuleFormPresentation | undefined;
+  /** Texte d'accompagnement affiché aux familles à côté de l'aide. */
+  helperText?: string | undefined;
+  /** Plafond facultatif du montant saisi par la famille (centimes). */
+  maxAmountCents?: number | undefined;
 };
 
 export type StripePresentationConfig = {

--- a/src/lib/club-registration/validate-admin-aids.test.ts
+++ b/src/lib/club-registration/validate-admin-aids.test.ts
@@ -38,4 +38,23 @@ describe("validateAdminAids", () => {
     );
     expect(issue?.message).toMatch(/0 €/);
   });
+
+  it("refuse un montant au-delà du plafond configuré pour l'aide", () => {
+    const cappedConfig = {
+      ...config,
+      aidRules: config.aidRules.map((rule) =>
+        rule.id === "pass_sport" ? { ...rule, maxAmountCents: 5_000 } : rule
+      ),
+    };
+    const issue = validateAdminAids(
+      {
+        ...baseDraft,
+        reductionTypes: ["pass_sport"],
+        paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 5_001 }],
+      },
+      cappedConfig
+    );
+    expect(issue?.message).toMatch(/50,00/);
+    expect(issue?.focusSelector).toBe('[data-field="paymentAid.pass_sport"]');
+  });
 });

--- a/src/lib/club-registration/validate-admin-aids.ts
+++ b/src/lib/club-registration/validate-admin-aids.ts
@@ -1,4 +1,5 @@
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import { findAidRuleById, getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
 import { buildPricingContext, calculateQuote, formatCentsAsEuros } from "@/lib/pricing";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
 import { findPaymentAid, normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
@@ -59,6 +60,16 @@ export function validateAdminAids(
       return {
         message:
           "Indiquez un montant supérieur à 0 € pour chaque aide sélectionnée.",
+        focusSelector: `[data-field="paymentAid.${reductionId}"]`,
+      };
+    }
+
+    const rule = findAidRuleById(config, reductionId);
+    const maxAmountCents = rule ? getAidRuleMaxAmountCents(rule) : undefined;
+    if (maxAmountCents !== undefined && entry.amountCents > maxAmountCents) {
+      const label = rule?.label ?? reductionId;
+      return {
+        message: `Le montant pour « ${label} » ne peut pas dépasser ${formatCentsAsEuros(maxAmountCents)}.`,
         focusSelector: `[data-field="paymentAid.${reductionId}"]`,
       };
     }


### PR DESCRIPTION
## Summary
- Ajoute un texte d'accompagnement et un montant maximum facultatifs par aide dans la config inscription
- Affiche ces informations dans le formulaire familles et valide le plafond à l'étape dossier administratif

## Test plan
- [x] Tests unitaires `aid-rules` et `validate-admin-aids`
- [ ] Configurer une aide avec texte + plafond dans l'éditeur admin
- [ ] Vérifier l'affichage et la validation côté parcours inscription


Made with [Cursor](https://cursor.com)