### PR TITLE
feat(club-registration): paiement self-service, CHAMP'YON, don libre et statut payé

### DIFF
--- a/docs/STRIPE.md
+++ b/docs/STRIPE.md
@@ -85,6 +85,11 @@ checkout.session.completed
    apres remises) », avec description detaillee (brut, remises, net facture) et
    un champ personnalise facture « Remises sur adhesion » (Stripe n'accepte pas de
    montants negatifs sur les line_items).
+   Le **don libre** (optionnel, min. 1 €) apparait en ligne positive ; la remise
+   de 25 % (plafond 73 €) est appliquee via un coupon Stripe visible sur la facture.
+   Les **aides secrétariat** (Pass Sport, etc.) sont fusionnées avec la remise don
+   dans un **seul coupon** Stripe (limite API Checkout) ; le détail figure dans les
+   champs personnalisés de la facture.
 5. Un e-mail contenant le lien de paiement est envoye a l'adherent, au premier
    representant legal, ou au compte soumetteur selon les donnees disponibles.
 6. Lorsque Stripe envoie `checkout.session.completed`, le webhook marque le

--- a/docs/technical/adr/0005-voluntary-donation-discount.md
+++ b/docs/technical/adr/0005-voluntary-donation-discount.md
@@ -1,0 +1,23 @@
+# ADR-0005: Don libre avec remise sur l'adhésion
+
+## Statut
+
+Accepté — 2026-06-29
+
+## Contexte
+
+Le club souhaite permettre un don libre lors de l'inscription, avec une remise de 25 % de ce don sur le prix de l'adhésion (plafond 73 €). Le don et la remise doivent figurer sur la facture Stripe.
+
+## Décision
+
+1. **Saisie** : à l'étape Paiement du wizard (adhérent) ; modifiable ensuite **uniquement** par le secrétariat. Minimum 1 € si don choisi.
+2. **Calcul pur** : `src/lib/pricing/donation-discount.ts` — remise = `min(don × 25 %, 73 €, adhésion nette catalogue)`.
+3. **Total facture** : `devis catalogue + don − remise don` ; les aides secrétariat réduisent le **net encaissé** via le même coupon Stripe que la remise don (fusion obligatoire : 1 coupon max. Checkout).
+4. **Stripe Checkout** : lignes détaillées + **un** coupon (remise don + aides) ; détail dans les champs personnalisés facture.
+5. **Paiement manuel** : même ventilation via `createPaidOutOfBandInvoice` multi-lignes + coupons.
+6. **Reporting** : champs `voluntaryDonationCents` et `donationDiscountCents` sur `clubRegistrations` + colonnes export tableau secrétariat.
+
+## Conséquences
+
+- Tests unitaires sur `donation-discount.ts`, `stripe-checkout-lines` et `stripe-checkout-discounts`.
+- Checkout multi-lignes dès qu'un devis catalogue est disponible ; le mode legacy (une ligne) ne subsiste que sans devis.

--- a/scripts/repair-registration-payment-status.ts
+++ b/scripts/repair-registration-payment-status.ts
@@ -1,0 +1,339 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Aligne paymentStatus (et l'objet payment imbriqué) sur les dossiers déjà réglés
+ * (paidAt ou status === "paid") mais encore en paymentStatus legacy "pending", etc.
+ *
+ * Usage :
+ *   # Staging (défaut via .env.local)
+ *   npx tsx scripts/repair-registration-payment-status.ts
+ *
+ *   # Production — compte Google (ADC), ignore les credentials .env.local
+ *   npx tsx scripts/repair-registration-payment-status.ts --project sqyping-teamup --use-adc
+ *
+ *   # Production — fichier service account dédié
+ *   npx tsx scripts/repair-registration-payment-status.ts \
+ *     --project sqyping-teamup \
+ *     --credentials ~/secrets/sqyping-teamup-adminsdk.json
+ *
+ *   # Appliquer les corrections
+ *   ... --apply
+ */
+import * as dotenv from "dotenv";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { initializeApp, applicationDefault, cert, getApps } from "firebase-admin/app";
+import { FieldValue, getFirestore, type DocumentData } from "firebase-admin/firestore";
+import {
+  normalizeRegistrationPayment,
+  paymentToFirestoreUpdate,
+} from "../src/lib/club-registration/payment/normalize-payment";
+import { markPaymentFullyPaid } from "../src/lib/club-registration/payment/payment-mutations";
+import { needsRegistrationPaymentStatusRepair } from "../src/lib/club-registration/repair-registration-payment-status";
+import { resolveRegistrationPaymentStatus } from "../src/lib/club-registration/resolve-registration-payment-status";
+import { formatPersonDisplayName } from "../src/lib/shared/person-name-format";
+
+const COLLECTION = "clubRegistrations";
+const BATCH_SIZE = 400;
+
+type ScriptArgs = {
+  apply: boolean;
+  projectId: string | null;
+  useAdc: boolean;
+  credentialsPath: string | null;
+};
+
+function readArgValue(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) {
+    return null;
+  }
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Valeur manquante pour ${flag}`);
+  }
+  return value;
+}
+
+function parseArgs(): ScriptArgs {
+  return {
+    apply: process.argv.includes("--apply"),
+    projectId: readArgValue("--project"),
+    useAdc: process.argv.includes("--use-adc"),
+    credentialsPath: readArgValue("--credentials"),
+  };
+}
+
+const args = parseArgs();
+const dryRun = !args.apply;
+
+dotenv.config({ path: path.join(__dirname, "..", ".env.local") });
+dotenv.config({ path: path.join(__dirname, "..", ".env") });
+
+function resolveProjectId(): string {
+  return (
+    args.projectId?.trim() ||
+    process.env.FB_PROJECT_ID?.trim() ||
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID?.trim() ||
+    "sqyping-teamup-dev"
+  );
+}
+
+function inferServiceAccountProjectId(clientEmail: string): string | null {
+  const match = clientEmail.match(/@([^.]+)\.iam\.gserviceaccount\.com$/);
+  return match?.[1] ?? null;
+}
+
+type AuthMode = "adc" | "service-account-file" | "env-cert";
+
+function initFirebaseAdmin(projectId: string): AuthMode {
+  if (getApps().length > 0) {
+    return "adc";
+  }
+
+  if (args.useAdc && args.credentialsPath) {
+    throw new Error("Utilisez soit --use-adc soit --credentials, pas les deux.");
+  }
+
+  if (args.credentialsPath) {
+    const credentialsPath = path.resolve(args.credentialsPath);
+    if (!fs.existsSync(credentialsPath)) {
+      throw new Error(`Fichier credentials introuvable : ${credentialsPath}`);
+    }
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+    initializeApp({
+      credential: applicationDefault(),
+      projectId,
+    });
+    console.log(`[repair-payment-status] Auth=service-account-file (${credentialsPath})`);
+    return "service-account-file";
+  }
+
+  if (args.useAdc) {
+    // .env.local définit souvent GOOGLE_APPLICATION_CREDENTIALS (staging) : ADC sinon
+    // continuerait d'utiliser ce fichier au lieu du compte gcloud.
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    initializeApp({
+      credential: applicationDefault(),
+      projectId,
+    });
+    console.log("[repair-payment-status] Auth=adc (gcloud application-default login)");
+    return "adc";
+  }
+
+  const envCredentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+  const privateKey = process.env.FB_PRIVATE_KEY || process.env.FIREBASE_PRIVATE_KEY;
+  const clientEmail = process.env.FB_CLIENT_EMAIL || process.env.FIREBASE_CLIENT_EMAIL;
+
+  if (envCredentialsPath) {
+    const resolvedPath = path.resolve(envCredentialsPath);
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`GOOGLE_APPLICATION_CREDENTIALS introuvable : ${resolvedPath}`);
+    }
+    initializeApp({
+      credential: applicationDefault(),
+      projectId,
+    });
+    const credentialProjectId = inferServiceAccountProjectId(
+      JSON.parse(fs.readFileSync(resolvedPath, "utf8")).client_email as string
+    );
+    if (credentialProjectId && credentialProjectId !== projectId) {
+      throw new Error(
+        `Incohérence projet/credentials : cible=${projectId}, service account=${credentialProjectId} (${resolvedPath}).\n` +
+          `Relancez avec --project ${credentialProjectId} ou --credentials <fichier-prod.json> ou --use-adc.`
+      );
+    }
+    console.log(`[repair-payment-status] Auth=service-account-file (${resolvedPath})`);
+    return "service-account-file";
+  }
+
+  if (!privateKey || !clientEmail) {
+    throw new Error(
+      "Credentials Firebase non configurés.\n" +
+        "Staging : .env.local (GOOGLE_APPLICATION_CREDENTIALS ou FB_*).\n" +
+        "Production : --project sqyping-teamup --use-adc (après gcloud auth application-default login)\n" +
+        "           ou --project sqyping-teamup --credentials <adminsdk-prod.json>"
+    );
+  }
+
+  const credentialProjectId = inferServiceAccountProjectId(clientEmail);
+  if (credentialProjectId && credentialProjectId !== projectId) {
+    throw new Error(
+      `Incohérence projet/credentials : cible=${projectId}, FB_CLIENT_EMAIL=${credentialProjectId}.\n` +
+        `Relancez avec --project ${credentialProjectId} ou --use-adc / --credentials pour la prod.`
+    );
+  }
+
+  initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey: privateKey.replace(/\\n/g, "\n"),
+    }),
+  });
+  console.log(`[repair-payment-status] Auth=env-cert (${clientEmail})`);
+  return "env-cert";
+}
+
+function formatPaidAt(value: unknown): string {
+  if (value && typeof value === "object" && "toDate" in value) {
+    const toDate = (value as { toDate?: () => Date }).toDate;
+    if (typeof toDate === "function") {
+      return toDate.call(value).toISOString();
+    }
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return "—";
+}
+
+function buildRepairPatch(data: DocumentData): Record<string, unknown> {
+  const payment = normalizeRegistrationPayment(data);
+  const nextPayment = payment
+    ? markPaymentFullyPaid(payment, { recordedBy: "repair-script" })
+    : null;
+
+  return {
+    status: "paid",
+    ...(nextPayment ? paymentToFirestoreUpdate(nextPayment) : { paymentStatus: "paid" }),
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+}
+
+async function commitBatch(
+  batch: FirebaseFirestore.WriteBatch,
+  pending: number
+): Promise<void> {
+  if (pending === 0 || dryRun) {
+    return;
+  }
+  await batch.commit();
+}
+
+function printPermissionDeniedHelp(projectId: string, authMode: AuthMode): void {
+  console.error(
+    [
+      "",
+      `Accès Firestore refusé sur le projet « ${projectId} » (auth=${authMode}).`,
+      "",
+      "Vérifications :",
+      `  1. Le compte / service account a un rôle Firestore sur ${projectId} (ex. Cloud Datastore User ou Firebase Admin).`,
+      "  2. Vous ne mélangez pas projet prod et credentials staging (.env.local = sqyping-teamup-dev).",
+      "",
+      "Commandes utiles :",
+      "  gcloud auth application-default login",
+      `  gcloud config set project ${projectId}`,
+      `  npx tsx scripts/repair-registration-payment-status.ts --project ${projectId} --use-adc`,
+      "",
+      "Ou avec un JSON adminsdk prod :",
+      `  npx tsx scripts/repair-registration-payment-status.ts --project ${projectId} --credentials <fichier.json>`,
+      "",
+    ].join("\n")
+  );
+}
+
+async function main(): Promise<void> {
+  const projectId = resolveProjectId();
+  const authMode = initFirebaseAdmin(projectId);
+  const db = getFirestore();
+
+  console.log(
+    `[repair-payment-status] Projet=${projectId} mode=${dryRun ? "simulation (--apply absent)" : "application"}`
+  );
+
+  let snapshot;
+  try {
+    snapshot = await db.collection(COLLECTION).get();
+  } catch (error) {
+    const code = (error as { code?: number }).code;
+    const message = error instanceof Error ? error.message : String(error);
+    if (code === 7 || message.includes("PERMISSION_DENIED")) {
+      printPermissionDeniedHelp(projectId, authMode);
+    }
+    throw error;
+  }
+
+  const affected: Array<{
+    id: string;
+    name: string;
+    status: string;
+    paymentStatus: string;
+    paidAt: string;
+    resolvedDisplay: string;
+  }> = [];
+
+  for (const docSnap of snapshot.docs) {
+    const data = docSnap.data();
+    if (!needsRegistrationPaymentStatusRepair(data)) {
+      continue;
+    }
+
+    const firstName = typeof data.firstName === "string" ? data.firstName : "";
+    const lastName = typeof data.lastName === "string" ? data.lastName : "";
+    const name = formatPersonDisplayName(firstName, lastName) || docSnap.id;
+    const resolved = resolveRegistrationPaymentStatus(data) ?? "inconnu";
+
+    affected.push({
+      id: docSnap.id,
+      name,
+      status: typeof data.status === "string" ? data.status : "—",
+      paymentStatus: typeof data.paymentStatus === "string" ? data.paymentStatus : "—",
+      paidAt: formatPaidAt(data.paidAt),
+      resolvedDisplay: resolved,
+    });
+  }
+
+  console.log(`\nDossiers analysés : ${snapshot.size}`);
+  console.log(`Dossiers à corriger : ${affected.length}\n`);
+
+  if (affected.length === 0) {
+    console.log("Aucun dossier incohérent trouvé.");
+    return;
+  }
+
+  for (const row of affected) {
+    console.log(
+      `- ${row.name} (${row.id}) | status=${row.status} | paymentStatus=${row.paymentStatus} | paidAt=${row.paidAt}`
+    );
+  }
+
+  if (dryRun) {
+    console.log(
+      "\nSimulation terminée. Relancez avec --apply pour écrire paymentStatus=paid sur ces dossiers."
+    );
+    return;
+  }
+
+  let batch = db.batch();
+  let batchCount = 0;
+  let updated = 0;
+
+  for (const row of affected) {
+    const docRef = db.collection(COLLECTION).doc(row.id);
+    const snap = await docRef.get();
+    const data = snap.data();
+    if (!data || !needsRegistrationPaymentStatusRepair(data)) {
+      continue;
+    }
+
+    const patch = buildRepairPatch(data);
+    batch.update(docRef, patch);
+    batchCount += 1;
+    updated += 1;
+
+    if (batchCount >= BATCH_SIZE) {
+      await commitBatch(batch, batchCount);
+      batch = db.batch();
+      batchCount = 0;
+    }
+  }
+
+  await commitBatch(batch, batchCount);
+  console.log(`\n[repair-payment-status] Terminé : ${updated} dossier(s) corrigé(s).`);
+}
+
+main().catch((error) => {
+  console.error("[repair-payment-status] Échec :", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/app/api/club/registration/[id]/checkout/route.ts
+++ b/src/app/api/club/registration/[id]/checkout/route.ts
@@ -1,0 +1,184 @@
+export const runtime = "nodejs";
+
+import { cookies } from "next/headers";
+import type { DocumentData } from "firebase-admin/firestore";
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { resolveRole } from "@/lib/auth/roles";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { checkRateLimit } from "@/lib/auth/rate-limit";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { canAccessClubRegistration } from "@/lib/club-registration/registration-access";
+import { getAppBaseUrl } from "@/lib/club-registration/stripe";
+import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import {
+  calculateQuoteForRecord,
+  resolveRegistrationConfigForRecord,
+} from "@/lib/club-registration-config/pricing-resolve";
+import { resolveRegistrationDonationPricing } from "@/lib/club-registration/resolve-registration-donation";
+import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve-registration-contact-email";
+import {
+  createStripeCheckoutForRegistration,
+  persistSelfServiceStripeCheckout,
+  recalculatePaymentForRequest,
+} from "@/lib/club-registration/request-payment-checkout";
+import {
+  canSelfServiceCheckout,
+  resolveSelfServicePayableCents,
+} from "@/lib/club-registration/self-service-checkout";
+import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
+import type { PriceQuote } from "@/lib/pricing/types";
+
+const COLLECTION = "clubRegistrations";
+
+async function resolveQuoteFromRegistration(
+  data: DocumentData
+): Promise<PriceQuote | null> {
+  return calculateQuoteForRecord(data as Record<string, unknown>);
+}
+
+/**
+ * POST /api/club/registration/[id]/checkout
+ * Génère un lien Stripe Checkout pour le soumettant du dossier (sans e-mail).
+ */
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!validateOrigin(req)) {
+      return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+    }
+
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("__session")?.value;
+    if (!sessionCookie) {
+      return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+    }
+
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    const role = resolveRole(decoded.role as string | undefined);
+    const { id } = await context.params;
+
+    const rate = checkRateLimit(`club-checkout:${decoded.uid}:${id}`, 5, 15 * 60 * 1000);
+    if (!rate.allowed) {
+      return jsonNoStore(
+        { error: "Trop de demandes de paiement. Réessayez dans quelques minutes." },
+        { status: 429 }
+      );
+    }
+
+    const db = getFirestoreAdmin();
+    const docRef = db.collection(COLLECTION).doc(id);
+    const snap = await docRef.get();
+    if (!snap.exists) {
+      return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
+    }
+
+    const data = snap.data() ?? {};
+    const submitterUid =
+      typeof data.submitterUid === "string" ? data.submitterUid : undefined;
+    if (!canAccessClubRegistration(role, submitterUid, decoded.uid)) {
+      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    if (!canSelfServiceCheckout(data)) {
+      return jsonNoStore(
+        { error: "Ce dossier n'est pas éligible au paiement en ligne." },
+        { status: 400 }
+      );
+    }
+
+    const paymentEmail = resolveRegistrationContactEmail(data);
+    if (!paymentEmail) {
+      return jsonNoStore(
+        { error: "Aucune adresse e-mail exploitable pour le paiement." },
+        { status: 400 }
+      );
+    }
+
+    const adherentName =
+      formatPersonDisplayName(
+        typeof data.firstName === "string" ? data.firstName : undefined,
+        typeof data.lastName === "string" ? data.lastName : undefined
+      ) || "adhérent";
+    const baseUrl = getAppBaseUrl(req);
+    const successUrl = `${baseUrl}/club/mes-inscriptions?payment=success&registration=${encodeURIComponent(id)}`;
+    const cancelUrl = `${baseUrl}/club/mes-inscriptions?payment=cancelled&registration=${encodeURIComponent(id)}`;
+
+    const quote = await resolveQuoteFromRegistration(data);
+    const pricingConfig = await resolveRegistrationConfigForRecord(
+      data as Record<string, unknown>
+    );
+    const donationPricing =
+      quote != null
+        ? resolveRegistrationDonationPricing(quote, data as Record<string, unknown>)
+        : null;
+    const invoiceTotalCents = donationPricing?.invoiceTotalCents ?? quote?.totalCents ?? 0;
+
+    const payment = recalculatePaymentForRequest(
+      normalizeRegistrationPayment(data),
+      quote,
+      invoiceTotalCents
+    );
+
+    const amountToPayCents =
+      payment?.amountToPayCents ?? resolveSelfServicePayableCents(data);
+
+    if (amountToPayCents <= 0) {
+      return jsonNoStore({ error: "Aucun montant à régler pour ce dossier." }, { status: 400 });
+    }
+
+    const checkoutResult = await createStripeCheckoutForRegistration({
+      registrationId: id,
+      quote,
+      donationPricing,
+      pricingConfig,
+      payment,
+      amountToPayCents,
+      paymentEmail,
+      adherentName,
+      successUrl,
+      cancelUrl,
+    });
+
+    if (!checkoutResult.ok) {
+      return jsonNoStore(checkoutResult.body, { status: checkoutResult.status });
+    }
+
+    await persistSelfServiceStripeCheckout({
+      docRef,
+      checkout: checkoutResult.result,
+    });
+
+    const sessionUrl = checkoutResult.result.session.url;
+    if (!sessionUrl) {
+      return jsonNoStore(
+        { error: "Stripe n'a pas retourné de lien de paiement." },
+        { status: 502 }
+      );
+    }
+
+    logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_REQUESTED, decoded.uid, {
+      resource: "clubRegistration",
+      resourceId: id,
+      details: {
+        amountCents: amountToPayCents,
+        stripeCheckoutSessionId: checkoutResult.result.session.id,
+        selfService: true,
+      },
+      success: true,
+    });
+
+    return jsonNoStore({ success: true, checkoutUrl: sessionUrl }, { status: 200 });
+  } catch (error) {
+    console.error("[api/club/registration/checkout]", error);
+    return jsonNoStore(
+      {
+        error:
+          error instanceof Error ? error.message : "Impossible d'ouvrir la page de paiement",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/club/registration/[id]/invoice/route.ts
+++ b/src/app/api/club/registration/[id]/invoice/route.ts
@@ -9,6 +9,17 @@ import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve
 import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
 import {
+  calculateQuoteForRecord,
+  resolveRegistrationConfigForRecord,
+} from "@/lib/club-registration-config/pricing-resolve";
+import { renderInvoiceHeader } from "@/lib/club-registration-config/helpers";
+import { resolveRegistrationDonationPricing } from "@/lib/club-registration/resolve-registration-donation";
+import { createCheckoutDiscountCouponIds } from "@/lib/club-registration/stripe-checkout-discounts";
+import {
+  buildStripeCheckoutLineItems,
+} from "@/lib/pricing/stripe-checkout-lines";
+import type { PriceQuote } from "@/lib/pricing/types";
+import {
   createPaidOutOfBandInvoice,
   pickInvoiceDownloadUrl,
   retrieveStripeInvoiceLinks,
@@ -29,6 +40,14 @@ function resolveInvoiceAmountCents(data: Record<string, unknown>): number {
     return payment.amountToPayCents;
   }
   return 0;
+}
+
+function readStoredQuote(data: Record<string, unknown>): PriceQuote | null {
+  const quote = data.pricingQuote;
+  if (!quote || typeof quote !== "object") {
+    return null;
+  }
+  return quote as PriceQuote;
 }
 
 /**
@@ -96,13 +115,65 @@ export async function GET(
           typeof data.lastName === "string" ? data.lastName : ""
         }`.trim() || "adhérent";
 
-      const created = await createPaidOutOfBandInvoice({
-        registrationId: id,
-        customerEmail: email,
-        amountCents,
-        description: `Adhésion SQY Ping — ${adherentName}`,
-      });
-      invoiceId = created.invoiceId;
+      const quote = readStoredQuote(data) ?? (await calculateQuoteForRecord(data));
+      const pricingConfig = await resolveRegistrationConfigForRecord(data);
+
+      if (quote) {
+        const donationPricing = resolveRegistrationDonationPricing(quote, data);
+        const donationContext =
+          donationPricing.voluntaryDonationCents > 0
+            ? {
+                voluntaryDonationCents: donationPricing.voluntaryDonationCents,
+                donationDiscountCents: donationPricing.donationDiscountCents,
+              }
+            : undefined;
+        const lineItems = buildStripeCheckoutLineItems(
+          quote,
+          pricingConfig.stripePresentation,
+          donationContext
+        );
+        const payment = normalizeRegistrationPayment(data);
+        const discountCouponIds = await createCheckoutDiscountCouponIds({
+          registrationId: id,
+          donationDiscountCents: donationPricing.donationDiscountCents,
+          donationDiscountCouponName:
+            pricingConfig.stripePresentation.donationDiscountCouponName,
+          aids: payment?.aids ?? [],
+        });
+
+        const created = await createPaidOutOfBandInvoice({
+          registrationId: id,
+          customerEmail: email,
+          customerName: adherentName,
+          invoiceDescription: renderInvoiceHeader(
+            pricingConfig.stripePresentation.invoiceHeaderTemplate,
+            {
+              clubName: pricingConfig.meta.clubName,
+              registrationId: id,
+              adherentName,
+            }
+          ),
+          lineItems,
+          discountCouponIds,
+        });
+        invoiceId = created.invoiceId;
+      } else {
+        const created = await createPaidOutOfBandInvoice({
+          registrationId: id,
+          customerEmail: email,
+          customerName: adherentName,
+          invoiceDescription: `Adhésion SQY Ping — ${adherentName}`,
+          lineItems: [
+            {
+              name: "Adhésion SQY Ping",
+              amountCents,
+              description: `Dossier ${id}`,
+            },
+          ],
+        });
+        invoiceId = created.invoiceId;
+      }
+
       await db.collection(COLLECTION).doc(id).set(
         {
           stripeInvoiceId: invoiceId,

--- a/src/app/api/club/registration/[id]/pricing/route.ts
+++ b/src/app/api/club/registration/[id]/pricing/route.ts
@@ -8,6 +8,10 @@ import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
 import { calculateQuoteForRecord } from "@/lib/club-registration-config/pricing-resolve";
+import {
+  readVoluntaryDonationCents,
+  resolveRegistrationDonationPricing,
+} from "@/lib/club-registration/resolve-registration-donation";
 import type { PriceQuote } from "@/lib/pricing/types";
 
 const COLLECTION = "clubRegistrations";
@@ -16,6 +20,8 @@ const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
 const PRICING_INPUT_FIELDS = [
   "birthDate",
   "mainSectionId",
+  "slotIds",
+  "additionalSectionIds",
   "wantsCompetitorExtras",
   "wantsOptionalJersey",
   "competitionIds",
@@ -150,7 +156,9 @@ export async function POST(
         updatedAt: FieldValue.serverTimestamp(),
       };
       if (applyPaymentAmount && quote.totalCents > 0) {
-        patch.paymentAmountCents = quote.totalCents;
+        const donation = resolveRegistrationDonationPricing(quote, merged);
+        patch.paymentAmountCents = donation.invoiceTotalCents;
+        patch.donationDiscountCents = donation.donationDiscountCents;
       }
       if (body.handisportPracticeLevel !== undefined) {
         patch.handisportPracticeLevel = body.handisportPracticeLevel;
@@ -170,11 +178,18 @@ export async function POST(
       });
     }
 
+    const donationCents = readVoluntaryDonationCents(merged);
+    const paymentAmountCents =
+      applyPaymentAmount && result.quote.totalCents > 0
+        ? resolveRegistrationDonationPricing(result.quote, merged).invoiceTotalCents
+        : undefined;
+
     return jsonNoStore(
       {
-        quote,
+        quote: result.quote,
         persisted: persist,
-        paymentAmountCents: applyPaymentAmount ? quote.totalCents : undefined,
+        paymentAmountCents,
+        voluntaryDonationCents: donationCents,
       },
       { status: 200 }
     );

--- a/src/app/api/club/registration/[id]/request-payment/route.ts
+++ b/src/app/api/club/registration/[id]/request-payment/route.ts
@@ -6,15 +6,8 @@ import { jsonNoStore } from "@/lib/http/cache-headers";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
 import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
-import { buildPaymentInstructionsEmail } from "@/lib/email/payment-instructions-email";
-import { buildPaymentRequestEmail } from "@/lib/email/payment-email";
-import { getSqyPingLogoAttachment } from "@/lib/email/logo-attachment";
-import { sendMail } from "@/lib/mailer";
-import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
-import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
 import {
-  createLegacySingleLineCheckoutSession,
-  createMembershipCheckoutSession,
   createStripePaymentForRegistration,
   getAppBaseUrl,
 } from "@/lib/club-registration/stripe";
@@ -22,24 +15,21 @@ import {
   normalizeRegistrationPayment,
   paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
-import {
-  recalculateRegistrationPayment,
-  regenerateExpectedPayments,
-  setManualFollowUp,
-} from "@/lib/club-registration/payment/payment-mutations";
+import { recalculateRegistrationPayment } from "@/lib/club-registration/payment/payment-mutations";
 import {
   calculateQuoteForRecord,
   resolveRegistrationConfigForRecord,
 } from "@/lib/club-registration-config/pricing-resolve";
-import { renderInvoiceHeader } from "@/lib/club-registration-config/helpers";
-import { hashPriceQuote } from "@/lib/pricing/quote-hash";
-import {
-  assertStripeLinesMatchQuote,
-  buildStripeCheckoutLineItems,
-  buildStripeInvoiceCustomFields,
-} from "@/lib/pricing/stripe-checkout-lines";
+import { resolveRegistrationDonationPricing } from "@/lib/club-registration/resolve-registration-donation";
 import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve-registration-contact-email";
-import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+import {
+  persistPaymentRequestedAndNotify,
+  processManualPaymentFollowUp,
+  recalculatePaymentForRequest,
+  validateRegistrationStripeCheckout,
+} from "@/lib/club-registration/request-payment-checkout";
+import { buildMesInscriptionsUrl } from "@/lib/club-registration/mes-inscriptions-url";
+import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import type { PriceQuote } from "@/lib/pricing/types";
 
 const COLLECTION = "clubRegistrations";
@@ -85,6 +75,17 @@ export async function POST(
     }
 
     const data = snap.data() ?? {};
+    if (isRegistrationPaidRecord(data)) {
+      return jsonNoStore(
+        {
+          error:
+            "Ce dossier est déjà réglé (paiement enregistré). Impossible de renvoyer un lien de paiement.",
+        },
+        { status: 409 }
+      );
+    }
+
+    const isResend = data.status === "payment_requested";
     const requestedAmount = body.amountCents ?? data.paymentAmountCents;
     if (!Number.isInteger(requestedAmount) || requestedAmount <= 0) {
       return jsonNoStore(
@@ -107,27 +108,22 @@ export async function POST(
         typeof data.lastName === "string" ? data.lastName : undefined
       ) || "adhérent";
     const baseUrl = getAppBaseUrl(req);
-    const successUrl = `${baseUrl}/club/mes-inscriptions?payment=success&registration=${encodeURIComponent(id)}`;
-    const cancelUrl = `${baseUrl}/club/mes-inscriptions?payment=cancelled&registration=${encodeURIComponent(id)}`;
 
     const quote = await resolveQuoteFromRegistration(data);
     const pricingConfig = await resolveRegistrationConfigForRecord(
       data as Record<string, unknown>
     );
+    const donationPricing =
+      quote != null
+        ? resolveRegistrationDonationPricing(quote, data as Record<string, unknown>)
+        : null;
+    const invoiceTotalCents = donationPricing?.invoiceTotalCents ?? quote?.totalCents ?? 0;
 
-    let payment = normalizeRegistrationPayment(data);
-    if (payment && quote) {
-      payment = recalculateRegistrationPayment({
-        ...payment,
-        totalAmountCents: quote.totalCents,
-      });
-      if (
-        payment.paymentMethod === "card" ||
-        payment.paymentMethod === "cheque"
-      ) {
-        payment = regenerateExpectedPayments(payment);
-      }
-    }
+    const payment = recalculatePaymentForRequest(
+      normalizeRegistrationPayment(data),
+      quote,
+      invoiceTotalCents
+    );
 
     const amountToPayCents =
       payment?.amountToPayCents ??
@@ -174,87 +170,23 @@ export async function POST(
     });
 
     if (!stripeCapability.supported) {
-      const paymentInstallments = payment?.paymentInstallments ?? 1;
-      const baseManualPayment: RegistrationPayment =
-        payment ??
-        ({
-          totalAmountCents: quote?.totalCents ?? amountToPayCents,
-          assistanceTotalAmountCents: 0,
-          amountToPayCents,
-          aids: [],
-          paymentMethod,
-          paymentInstallments,
-          expectedPayments: [],
-          receivedPayments: [],
-          paidAmountCents: 0,
-          remainingAmountCents: amountToPayCents,
-          paymentStatus: "waiting_payment",
-        } satisfies RegistrationPayment);
-
-      const manualPayment = setManualFollowUp(baseManualPayment);
-
-      await docRef.set(
-        {
-          status: "payment_requested",
-          ...paymentToFirestoreUpdate(manualPayment),
-          paymentAmountCents: amountToPayCents,
-          paymentRequestedAt: FieldValue.serverTimestamp(),
-          paymentRequestedBy: decoded.uid,
-          paymentEmailSentTo: paymentEmail,
-          updatedAt: FieldValue.serverTimestamp(),
-        },
-        { merge: true }
-      );
-
-      const instructionsMail = buildPaymentInstructionsEmail({
-        adherentName,
-        amountCents: amountToPayCents,
+      const manualResult = await processManualPaymentFollowUp({
+        docRef,
         registrationId: id,
-        appOrigin: baseUrl,
-        paymentMethod: manualPayment.paymentMethod,
-        paymentInstallments: manualPayment.paymentInstallments,
-        expectedPayments: manualPayment.expectedPayments,
-        ...(manualPayment.holidayVoucherAmountCents != null
-          ? { holidayVoucherAmountCents: manualPayment.holidayVoucherAmountCents }
-          : {}),
-        ...(manualPayment.remainingPaymentMethod
-          ? { remainingPaymentMethod: manualPayment.remainingPaymentMethod }
-          : {}),
-        ...(manualPayment.specialPaymentNote
-          ? { specialPaymentNote: manualPayment.specialPaymentNote }
-          : {}),
-        ...(manualPayment.paymentNote ? { paymentNote: manualPayment.paymentNote } : {}),
+        payment,
         quote,
+        donationPricing,
+        amountToPayCents,
+        paymentMethod,
+        paymentEmail,
+        adherentName,
+        baseUrl,
+        requestedByUid: decoded.uid,
       });
 
-      try {
-        await sendMail({
-          to: paymentEmail,
-          subject: `Instructions de règlement — adhésion ${adherentName}`,
-          html: instructionsMail.html,
-          text: instructionsMail.text,
-          attachments: [getSqyPingLogoAttachment()],
-        });
-      } catch (emailError) {
-        console.error("[api/club/registration/request-payment] instructions email", emailError);
-        return jsonNoStore(
-          {
-            error: "Dossier mis à jour mais l'e-mail d'instructions n'a pas pu être envoyé.",
-          },
-          { status: 500 }
-        );
+      if (!manualResult.success) {
+        return jsonNoStore({ error: manualResult.error }, { status: 500 });
       }
-
-      logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_REQUESTED, decoded.uid, {
-        resource: "clubRegistration",
-        resourceId: id,
-        details: {
-          amountCents: amountToPayCents,
-          manualFollowUp: true,
-          paymentMethod: manualPayment.paymentMethod,
-        },
-        success: true,
-      });
 
       return jsonNoStore(
         {
@@ -267,157 +199,38 @@ export async function POST(
       );
     }
 
-    let session;
-    const useQuoteLineItems =
-      quote &&
-      quote.totalCents > 0 &&
-      amountToPayCents === quote.totalCents;
-
-    if (useQuoteLineItems && quote) {
-      const stripePresentation = pricingConfig.stripePresentation;
-      const stripeLineItems = buildStripeCheckoutLineItems(quote, stripePresentation);
-      const invoiceCustomFields = buildStripeInvoiceCustomFields(quote, stripePresentation);
-      assertStripeLinesMatchQuote(quote, stripeLineItems);
-
-      session = await createMembershipCheckoutSession({
-        registrationId: id,
-        lineItems: stripeLineItems,
-        customerEmail: paymentEmail,
-        customerName: adherentName,
-        invoiceDescription: renderInvoiceHeader(stripePresentation.invoiceHeaderTemplate, {
-          clubName: pricingConfig.meta.clubName,
-          registrationId: id,
-          adherentName,
-        }),
-        catalogVersion: quote.catalogVersion,
-        quoteHash: hashPriceQuote(quote),
-        invoiceCustomFields,
-        successUrl,
-        cancelUrl,
-      });
-
-      const waitingPayment = payment
-        ? recalculateRegistrationPayment({
-            ...payment,
-            paymentStatus: "waiting_payment",
-          })
-        : null;
-
-      await docRef.set(
-        {
-          status: "payment_requested",
-          ...(waitingPayment ? paymentToFirestoreUpdate(waitingPayment) : {}),
-          paymentAmountCents: amountToPayCents,
-          paymentStatus: "pending",
-          paymentRequestedAt: FieldValue.serverTimestamp(),
-          paymentRequestedBy: decoded.uid,
-          paymentEmailSentTo: paymentEmail,
-          stripeCheckoutSessionId: session.id,
-          stripeCheckoutUrl: session.url,
-          pricingQuote: quote,
-          pricingQuoteStatus: "validated",
-          paymentStripeLineItems: stripeLineItems,
-          updatedAt: FieldValue.serverTimestamp(),
-        },
-        { merge: true }
-      );
-
-      const paymentMail = buildPaymentRequestEmail({
-        adherentName,
-        amountCents: amountToPayCents,
-        checkoutUrl: session.url ?? "",
-        appOrigin: baseUrl,
-        quote: quote,
-      });
-
-      await sendMail({
-        to: paymentEmail,
-        subject: `Paiement de votre adhésion SQY Ping - ${adherentName}`,
-        text: paymentMail.text,
-        html: paymentMail.html,
-        attachments: [getSqyPingLogoAttachment()],
-      });
-
-      logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_REQUESTED, decoded.uid, {
-        resource: "clubRegistration",
-        resourceId: id,
-        details: {
-          amountCents: amountToPayCents,
-          stripeCheckoutSessionId: session.id,
-          lineCount: stripeLineItems.length,
-          catalogVersion: quote.catalogVersion,
-        },
-        success: true,
-      });
-    } else {
-      session = await createLegacySingleLineCheckoutSession({
-        registrationId: id,
-        amountCents: amountToPayCents,
-        customerEmail: paymentEmail,
-        adherentName,
-        successUrl,
-        cancelUrl,
-      });
-
-      const waitingPayment = payment
-        ? recalculateRegistrationPayment({
-            ...payment,
-            paymentStatus: "waiting_payment",
-          })
-        : null;
-
-      await docRef.set(
-        {
-          status: "payment_requested",
-          ...(waitingPayment ? paymentToFirestoreUpdate(waitingPayment) : {}),
-          paymentAmountCents: amountToPayCents,
-          paymentStatus: "pending",
-          paymentRequestedAt: FieldValue.serverTimestamp(),
-          paymentRequestedBy: decoded.uid,
-          paymentEmailSentTo: paymentEmail,
-          stripeCheckoutSessionId: session.id,
-          stripeCheckoutUrl: session.url,
-          updatedAt: FieldValue.serverTimestamp(),
-        },
-        { merge: true }
-      );
-
-      const paymentMail = buildPaymentRequestEmail({
-        adherentName,
-        amountCents: amountToPayCents,
-        checkoutUrl: session.url ?? "",
-        appOrigin: baseUrl,
-        quote: null,
-      });
-
-      await sendMail({
-        to: paymentEmail,
-        subject: `Paiement de votre adhésion SQY Ping - ${adherentName}`,
-        text: paymentMail.text,
-        html: paymentMail.html,
-        attachments: [getSqyPingLogoAttachment()],
-      });
-
-      logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_REQUESTED, decoded.uid, {
-        resource: "clubRegistration",
-        resourceId: id,
-        details: {
-          amountCents: amountToPayCents,
-          stripeCheckoutSessionId: session.id,
-          legacy: true,
-        },
-        success: true,
-      });
+    const checkoutValidation = validateRegistrationStripeCheckout({
+      quote,
+      donationPricing,
+      pricingConfig,
+      payment,
+      amountToPayCents,
+    });
+    if (!checkoutValidation.ok) {
+      return jsonNoStore(checkoutValidation.body, { status: checkoutValidation.status });
     }
 
-    if (!session.url) {
-      return jsonNoStore(
-        { error: "Stripe n'a pas retourné de lien de paiement." },
-        { status: 502 }
-      );
-    }
+    await persistPaymentRequestedAndNotify({
+      docRef,
+      registrationId: id,
+      payment,
+      quote,
+      donationPricing,
+      amountToPayCents,
+      paymentEmail,
+      adherentName,
+      baseUrl,
+      requestedByUid: decoded.uid,
+      isResend,
+    });
 
-    return jsonNoStore({ success: true, checkoutUrl: session.url }, { status: 200 });
+    return jsonNoStore(
+      {
+        success: true,
+        mesInscriptionsUrl: buildMesInscriptionsUrl(baseUrl, id),
+      },
+      { status: 200 }
+    );
   } catch (error) {
     console.error("[api/club/registration/request-payment]", error);
     return jsonNoStore(

--- a/src/app/api/club/registration/route.ts
+++ b/src/app/api/club/registration/route.ts
@@ -17,12 +17,12 @@ import {
   normalizeMedicalCertificateStatus,
 } from "@/lib/club-registration/medical-certificate";
 import { checkRateLimit } from "@/lib/auth/rate-limit";
-import { buildPricingContextFromRecord } from "@/lib/pricing/from-registration-record";
+import { buildManagerRegistrationPricingPatch } from "@/lib/club-registration/build-manager-registration-pricing-patch";
 import {
-  getActiveRegistrationConfig,
   ensureRegistrationConfigSeeded,
+  getActiveRegistrationConfig,
 } from "@/lib/club-registration-config/store";
-import { calculateQuoteWithConfig } from "@/lib/club-registration-config/pricing-resolve";
+import { isValidVoluntaryDonationCents } from "@/lib/pricing/donation-discount";
 import {
   APPLICANT_NOTES_MAX_LENGTH,
   isApplicantNotesTooLong,
@@ -170,6 +170,17 @@ export async function PATCH(req: Request) {
     }
 
     if (
+      updates.voluntaryDonationCents !== undefined &&
+      (!Number.isInteger(updates.voluntaryDonationCents as number) ||
+        !isValidVoluntaryDonationCents(updates.voluntaryDonationCents as number))
+    ) {
+      return jsonNoStore(
+        { error: "Don libre invalide (0 € ou minimum 1 €)." },
+        { status: 400 }
+      );
+    }
+
+    if (
       updates.paymentAmountCents !== undefined &&
       (!Number.isInteger(updates.paymentAmountCents) ||
         (updates.paymentAmountCents as number) < 0)
@@ -267,16 +278,10 @@ export async function PATCH(req: Request) {
     }
 
     const mergedForPricing = { ...currentData, ...updates };
-    const pricingCtx = buildPricingContextFromRecord(mergedForPricing);
-    const pricingPatch: Record<string, unknown> = {};
-    if (pricingCtx) {
-      await ensureRegistrationConfigSeeded();
-      const config = await getActiveRegistrationConfig();
-      const quote = calculateQuoteWithConfig(pricingCtx, config);
-      pricingPatch.pricingQuote = quote;
-      pricingPatch.pricingQuoteStatus = "proposed";
-      pricingPatch.pricingQuoteComputedAt = FieldValue.serverTimestamp();
-    }
+    const pricingPatch = await buildManagerRegistrationPricingPatch(
+      mergedForPricing,
+      currentData
+    );
 
     await docRef.set(
       {

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -10,7 +10,10 @@ import {
   normalizeRegistrationPayment,
   paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
-import { addManualReceivedPayment } from "@/lib/club-registration/payment/payment-mutations";
+import {
+  addManualReceivedPayment,
+  markPaymentFullyPaid,
+} from "@/lib/club-registration/payment/payment-mutations";
 
 type StripeWebhookEvent = {
   id: string;
@@ -19,12 +22,29 @@ type StripeWebhookEvent = {
     object?: {
       id?: string;
       payment_status?: string;
+      amount_total?: number;
       client_reference_id?: string;
       invoice?: string;
       metadata?: Record<string, string>;
     };
   };
 };
+
+const STRIPE_PAID_CHECKOUT_STATUSES = new Set(["paid", "no_payment_required"]);
+
+function resolveStripeCheckoutPaidAmountCents(
+  session: NonNullable<StripeWebhookEvent["data"]>["object"],
+  existing: Record<string, unknown>,
+  basePaymentAmountToPayCents: number | null
+): number {
+  if (typeof session?.amount_total === "number" && session.amount_total > 0) {
+    return session.amount_total;
+  }
+  if (typeof existing.paymentAmountCents === "number" && existing.paymentAmountCents > 0) {
+    return existing.paymentAmountCents;
+  }
+  return basePaymentAmountToPayCents ?? 0;
+}
 
 export async function POST(req: Request) {
   try {
@@ -39,6 +59,16 @@ export async function POST(req: Request) {
     }
 
     const session = event.data?.object;
+    const stripePaymentStatus = session?.payment_status;
+    if (
+      stripePaymentStatus &&
+      !STRIPE_PAID_CHECKOUT_STATUSES.has(stripePaymentStatus)
+    ) {
+      return jsonNoStore(
+        { received: true, ignored: "checkout completed but payment not settled" },
+        { status: 200 }
+      );
+    }
     const registrationId =
       session?.metadata?.registrationId || session?.client_reference_id || null;
     if (!registrationId) {
@@ -54,18 +84,25 @@ export async function POST(req: Request) {
     }
 
     const basePayment = normalizeRegistrationPayment(existing);
-    const amountCents =
-      typeof existing.paymentAmountCents === "number"
-        ? existing.paymentAmountCents
-        : basePayment?.amountToPayCents ?? 0;
+    const amountCents = resolveStripeCheckoutPaidAmountCents(
+      session,
+      existing,
+      basePayment?.amountToPayCents ?? null
+    );
 
     let payment = basePayment;
-    if (payment && amountCents > 0) {
-      payment = addManualReceivedPayment(payment, {
-        method: "card",
-        label: "Paiement Stripe",
-        amountCents,
-        receivedAt: new Date().toISOString(),
+    if (payment) {
+      if (amountCents > 0) {
+        payment = addManualReceivedPayment(payment, {
+          method: "card",
+          label: "Paiement Stripe",
+          amountCents,
+          receivedAt: new Date().toISOString(),
+          recordedBy: "stripe",
+          ...(session?.id ? { note: `Checkout ${session.id}` } : {}),
+        });
+      }
+      payment = markPaymentFullyPaid(payment, {
         recordedBy: "stripe",
         ...(session?.id ? { note: `Checkout ${session.id}` } : {}),
       });
@@ -74,13 +111,12 @@ export async function POST(req: Request) {
     await docRef.set(
       {
         status: "paid",
-        paymentStatus: session?.payment_status ?? "paid",
         stripeCheckoutSessionId: session?.id ?? null,
         stripeInvoiceId: session?.invoice ?? null,
         stripePaymentUrl: null,
         paidAt: FieldValue.serverTimestamp(),
         updatedAt: FieldValue.serverTimestamp(),
-        ...(payment ? paymentToFirestoreUpdate(payment) : {}),
+        ...(payment ? paymentToFirestoreUpdate(payment) : { paymentStatus: "paid" }),
       },
       { merge: true }
     );
@@ -88,7 +124,12 @@ export async function POST(req: Request) {
     logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_CONFIRMED, "stripe", {
       resource: "clubRegistration",
       resourceId: registrationId,
-      details: { eventId: event.id, checkoutSessionId: session?.id },
+      details: {
+        eventId: event.id,
+        checkoutSessionId: session?.id,
+        donationCents: session?.metadata?.donationCents,
+        donationDiscountCents: session?.metadata?.donationDiscountCents,
+      },
       success: true,
     });
 

--- a/src/components/club-registration-config/PricingDevicesEditor.tsx
+++ b/src/components/club-registration-config/PricingDevicesEditor.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import {
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+} from "@mui/material";
+import type { PricingDevice, RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import { getEnabledSectionIds } from "@/lib/club-registration-config/helpers";
+import { listPricingProfiles } from "@/lib/club-registration-config/pricing-profiles";
+import { moveArrayItem } from "@/lib/club-registration-config/sort-order";
+import { generateConfigItemId } from "./config-editor-utils";
+import {
+  ConfigEditorAddButton,
+  ConfigEditorCollapsibleItem,
+  ConfigEditorHint,
+  ConfigEditorInfoAlert,
+  ConfigEditorOptionPanel,
+  ConfigEditorRoot,
+} from "./ConfigEditorLayout";
+import { useConfigEditorExpansion } from "./useConfigEditorExpansion";
+import { ConfigEditorRemoveAction } from "./ConfigEditorRemoveAction";
+import { pricingDeviceDecor } from "./config-editor-item-decor";
+import {
+  ConfigEditorDraggableItem,
+  ConfigEditorSortableList,
+} from "./ConfigEditorSortableList";
+
+type Props = {
+  config: RegistrationConfigV1;
+  onChange: (config: RegistrationConfigV1) => void;
+};
+
+function conditionSummary(device: PricingDevice, config: RegistrationConfigV1): string {
+  const sections = device.conditions.sectionIds
+    .map((id) => config.sections.find((section) => section.id === id)?.label ?? id)
+    .join(", ");
+  return `${sections} · ${device.conditions.exactSlotCount} créneau(x) · loisir sans compétition`;
+}
+
+export function PricingDevicesEditor({ config, onChange }: Props) {
+  const expansion = useConfigEditorExpansion();
+  const sectionOptions = getEnabledSectionIds(config);
+  const profileOptions = listPricingProfiles(config);
+  const ageBandOptions = Object.keys(config.ageBandProfiles);
+
+  const updateDevice = (index: number, patch: Partial<PricingDevice>) => {
+    const pricingDevices = [...config.pricingDevices];
+    pricingDevices[index] = { ...pricingDevices[index], ...patch };
+    onChange({ ...config, pricingDevices });
+  };
+
+  const updateConditions = (
+    index: number,
+    patch: Partial<PricingDevice["conditions"]>
+  ) => {
+    const pricingDevices = [...config.pricingDevices];
+    pricingDevices[index] = {
+      ...pricingDevices[index],
+      conditions: { ...pricingDevices[index].conditions, ...patch },
+    };
+    onChange({ ...config, pricingDevices });
+  };
+
+  const moveDevice = (fromIndex: number, toIndex: number) => {
+    onChange({
+      ...config,
+      pricingDevices: moveArrayItem(config.pricingDevices, fromIndex, toIndex),
+    });
+  };
+
+  return (
+    <ConfigEditorRoot>
+      <ConfigEditorInfoAlert>
+        Dispositifs tarifaires conditionnels (ex. CHAMP&apos;YON). Le premier dispositif
+        activé dont les conditions correspondent remplace le profil tarifaire de la section.
+        Les montants d&apos;adhésion se règlent dans l&apos;onglet <strong>Tarifs</strong>{" "}
+        (profil associé).
+      </ConfigEditorInfoAlert>
+      <ConfigEditorHint>
+        Priorité : valeur la plus élevée évaluée en premier. Glissez-déposez pour l&apos;ordre
+        d&apos;affichage.
+      </ConfigEditorHint>
+      <ConfigEditorSortableList droppableId="pricing-devices" onMove={moveDevice}>
+        {config.pricingDevices.map((device, index) => (
+          <ConfigEditorDraggableItem key={device.id} draggableId={device.id} index={index}>
+            {({ dragHandleProps, isDragging }) => (
+              <ConfigEditorCollapsibleItem
+                expanded={expansion.isExpanded(device.id)}
+                onExpandedChange={(open) => expansion.setExpanded(device.id, open)}
+                title={device.label}
+                itemLabel={device.label}
+                meta={`${device.enabled ? "Actif" : "Inactif"} · ${conditionSummary(device, config)}`}
+                decor={pricingDeviceDecor}
+                dragHandleProps={dragHandleProps}
+                isDragging={isDragging}
+                removeButton={
+                  device.builtIn ? null : (
+                    <ConfigEditorRemoveAction
+                      label="Supprimer le dispositif"
+                      onClick={() =>
+                        onChange({
+                          ...config,
+                          pricingDevices: config.pricingDevices.filter((_, i) => i !== index),
+                        })
+                      }
+                    />
+                  )
+                }
+              >
+                <Stack spacing={2}>
+                  <TextField
+                    label="Libellé"
+                    value={device.label}
+                    onChange={(e) => updateDevice(index, { label: e.target.value })}
+                    fullWidth
+                  />
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                    <TextField
+                      label="Priorité"
+                      type="number"
+                      value={device.priority}
+                      onChange={(e) =>
+                        updateDevice(index, {
+                          priority: Number.parseInt(e.target.value, 10) || 0,
+                        })
+                      }
+                      inputProps={{ min: 0 }}
+                      fullWidth
+                    />
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={device.enabled}
+                          onChange={(e) => updateDevice(index, { enabled: e.target.checked })}
+                        />
+                      }
+                      label="Activé"
+                    />
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={device.stackableWithDiscounts}
+                          onChange={(e) =>
+                            updateDevice(index, {
+                              stackableWithDiscounts: e.target.checked,
+                            })
+                          }
+                        />
+                      }
+                      label="Cumulable avec remises catalogue"
+                    />
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={device.includesFfttLicense}
+                          onChange={(e) =>
+                            updateDevice(index, {
+                              includesFfttLicense: e.target.checked,
+                            })
+                          }
+                        />
+                      }
+                      label="Inclure la licence FFTT"
+                    />
+                  </Stack>
+                  <FormControl fullWidth>
+                    <InputLabel id={`device-sections-${device.id}`}>Sections éligibles</InputLabel>
+                    <Select
+                      labelId={`device-sections-${device.id}`}
+                      multiple
+                      label="Sections éligibles"
+                      value={device.conditions.sectionIds}
+                      onChange={(e) =>
+                        updateConditions(index, {
+                          sectionIds:
+                            typeof e.target.value === "string"
+                              ? e.target.value.split(",")
+                              : e.target.value,
+                        })
+                      }
+                      renderValue={(selected) =>
+                        selected
+                          .map(
+                            (id) =>
+                              config.sections.find((section) => section.id === id)?.label ?? id
+                          )
+                          .join(", ")
+                      }
+                    >
+                      {sectionOptions.map((sectionId) => (
+                        <MenuItem key={sectionId} value={sectionId}>
+                          {config.sections.find((section) => section.id === sectionId)?.label ??
+                            sectionId}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <TextField
+                    label="Nombre exact de créneaux"
+                    type="number"
+                    value={device.conditions.exactSlotCount}
+                    onChange={(e) =>
+                      updateConditions(index, {
+                        exactSlotCount: Number.parseInt(e.target.value, 10) || 0,
+                      })
+                    }
+                    inputProps={{ min: 0 }}
+                    fullWidth
+                  />
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                    <FormControl fullWidth>
+                      <InputLabel id={`device-profile-${device.id}`}>Profil tarifaire</InputLabel>
+                      <Select
+                        labelId={`device-profile-${device.id}`}
+                        label="Profil tarifaire"
+                        value={device.pricingProfileId}
+                        onChange={(e) =>
+                          updateDevice(index, { pricingProfileId: e.target.value as string })
+                        }
+                      >
+                        {profileOptions.map((profile) => (
+                          <MenuItem key={profile.id} value={profile.id}>
+                            {profile.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <FormControl fullWidth>
+                      <InputLabel id={`device-age-${device.id}`}>Profil d&apos;âge</InputLabel>
+                      <Select
+                        labelId={`device-age-${device.id}`}
+                        label="Profil d'âge"
+                        value={device.ageBandProfileId ?? device.pricingProfileId}
+                        onChange={(e) =>
+                          updateDevice(index, { ageBandProfileId: e.target.value as string })
+                        }
+                      >
+                        {ageBandOptions.map((profileId) => (
+                          <MenuItem key={profileId} value={profileId}>
+                            {config.ageBandProfiles[profileId]?.label ?? profileId}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Stack>
+                  <TextField
+                    label="Préfixe libellé segment (devis)"
+                    value={device.uiCopy?.segmentLabelPrefix ?? ""}
+                    onChange={(e) =>
+                      updateDevice(index, {
+                        uiCopy: {
+                          ...device.uiCopy,
+                          segmentLabelPrefix: e.target.value || undefined,
+                        },
+                      })
+                    }
+                    fullWidth
+                  />
+                  <TextField
+                    label="Texte récap formulaire"
+                    value={device.uiCopy?.recapHint ?? ""}
+                    onChange={(e) =>
+                      updateDevice(index, {
+                        uiCopy: {
+                          ...device.uiCopy,
+                          recapHint: e.target.value || undefined,
+                        },
+                      })
+                    }
+                    multiline
+                    minRows={2}
+                    fullWidth
+                  />
+                  <TextField
+                    label="Badge secrétariat"
+                    value={device.uiCopy?.adminBadge ?? ""}
+                    onChange={(e) =>
+                      updateDevice(index, {
+                        uiCopy: {
+                          ...device.uiCopy,
+                          adminBadge: e.target.value || undefined,
+                        },
+                      })
+                    }
+                    fullWidth
+                  />
+                </Stack>
+              </ConfigEditorCollapsibleItem>
+            )}
+          </ConfigEditorDraggableItem>
+        ))}
+      </ConfigEditorSortableList>
+      <ConfigEditorAddButton
+        label="Ajouter un dispositif"
+        onClick={() => {
+          const id = generateConfigItemId("device");
+          const device: PricingDevice = {
+            id,
+            label: "Nouveau dispositif",
+            enabled: true,
+            sortOrder: config.pricingDevices.length,
+            priority: 0,
+            conditions: {
+              sectionIds: sectionOptions.slice(0, 1),
+              exactSlotCount: 1,
+              requiresNoAdditionalSections: true,
+              requiresNoCompetitorExtras: true,
+              requiresNoCompetitionSelection: true,
+            },
+            pricingProfileId: profileOptions[0]?.id ?? "classic",
+            ageBandProfileId: "classic",
+            stackableWithDiscounts: false,
+            includesFfttLicense: true,
+          };
+          onChange({
+            ...config,
+            pricingDevices: [...config.pricingDevices, device],
+          });
+          expansion.setExpanded(id, true);
+        }}
+      />
+      <ConfigEditorOptionPanel title="Conditions fixes (CHAMP'YON et similaires)">
+        Les dispositifs créés via ce formulaire imposent : aucune section complémentaire, pas de
+        section compétiteur, aucune compétition cochée.
+      </ConfigEditorOptionPanel>
+    </ConfigEditorRoot>
+  );
+}

--- a/src/components/club-registration-config/RegistrationConfigClient.tsx
+++ b/src/components/club-registration-config/RegistrationConfigClient.tsx
@@ -24,6 +24,7 @@ import { DiscountRulesEditor } from "./DiscountRulesEditor";
 import { AidRulesEditor } from "./AidRulesEditor";
 import { StripePresentationEditor } from "./StripePresentationEditor";
 import { ExportImportPanel } from "./ExportImportPanel";
+import { PricingDevicesEditor } from "./PricingDevicesEditor";
 import { useRegistrationConfigDraft } from "./useRegistrationConfigDraft";
 import {
   CONFIG_PAGE_BLOCK_SPACING,
@@ -41,6 +42,7 @@ const TABS = [
   "Compétitions",
   "Profils d'âge",
   "Tarifs",
+  "Dispositifs",
   "Remises",
   "Aides",
   "Stripe",
@@ -114,10 +116,11 @@ export function RegistrationConfigClient() {
             {tab === 4 && <CompetitionsEditor config={draft} onChange={updateDraft} />}
             {tab === 5 && <AgeBandsEditor config={draft} onChange={updateDraft} />}
             {tab === 6 && <RateTableEditor config={draft} onChange={updateDraft} />}
-            {tab === 7 && <DiscountRulesEditor config={draft} onChange={updateDraft} />}
-            {tab === 8 && <AidRulesEditor config={draft} onChange={updateDraft} />}
-            {tab === 9 && <StripePresentationEditor config={draft} onChange={updateDraft} />}
-            {tab === 10 && <ExportImportPanel config={draft} onImported={() => void load()} />}
+            {tab === 7 && <PricingDevicesEditor config={draft} onChange={updateDraft} />}
+            {tab === 8 && <DiscountRulesEditor config={draft} onChange={updateDraft} />}
+            {tab === 9 && <AidRulesEditor config={draft} onChange={updateDraft} />}
+            {tab === 10 && <StripePresentationEditor config={draft} onChange={updateDraft} />}
+            {tab === 11 && <ExportImportPanel config={draft} onImported={() => void load()} />}
           </Box>
         </Paper>
       </Stack>

--- a/src/components/club-registration-config/config-editor-item-decor.tsx
+++ b/src/components/club-registration-config/config-editor-item-decor.tsx
@@ -74,6 +74,11 @@ export const discountRuleDecor: ConfigEditorItemDecor = {
   Icon: resolveConfigEditorIcon("local_offer"),
 };
 
+export const pricingDeviceDecor: ConfigEditorItemDecor = {
+  accent: "warning",
+  Icon: resolveConfigEditorIcon("emoji_events"),
+};
+
 export const aidRuleDecor: ConfigEditorItemDecor = {
   accent: "info",
   Icon: resolveConfigEditorIcon("volunteer"),

--- a/src/components/club-registration/AidEuroAmountField.tsx
+++ b/src/components/club-registration/AidEuroAmountField.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { TextField } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import {
-  centsToEurosInput,
-  eurosInputToCents,
-  sanitizeEurosMonetaryInput,
-} from "@/lib/club-registration/payment/payment-draft-helpers";
+import { EuroMonetaryInputField } from "./EuroMonetaryInputField";
 
 type Props = {
   label: string;
@@ -20,11 +14,7 @@ type Props = {
   helperText?: string;
 };
 
-/**
- * Montant en euros pour une aide : la valeur affichée est pilotée en local
- * pendant la frappe et n’est convertie en centimes qu’au blur (évite le blocage
- * au-delà de 9,99 € et les effacements impossibles dus au formatage à chaque frappe).
- */
+/** Montant en euros pour une aide (délègue à {@link EuroMonetaryInputField}). */
 export function AidEuroAmountField({
   label,
   amountCents,
@@ -35,41 +25,16 @@ export function AidEuroAmountField({
   dataField,
   helperText,
 }: Props) {
-  const [text, setText] = useState(() => centsToEurosInput(amountCents));
-  const focusedRef = useRef(false);
-
-  useEffect(() => {
-    if (!focusedRef.current) {
-      setText(centsToEurosInput(amountCents));
-    }
-  }, [amountCents]);
-
   return (
-    <TextField
+    <EuroMonetaryInputField
       label={label}
-      value={text}
-      onChange={(e) => {
-        setText(sanitizeEurosMonetaryInput(e.target.value));
-      }}
-      onFocus={() => {
-        focusedRef.current = true;
-      }}
-      onBlur={() => {
-        focusedRef.current = false;
-        const cents = eurosInputToCents(text);
-        onCommitCents(cents);
-        setText(centsToEurosInput(cents));
-      }}
+      amountCents={amountCents}
+      onCommitCents={onCommitCents}
       required={required}
       size={size}
+      dataField={dataField}
+      selectAllOnFocus={true}
       {...(sx !== undefined ? { sx } : {})}
-      InputLabelProps={{ shrink: true }}
-      inputProps={{
-        "data-field": dataField,
-        inputMode: "decimal",
-        autoComplete: "off",
-      }}
-      placeholder="0,00"
       {...(helperText !== undefined ? { helperText } : {})}
     />
   );

--- a/src/components/club-registration/EuroMonetaryInputField.tsx
+++ b/src/components/club-registration/EuroMonetaryInputField.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { InputAdornment, TextField } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+import {
+  centsToEurosInput,
+  eurosInputToCents,
+  sanitizeEurosMonetaryInput,
+} from "@/lib/club-registration/payment/payment-draft-helpers";
+
+type Props = {
+  label: string;
+  amountCents: number;
+  onCommitCents: (cents: number) => void;
+  /** Mise à jour optionnelle pendant la frappe (aperçu, sans valider le formulaire). */
+  onDraftCents?: (cents: number) => void;
+  /** Si défini, le montant est relevé à ce minimum au blur (ex. don 1 €). */
+  minCentsOnBlur?: number;
+  required?: boolean;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  size?: "small" | "medium";
+  sx?: SxProps<Theme>;
+  id?: string;
+  dataField?: string;
+  helperText?: string;
+  placeholder?: string;
+  /** Sélectionne tout au focus pour remplacer le montant d'un coup (défaut : true). */
+  selectAllOnFocus?: boolean;
+  endAdornment?: ReactNode;
+};
+
+/**
+ * Saisie euros (virgule) : texte local pendant la frappe, conversion en centimes au blur.
+ * Évite les effacements impossibles dus au formatage « 1,00 » à chaque touche.
+ */
+export function EuroMonetaryInputField({
+  label,
+  amountCents,
+  onCommitCents,
+  onDraftCents,
+  minCentsOnBlur,
+  required = false,
+  disabled = false,
+  fullWidth = false,
+  size = "medium",
+  sx,
+  id,
+  dataField,
+  helperText,
+  placeholder = "0,00",
+  selectAllOnFocus = true,
+  endAdornment,
+}: Props) {
+  const [text, setText] = useState(() => centsToEurosInput(amountCents));
+  const focusedRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setText(centsToEurosInput(amountCents));
+    }
+  }, [amountCents]);
+
+  const commitFromText = (raw: string) => {
+    let cents = eurosInputToCents(raw);
+    if (minCentsOnBlur != null && cents > 0 && cents < minCentsOnBlur) {
+      cents = minCentsOnBlur;
+    }
+    onCommitCents(cents);
+    setText(cents > 0 ? centsToEurosInput(cents) : "");
+  };
+
+  return (
+    <TextField
+      {...(id ? { id } : {})}
+      label={label}
+      value={text}
+      disabled={disabled}
+      required={required}
+      fullWidth={fullWidth}
+      size={size}
+      onChange={(e) => {
+        const next = sanitizeEurosMonetaryInput(e.target.value);
+        setText(next);
+        onDraftCents?.(eurosInputToCents(next));
+      }}
+      onFocus={(e) => {
+        focusedRef.current = true;
+        if (selectAllOnFocus) {
+          e.target.select();
+        }
+      }}
+      onBlur={() => {
+        focusedRef.current = false;
+        commitFromText(text);
+      }}
+      InputLabelProps={{ shrink: true }}
+      inputRef={inputRef}
+      inputProps={{
+        ...(dataField ? { "data-field": dataField } : {}),
+        inputMode: "decimal",
+        autoComplete: "off",
+      }}
+      placeholder={placeholder}
+      {...(helperText !== undefined ? { helperText } : {})}
+      {...(endAdornment
+        ? {
+            InputProps: {
+              endAdornment: <InputAdornment position="end">{endAdornment}</InputAdornment>,
+            },
+          }
+        : {})}
+      {...(sx !== undefined ? { sx } : {})}
+    />
+  );
+}

--- a/src/components/club-registration/MesInscriptionPayOnlineButton.tsx
+++ b/src/components/club-registration/MesInscriptionPayOnlineButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { Button, CircularProgress, Typography } from "@mui/material";
+import PaymentIcon from "@mui/icons-material/Payment";
+import {
+  ADHERENT_NON_CARD_PAYMENT_HINT,
+  ADHERENT_PAY_ONLINE_BUTTON_LABEL,
+  ADHERENT_PAY_ONLINE_HELPER,
+} from "@/lib/club-registration/payment/bnpl-checkout-copy";
+import {
+  canSelfServiceCheckout,
+  isAwaitingNonCardPayment,
+  type SelfServiceCheckoutRecord,
+} from "@/lib/club-registration/self-service-checkout";
+
+type Props = {
+  registration: SelfServiceCheckoutRecord & { id: string };
+  onError: (message: string | null) => void;
+};
+
+export function MesInscriptionPayOnlineButton({ registration, onError }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  if (canSelfServiceCheckout(registration)) {
+    const handlePay = async () => {
+      setLoading(true);
+      onError(null);
+      try {
+        const res = await fetch(
+          `/api/club/registration/${encodeURIComponent(registration.id)}/checkout`,
+          {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+        const json = (await res.json().catch(() => ({}))) as {
+          checkoutUrl?: string;
+          error?: string;
+        };
+        if (!res.ok || !json.checkoutUrl) {
+          throw new Error(json.error || "Impossible d'ouvrir la page de paiement.");
+        }
+        window.location.assign(json.checkoutUrl);
+      } catch (err) {
+        onError(err instanceof Error ? err.message : "Impossible d'ouvrir la page de paiement.");
+        setLoading(false);
+      }
+    };
+
+    return (
+      <>
+        <Button
+          size="small"
+          variant="contained"
+          color="secondary"
+          startIcon={
+            loading ? <CircularProgress size={16} color="inherit" /> : <PaymentIcon fontSize="small" />
+          }
+          disabled={loading}
+          onClick={() => void handlePay()}
+          sx={{ alignSelf: { xs: "stretch", sm: "auto" }, flexShrink: 0 }}
+        >
+          {loading ? "Redirection…" : ADHERENT_PAY_ONLINE_BUTTON_LABEL}
+        </Button>
+        <Typography variant="caption" color="text.secondary" sx={{ width: "100%" }}>
+          {ADHERENT_PAY_ONLINE_HELPER}
+        </Typography>
+      </>
+    );
+  }
+
+  if (isAwaitingNonCardPayment(registration)) {
+    return (
+      <Typography variant="caption" color="text.secondary" sx={{ width: "100%" }}>
+        {ADHERENT_NON_CARD_PAYMENT_HINT}
+      </Typography>
+    );
+  }
+
+  return null;
+}

--- a/src/components/club-registration/MesInscriptionRegistrationCard.tsx
+++ b/src/components/club-registration/MesInscriptionRegistrationCard.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography,
+  Box,
+} from "@mui/material";
+import DownloadIcon from "@mui/icons-material/Download";
+import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
+import { MEDICAL_CERTIFICATE_STATUS_LABELS } from "@/lib/club-registration/medical-certificate";
+import { MesInscriptionPayOnlineButton } from "@/components/club-registration/MesInscriptionPayOnlineButton";
+import {
+  findMesInscriptionSectionLabel,
+  formatMesInscriptionAmount,
+  formatMesInscriptionDate,
+  isMesInscriptionPaid,
+  MES_INSCRIPTION_MEDICAL_COLOR,
+  MES_INSCRIPTION_ROLE_LABEL,
+  MES_INSCRIPTION_STATUS_COLOR,
+  MES_INSCRIPTION_STATUS_LABEL,
+  type MesInscriptionSummary,
+} from "@/components/club-registration/mes-inscriptions-shared";
+
+type Props = {
+  registration: MesInscriptionSummary;
+  highlighted?: boolean;
+  invoiceLoadingId: string | null;
+  onOpenInvoice: (registrationId: string) => void;
+  onPaymentError: (message: string | null) => void;
+};
+
+export const MesInscriptionRegistrationCard = forwardRef<HTMLDivElement, Props>(
+  function MesInscriptionRegistrationCard(
+    { registration: r, highlighted = false, invoiceLoadingId, onOpenInvoice, onPaymentError },
+    ref
+  ) {
+    return (
+      <Card
+        ref={ref}
+        variant="outlined"
+        sx={
+          highlighted
+            ? {
+                borderWidth: 2,
+                borderColor: "secondary.main",
+                boxShadow: (theme) => `0 0 0 4px ${theme.palette.secondary.main}22`,
+              }
+            : {
+                borderColor: "divider",
+              }
+        }
+      >
+        <CardContent sx={{ pb: 1.5 }}>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            alignItems={{ xs: "stretch", sm: "flex-start" }}
+            justifyContent="space-between"
+            spacing={{ xs: 1.5, sm: 2 }}
+          >
+            <Box sx={{ minWidth: 0 }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  color: "primary.main",
+                  wordBreak: "break-word",
+                  lineHeight: 1.3,
+                }}
+              >
+                {formatPersonDisplayName(r.firstName, r.lastName) || "—"}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-word" }}>
+                {r.adherentRole ? MES_INSCRIPTION_ROLE_LABEL[r.adherentRole] : ""}
+                {r.mainSectionId ? ` • ${findMesInscriptionSectionLabel(r.mainSectionId)}` : ""}
+              </Typography>
+            </Box>
+            <Stack
+              direction={{ xs: "row", sm: "column" }}
+              alignItems={{ xs: "center", sm: "flex-end" }}
+              justifyContent={{ xs: "space-between", sm: "flex-start" }}
+              spacing={{ xs: 1, sm: 0.5 }}
+              flexWrap="wrap"
+              useFlexGap
+            >
+              <Chip
+                size="small"
+                label={MES_INSCRIPTION_STATUS_LABEL[r.status ?? ""] ?? r.status ?? "—"}
+                color={MES_INSCRIPTION_STATUS_COLOR[r.status ?? ""] ?? "default"}
+                sx={{ flexShrink: 0 }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                Envoyé le {formatMesInscriptionDate(r.submittedAt)}
+              </Typography>
+              {r.status === "payment_requested" ? (
+                <Typography variant="caption" color="secondary.main" fontWeight={700}>
+                  Paiement attendu
+                  {formatMesInscriptionAmount(r.paymentAmountCents)
+                    ? ` : ${formatMesInscriptionAmount(r.paymentAmountCents)}`
+                    : ""}
+                </Typography>
+              ) : null}
+              {r.medicalCertificateStatus && r.medicalCertificateStatus !== "not_required" ? (
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={`Certificat : ${
+                    MEDICAL_CERTIFICATE_STATUS_LABELS[r.medicalCertificateStatus]
+                  }`}
+                  color={MES_INSCRIPTION_MEDICAL_COLOR[r.medicalCertificateStatus]}
+                  sx={{ flexShrink: 0 }}
+                />
+              ) : null}
+            </Stack>
+          </Stack>
+        </CardContent>
+        <CardActions
+          sx={{
+            flexDirection: { xs: "column", sm: "row" },
+            alignItems: { xs: "stretch", sm: "center" },
+            justifyContent: "space-between",
+            gap: 1,
+            pt: 0,
+            px: { xs: 2, sm: 3 },
+            pb: 2,
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{ wordBreak: "break-all" }}>
+            Référence&nbsp;: {r.id}
+          </Typography>
+          <Stack
+            direction="column"
+            spacing={0.75}
+            alignItems={{ xs: "stretch", sm: "flex-end" }}
+            sx={{ width: { xs: "100%", sm: "auto" } }}
+          >
+            <MesInscriptionPayOnlineButton registration={r} onError={onPaymentError} />
+            {isMesInscriptionPaid(r) && r.invoiceAvailable ? (
+              <Button
+                size="small"
+                variant="outlined"
+                color="secondary"
+                startIcon={
+                  invoiceLoadingId === r.id ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : (
+                    <DownloadIcon fontSize="small" />
+                  )
+                }
+                disabled={invoiceLoadingId === r.id}
+                onClick={() => onOpenInvoice(r.id)}
+                sx={{ alignSelf: { xs: "stretch", sm: "auto" }, flexShrink: 0 }}
+              >
+                Télécharger la facture
+              </Button>
+            ) : isMesInscriptionPaid(r) ? (
+              <Typography variant="caption" color="text.secondary">
+                Facture en cours de publication…
+              </Typography>
+            ) : null}
+          </Stack>
+        </CardActions>
+      </Card>
+    );
+  }
+);

--- a/src/components/club-registration/MesInscriptionsClient.tsx
+++ b/src/components/club-registration/MesInscriptionsClient.tsx
@@ -1,130 +1,47 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
   Button,
   Card,
-  CardActions,
   CardContent,
-  Chip,
   CircularProgress,
   Container,
   Stack,
   Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
-import DownloadIcon from "@mui/icons-material/Download";
 import NextLink from "next/link";
 import { useSearchParams } from "next/navigation";
 import { PageHeader } from "@/components/ui";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
-import { getEnabledSections } from "@/lib/club-registration-config/helpers";
-import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import { ADHERENT_PAYMENT_EMAIL_LANDING_ALERT, ADHERENT_PAYMENT_PENDING_ALERT } from "@/lib/club-registration/payment/bnpl-checkout-copy";
+import { canSelfServiceCheckout } from "@/lib/club-registration/self-service-checkout";
+import { MesInscriptionRegistrationCard } from "@/components/club-registration/MesInscriptionRegistrationCard";
 import {
-  MEDICAL_CERTIFICATE_STATUS_LABELS,
-  type MedicalCertificateStatus,
-} from "@/lib/club-registration/medical-certificate";
-
-type RegistrationSummary = {
-  id: string;
-  adherentRole?: "self" | "minor_dependent" | "other_adult";
-  firstName?: string;
-  lastName?: string;
-  birthDate?: string;
-  isMinor?: boolean;
-  mainSectionId?: string;
-  medicalCertificateStatus?: MedicalCertificateStatus;
-  status?: string;
-  paymentAmountCents?: number;
-  paymentStatus?: string;
-  invoiceAvailable?: boolean;
-  submittedAt?: string | null;
-  updatedAt?: string | null;
-  paidAt?: string | null;
-};
-
-type ApiResponse =
-  | { registrations: RegistrationSummary[] }
-  | { error: string };
-
-const ROLE_LABEL: Record<NonNullable<RegistrationSummary["adherentRole"]>, string> = {
-  self: "Inscription pour moi",
-  minor_dependent: "Mineur dont je suis le représentant légal",
-  other_adult: "Autre adulte",
-};
-
-const STATUS_COLOR: Record<string, "default" | "warning" | "success" | "error"> = {
-  submitted: "warning",
-  in_review: "warning",
-  payment_requested: "warning",
-  paid: "success",
-  approved: "success",
-  rejected: "error",
-};
-
-const STATUS_LABEL: Record<string, string> = {
-  submitted: "En cours d’examen",
-  in_review: "En cours de relecture",
-  payment_requested: "Paiement demandé",
-  paid: "Paiement reçu",
-  approved: "Approuvé",
-  rejected: "Refusé",
-};
-
-const MEDICAL_CERTIFICATE_STATUS_COLOR: Record<
-  MedicalCertificateStatus,
-  "default" | "warning" | "success"
-> = {
-  not_required: "default",
-  required_not_received: "warning",
-  received: "warning",
-  validated: "success",
-};
-
-function formatAmount(cents: number | undefined): string | null {
-  if (typeof cents !== "number") return null;
-  return new Intl.NumberFormat("fr-FR", {
-    style: "currency",
-    currency: "EUR",
-  }).format(cents / 100);
-}
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return "—";
-  try {
-    return new Date(iso).toLocaleDateString();
-  } catch {
-    return iso;
-  }
-}
-
-function findSectionLabel(id: string | undefined): string {
-  if (!id) return "";
-  const found = getEnabledSections(getDefaultRegistrationConfig()).find((s) => s.id === id);
-  return found?.label ?? id;
-}
-
-function isRegistrationPaid(r: RegistrationSummary): boolean {
-  return (
-    r.status === "paid" ||
-    r.paymentStatus === "paid" ||
-    r.paymentStatus === "complete"
-  );
-}
+  isMesInscriptionPaid,
+  type MesInscriptionSummary,
+  type MesInscriptionsApiResponse,
+} from "@/components/club-registration/mes-inscriptions-shared";
 
 export function MesInscriptionsClient() {
   const params = useSearchParams();
   const createdId = params?.get("created") ?? null;
-  const paymentSuccessId = params?.get("registration") ?? null;
+  const registrationFocusId = params?.get("registration") ?? null;
   const paymentBanner =
-    params?.get("payment") === "success" ? "success" : null;
+    params?.get("payment") === "success"
+      ? "success"
+      : params?.get("payment") === "cancelled"
+        ? "cancelled"
+        : null;
   const [loading, setLoading] = useState(true);
-  const [registrations, setRegistrations] = useState<RegistrationSummary[]>([]);
+  const [registrations, setRegistrations] = useState<MesInscriptionSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [invoiceError, setInvoiceError] = useState<string | null>(null);
   const [invoiceLoadingId, setInvoiceLoadingId] = useState<string | null>(null);
+  const highlightCardRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -135,7 +52,7 @@ export function MesInscriptionsClient() {
         const res = await fetch("/api/club/registrations", {
           credentials: "include",
         });
-        const json = (await res.json()) as ApiResponse;
+        const json = (await res.json()) as MesInscriptionsApiResponse;
         if (cancelled) return;
         if (!res.ok || "error" in json) {
           setError("error" in json ? json.error : "Impossible de charger vos dossiers.");
@@ -162,8 +79,46 @@ export function MesInscriptionsClient() {
   );
 
   const paymentJustCompleted = useMemo(
-    () => registrations.find((r) => r.id === paymentSuccessId) ?? null,
-    [registrations, paymentSuccessId]
+    () =>
+      paymentBanner === "success" && registrationFocusId
+        ? registrations.find((r) => r.id === registrationFocusId) ?? null
+        : null,
+    [registrations, paymentBanner, registrationFocusId]
+  );
+
+  const paymentCancelledRegistration = useMemo(
+    () =>
+      paymentBanner === "cancelled" && registrationFocusId
+        ? registrations.find((r) => r.id === registrationFocusId) ?? null
+        : null,
+    [registrations, paymentBanner, registrationFocusId]
+  );
+
+  const paymentLandingRegistration = useMemo(
+    () =>
+      !paymentBanner && registrationFocusId
+        ? registrations.find((r) => r.id === registrationFocusId) ?? null
+        : null,
+    [registrations, paymentBanner, registrationFocusId]
+  );
+
+  const highlightRegistrationId = useMemo(() => {
+    if (!registrationFocusId || paymentBanner === "success") {
+      return null;
+    }
+    return registrations.some((r) => r.id === registrationFocusId) ? registrationFocusId : null;
+  }, [registrationFocusId, paymentBanner, registrations]);
+
+  useEffect(() => {
+    if (!highlightRegistrationId || loading) {
+      return;
+    }
+    highlightCardRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [highlightRegistrationId, loading]);
+
+  const hasPendingSelfServicePayment = useMemo(
+    () => registrations.some((r) => canSelfServiceCheckout(r)),
+    [registrations]
   );
 
   const openInvoice = async (registrationId: string) => {
@@ -213,13 +168,13 @@ export function MesInscriptionsClient() {
             Votre demande pour{" "}
             <strong>
               {formatPersonDisplayName(justCreated.firstName, justCreated.lastName)}
-            </strong>
-            {" "}a bien été envoyée au club. Un e-mail de confirmation vous a été adressé à
+            </strong>{" "}
+            a bien été envoyée au club. Un e-mail de confirmation vous a été adressé à
             l’adresse de votre compte.
           </Alert>
         ) : null}
 
-        {paymentBanner && paymentJustCompleted ? (
+        {paymentBanner === "success" && paymentJustCompleted ? (
           <Alert severity="success">
             Paiement enregistré pour{" "}
             <strong>
@@ -230,7 +185,7 @@ export function MesInscriptionsClient() {
             </strong>
             .{" "}
             {paymentJustCompleted.invoiceAvailable ||
-            isRegistrationPaid(paymentJustCompleted) ? (
+            isMesInscriptionPaid(paymentJustCompleted) ? (
               <>
                 Votre facture Stripe est disponible ci-dessous (
                 <em>Télécharger la facture</em>).
@@ -239,6 +194,27 @@ export function MesInscriptionsClient() {
               <>La facture apparaîtra d’ici quelques instants sur cette page.</>
             )}
           </Alert>
+        ) : null}
+
+        {paymentCancelledRegistration ? (
+          <Alert severity="info">
+            Paiement annulé pour{" "}
+            <strong>
+              {formatPersonDisplayName(
+                paymentCancelledRegistration.firstName,
+                paymentCancelledRegistration.lastName
+              )}
+            </strong>
+            . Vous pouvez réessayer avec le bouton <em>Payer en ligne</em> ci-dessous.
+          </Alert>
+        ) : null}
+
+        {paymentLandingRegistration && canSelfServiceCheckout(paymentLandingRegistration) ? (
+          <Alert severity="info">{ADHERENT_PAYMENT_EMAIL_LANDING_ALERT}</Alert>
+        ) : null}
+
+        {hasPendingSelfServicePayment && !paymentLandingRegistration ? (
+          <Alert severity="warning">{ADHERENT_PAYMENT_PENDING_ALERT}</Alert>
         ) : null}
 
         {error ? <Alert severity="error">{error}</Alert> : null}
@@ -264,120 +240,15 @@ export function MesInscriptionsClient() {
         ) : (
           <Stack spacing={2}>
             {registrations.map((r) => (
-              <Card key={r.id}>
-                <CardContent sx={{ pb: 1.5 }}>
-                  <Stack
-                    direction={{ xs: "column", sm: "row" }}
-                    alignItems={{ xs: "stretch", sm: "flex-start" }}
-                    justifyContent="space-between"
-                    spacing={{ xs: 1.5, sm: 2 }}
-                  >
-                    <Box sx={{ minWidth: 0 }}>
-                      <Typography
-                        variant="h6"
-                        sx={{
-                          color: "primary.main",
-                          wordBreak: "break-word",
-                          lineHeight: 1.3,
-                        }}
-                      >
-                        {formatPersonDisplayName(r.firstName, r.lastName) || "—"}
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{ wordBreak: "break-word" }}
-                      >
-                        {r.adherentRole ? ROLE_LABEL[r.adherentRole] : ""}
-                        {r.mainSectionId ? ` • ${findSectionLabel(r.mainSectionId)}` : ""}
-                      </Typography>
-                    </Box>
-                    <Stack
-                      direction={{ xs: "row", sm: "column" }}
-                      alignItems={{ xs: "center", sm: "flex-end" }}
-                      justifyContent={{ xs: "space-between", sm: "flex-start" }}
-                      spacing={{ xs: 1, sm: 0.5 }}
-                      flexWrap="wrap"
-                      useFlexGap
-                    >
-                      <Chip
-                        size="small"
-                        label={STATUS_LABEL[r.status ?? ""] ?? r.status ?? "—"}
-                        color={STATUS_COLOR[r.status ?? ""] ?? "default"}
-                        sx={{ flexShrink: 0 }}
-                      />
-                      <Typography variant="caption" color="text.secondary">
-                        Envoyé le {formatDate(r.submittedAt)}
-                      </Typography>
-                      {r.status === "payment_requested" ? (
-                        <Typography variant="caption" color="secondary.main" fontWeight={700}>
-                          Paiement attendu{formatAmount(r.paymentAmountCents) ? ` : ${formatAmount(r.paymentAmountCents)}` : ""}
-                        </Typography>
-                      ) : null}
-                      {r.medicalCertificateStatus &&
-                      r.medicalCertificateStatus !== "not_required" ? (
-                        <Chip
-                          size="small"
-                          variant="outlined"
-                          label={`Certificat : ${
-                            MEDICAL_CERTIFICATE_STATUS_LABELS[
-                              r.medicalCertificateStatus
-                            ]
-                          }`}
-                          color={
-                            MEDICAL_CERTIFICATE_STATUS_COLOR[
-                              r.medicalCertificateStatus
-                            ]
-                          }
-                          sx={{ flexShrink: 0 }}
-                        />
-                      ) : null}
-                    </Stack>
-                  </Stack>
-                </CardContent>
-                <CardActions
-                  sx={{
-                    flexDirection: { xs: "column", sm: "row" },
-                    alignItems: { xs: "stretch", sm: "center" },
-                    justifyContent: "space-between",
-                    gap: 1,
-                    pt: 0,
-                    px: { xs: 2, sm: 3 },
-                    pb: 2,
-                  }}
-                >
-                  <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ wordBreak: "break-all" }}
-                  >
-                    Référence&nbsp;: {r.id}
-                  </Typography>
-                  {isRegistrationPaid(r) && r.invoiceAvailable ? (
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      color="secondary"
-                      startIcon={
-                        invoiceLoadingId === r.id ? (
-                          <CircularProgress size={16} color="inherit" />
-                        ) : (
-                          <DownloadIcon fontSize="small" />
-                        )
-                      }
-                      disabled={invoiceLoadingId === r.id}
-                      onClick={() => openInvoice(r.id)}
-                      sx={{ alignSelf: { xs: "stretch", sm: "auto" }, flexShrink: 0 }}
-                    >
-                      Télécharger la facture
-                    </Button>
-                  ) : isRegistrationPaid(r) ? (
-                    <Typography variant="caption" color="text.secondary">
-                      Facture en cours de publication…
-                    </Typography>
-                  ) : null}
-                </CardActions>
-              </Card>
+              <MesInscriptionRegistrationCard
+                key={r.id}
+                ref={r.id === highlightRegistrationId ? highlightCardRef : undefined}
+                registration={r}
+                highlighted={r.id === highlightRegistrationId}
+                invoiceLoadingId={invoiceLoadingId}
+                onOpenInvoice={openInvoice}
+                onPaymentError={setError}
+              />
             ))}
           </Stack>
         )}

--- a/src/components/club-registration/PaymentStep.tsx
+++ b/src/components/club-registration/PaymentStep.tsx
@@ -27,15 +27,14 @@ import {
   type RemainingPaymentMethodId,
 } from "@/lib/club-registration/payment-constants";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
-import {
-  centsToEurosInput,
-  eurosInputToCents,
-  normalizePaymentAidList,
-} from "@/lib/club-registration/payment/payment-draft-helpers";
+import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
 import { BNPL_ADHERENT_WIZARD_MESSAGE } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import { formatCentsAsEuros } from "@/lib/pricing";
 import type { RegistrationDraft } from "./registration-defaults";
 import { usePricingQuote, type PricingBreakdownDraft } from "./PricingBreakdown";
+import { VoluntaryDonationFields } from "./VoluntaryDonationFields";
+import { EuroMonetaryInputField } from "./EuroMonetaryInputField";
+import { resolveDonationPricing } from "@/lib/pricing/donation-discount";
 
 type Props = {
   draft: RegistrationDraft;
@@ -50,16 +49,20 @@ export function PaymentStep({ draft, onChange }: Props) {
   const quote = usePricingQuote(draft as PricingBreakdownDraft);
 
   const totalCents = quote?.totalCents ?? 0;
+  const donationPricing = quote
+    ? resolveDonationPricing(quote, draft.voluntaryDonationCents ?? 0)
+    : null;
+  const invoiceTotalCents = donationPricing?.invoiceTotalCents ?? totalCents;
 
   const summary = useMemo(
     () =>
       calculatePaymentSummary({
-        totalAmountCents: totalCents,
+        totalAmountCents: invoiceTotalCents,
         aids: normalizePaymentAidList(draft.paymentAids),
         receivedPayments: [],
         currentPaymentStatus: "pending_validation",
       }),
-    [totalCents, draft.paymentAids]
+    [invoiceTotalCents, draft.paymentAids]
   );
 
   const setPaymentMethod = (method: PaymentMethodId) => {
@@ -94,8 +97,22 @@ export function PaymentStep({ draft, onChange }: Props) {
         >
           <Stack spacing={0.5}>
             <Typography variant="body2">
-              Montant total : <strong>{formatCentsAsEuros(totalCents)}</strong>
+              Montant catalogue : <strong>{formatCentsAsEuros(totalCents)}</strong>
             </Typography>
+            {donationPricing && donationPricing.voluntaryDonationCents > 0 ? (
+              <>
+                <Typography variant="body2">
+                  Don :{" "}
+                  <strong>
+                    {formatCentsAsEuros(donationPricing.voluntaryDonationCents)}
+                  </strong>
+                </Typography>
+                <Typography variant="body2">
+                  Remise don :{" "}
+                  <strong>−{formatCentsAsEuros(donationPricing.donationDiscountCents)}</strong>
+                </Typography>
+              </>
+            ) : null}
             <Typography variant="body2">
               Aides déclarées :{" "}
               <strong>{formatCentsAsEuros(summary.assistanceTotalAmountCents)}</strong>
@@ -113,6 +130,12 @@ export function PaymentStep({ draft, onChange }: Props) {
           montants à l&apos;étape « Dossier administratif ».
         </Alert>
       ) : null}
+
+      <VoluntaryDonationFields
+        quote={quote}
+        voluntaryDonationCents={draft.voluntaryDonationCents ?? 0}
+        onChange={(voluntaryDonationCents) => onChange({ voluntaryDonationCents })}
+      />
 
       <Stack spacing={1.5}>
         <Typography variant="subtitle1" component="h3" sx={{ fontWeight: 700 }}>
@@ -183,16 +206,15 @@ export function PaymentStep({ draft, onChange }: Props) {
             Les chèques vacances peuvent couvrir tout ou partie du règlement. En cas
             de complément, le secrétariat vous indiquera la marche à suivre.
           </Alert>
-          <TextField
-            label="Montant prévu en chèques vacances (€)"
-            value={centsToEurosInput(draft.holidayVoucherAmountCents ?? 0)}
-            onChange={(e) =>
-              onChange({
-                holidayVoucherAmountCents: eurosInputToCents(e.target.value) || null,
-              })
+          <EuroMonetaryInputField
+            label="Montant prévu en chèques vacances"
+            amountCents={draft.holidayVoucherAmountCents ?? 0}
+            onCommitCents={(cents) =>
+              onChange({ holidayVoucherAmountCents: cents > 0 ? cents : null })
             }
             fullWidth
-            inputProps={{ "data-field": "holidayVoucherAmountCents" }}
+            dataField="holidayVoucherAmountCents"
+            endAdornment="€"
           />
           <FormControl fullWidth>
             <InputLabel id="remaining-payment-method-label">

--- a/src/components/club-registration/PricingBreakdown.tsx
+++ b/src/components/club-registration/PricingBreakdown.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import {
   Alert,
   Box,
+  Chip,
   Stack,
   Table,
   TableBody,
@@ -22,11 +23,18 @@ import type { PriceQuote } from "@/lib/pricing/types";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
 import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
 import type { RegistrationDraft } from "./registration-defaults";
+import {
+  PricingBreakdownDonationRows,
+  useDonationPricing,
+  useEstimatedInvoiceTotalCents as useEstimatedInvoiceTotalFromQuote,
+} from "./pricing-breakdown-donation";
 
 export type PricingBreakdownDraft = Pick<
   RegistrationDraft,
   | "birthDate"
   | "mainSectionId"
+  | "slotIds"
+  | "additionalSectionIds"
   | "wantsCompetitorExtras"
   | "wantsOptionalJersey"
   | "competitionIds"
@@ -36,12 +44,15 @@ export type PricingBreakdownDraft = Pick<
   | "reductionTypes"
 > & {
   paymentAids?: RegistrationDraft["paymentAids"];
+  voluntaryDonationCents?: number;
 };
 
 function toPricingContextInput(draft: PricingBreakdownDraft) {
   const input = {
     birthDate: draft.birthDate,
     mainSectionId: draft.mainSectionId,
+    slotIds: draft.slotIds ?? [],
+    additionalSectionIds: draft.additionalSectionIds ?? [],
     wantsCompetitorExtras: draft.wantsCompetitorExtras,
     wantsOptionalJersey: draft.wantsOptionalJersey,
     competitionIds: draft.competitionIds,
@@ -72,9 +83,15 @@ export function usePricingQuote(draft: PricingBreakdownDraft) {
   }, [draft, config]);
 }
 
+export function useEstimatedInvoiceTotalCents(draft: PricingBreakdownDraft): number | null {
+  const quote = usePricingQuote(draft);
+  return useEstimatedInvoiceTotalFromQuote(quote, draft);
+}
+
 function useDeclarativeAidSummary(
   quote: PriceQuote | null,
-  draft: PricingBreakdownDraft
+  draft: PricingBreakdownDraft,
+  invoiceTotalCents: number
 ) {
   return useMemo(() => {
     if (!quote) return null;
@@ -83,16 +100,18 @@ function useDeclarativeAidSummary(
       (draft.reductionTypes?.length ?? 0) > 0 || aids.length > 0;
     if (!hasDeclarativeAids) return null;
     return calculatePaymentSummary({
-      totalAmountCents: quote.totalCents,
+      totalAmountCents: invoiceTotalCents,
       aids,
       receivedPayments: [],
     });
-  }, [quote, draft.reductionTypes, draft.paymentAids]);
+  }, [quote, draft.reductionTypes, draft.paymentAids, invoiceTotalCents]);
 }
 
 export function PricingBreakdown({ draft, variant = "full" }: Props) {
   const quote = usePricingQuote(draft);
-  const aidSummary = useDeclarativeAidSummary(quote, draft);
+  const donationPricing = useDonationPricing(quote, draft);
+  const invoiceTotalCents = donationPricing?.invoiceTotalCents ?? quote?.totalCents ?? 0;
+  const aidSummary = useDeclarativeAidSummary(quote, draft, invoiceTotalCents);
   const declaredAids = useMemo(
     () =>
       normalizePaymentAidList(draft.paymentAids ?? []).filter(
@@ -135,8 +154,21 @@ export function PricingBreakdown({ draft, variant = "full" }: Props) {
         <Typography variant="caption" color="text.secondary">
           {quote.segmentLabel}
         </Typography>
+        {donationPricing ? (
+          <>
+            <Typography variant="caption" color="text.secondary">
+              Catalogue : {formatCentsAsEuros(quote.totalCents)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Don : {formatCentsAsEuros(donationPricing.voluntaryDonationCents)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Remise don : −{formatCentsAsEuros(donationPricing.donationDiscountCents)}
+            </Typography>
+          </>
+        ) : null}
         <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-          Total estimé : {formatCentsAsEuros(quote.totalCents)}
+          Total estimé : {formatCentsAsEuros(invoiceTotalCents)}
         </Typography>
         {aidSummary ? (
           <>
@@ -165,13 +197,23 @@ export function PricingBreakdown({ draft, variant = "full" }: Props) {
 
   return (
     <Stack spacing={isSidebar ? 0.5 : 1.5}>
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ lineHeight: 1.3, display: "block" }}
-      >
-        {quote.segmentLabel}
-      </Typography>
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ lineHeight: 1.3, display: "block" }}
+        >
+          {quote.segmentLabel}
+        </Typography>
+        {quote.appliedPricingDeviceLabel ? (
+          <Chip
+            size="small"
+            color="warning"
+            label={quote.appliedPricingDeviceLabel}
+            sx={{ height: 20, fontSize: "0.6875rem" }}
+          />
+        ) : null}
+      </Stack>
 
       <Box sx={{ overflowX: "auto" }}>
         <Table size="small" aria-label="Détail tarifaire estimé">
@@ -195,6 +237,12 @@ export function PricingBreakdown({ draft, variant = "full" }: Props) {
                 </TableCell>
               </TableRow>
             ))}
+            {donationPricing ? (
+              <PricingBreakdownDonationRows
+                donationPricing={donationPricing}
+                cellSx={cellSx}
+              />
+            ) : null}
             <TableRow>
               <TableCell
                 sx={{
@@ -205,7 +253,7 @@ export function PricingBreakdown({ draft, variant = "full" }: Props) {
                   fontSize: isSidebar ? "0.875rem" : undefined,
                 }}
               >
-                Total estimé
+                {donationPricing ? "Total avec don" : "Total estimé"}
               </TableCell>
               <TableCell
                 align="right"
@@ -217,7 +265,7 @@ export function PricingBreakdown({ draft, variant = "full" }: Props) {
                   fontSize: isSidebar ? "0.875rem" : undefined,
                 }}
               >
-                {formatCentsAsEuros(quote.totalCents)}
+                {formatCentsAsEuros(invoiceTotalCents)}
               </TableCell>
             </TableRow>
             {aidSummary ? (

--- a/src/components/club-registration/RegistrationSidebar.tsx
+++ b/src/components/club-registration/RegistrationSidebar.tsx
@@ -20,7 +20,7 @@ import { computeAgeAt, isMinorAt } from "@/lib/club-registration/age";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import type { RegistrationStepId } from "@/lib/club-registration/field-to-step";
 import { formatCentsAsEuros } from "@/lib/pricing";
-import { PricingBreakdown, usePricingQuote } from "./PricingBreakdown";
+import { PricingBreakdown, useEstimatedInvoiceTotalCents } from "./PricingBreakdown";
 import { registrationSidebarPanelSx } from "./registration-sidebar-styles";
 import type { RegistrationStickyOffsets } from "./useRegistrationStickyOffsets";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
@@ -253,10 +253,10 @@ export function RegistrationSidebar({
   stickyOffsets,
   ...props
 }: Props) {
-  const quote = usePricingQuote(props.draft);
+  const totalCents = useEstimatedInvoiceTotalCents(props.draft);
   const age = computeAgeAt(props.draft.birthDate);
   const totalLabel =
-    quote && age !== null ? formatCentsAsEuros(quote.totalCents) : null;
+    totalCents !== null && age !== null ? formatCentsAsEuros(totalCents) : null;
 
   return (
     <>

--- a/src/components/club-registration/VoluntaryDonationFields.tsx
+++ b/src/components/club-registration/VoluntaryDonationFields.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  VOLUNTARY_DONATION_MIN_CENTS,
+  computeDonationDiscountCents,
+  formatCentsAsEuros,
+  getMembershipNetCents,
+} from "@/lib/pricing";
+import type { PriceQuote } from "@/lib/pricing/types";
+import { EuroMonetaryInputField } from "./EuroMonetaryInputField";
+
+type Props = {
+  quote: PriceQuote | null;
+  voluntaryDonationCents: number;
+  onChange: (voluntaryDonationCents: number) => void;
+  disabled?: boolean;
+  idPrefix?: string;
+};
+
+export function VoluntaryDonationFields({
+  quote,
+  voluntaryDonationCents,
+  onChange,
+  disabled = false,
+  idPrefix = "donation",
+}: Props) {
+  const wantsDonation = voluntaryDonationCents > 0;
+  const [draftDonationCents, setDraftDonationCents] = useState(voluntaryDonationCents);
+
+  useEffect(() => {
+    setDraftDonationCents(voluntaryDonationCents);
+  }, [voluntaryDonationCents]);
+
+  const previewCents = wantsDonation ? draftDonationCents || voluntaryDonationCents : 0;
+
+  const preview = (() => {
+    if (!quote || !wantsDonation || previewCents <= 0) {
+      return null;
+    }
+    const membershipNet = getMembershipNetCents(quote);
+    const discount = computeDonationDiscountCents(previewCents, membershipNet);
+    return {
+      discount,
+      total: quote.totalCents + previewCents - discount,
+    };
+  })();
+
+  const toggleDonation = (checked: boolean) => {
+    if (!checked) {
+      setDraftDonationCents(0);
+      onChange(0);
+      return;
+    }
+    setDraftDonationCents(VOLUNTARY_DONATION_MIN_CENTS);
+    onChange(VOLUNTARY_DONATION_MIN_CENTS);
+  };
+
+  const commitDonation = (cents: number) => {
+    const next = cents > 0 ? Math.max(cents, VOLUNTARY_DONATION_MIN_CENTS) : VOLUNTARY_DONATION_MIN_CENTS;
+    setDraftDonationCents(next);
+    onChange(next);
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      <Typography variant="subtitle1" component="h3" sx={{ fontWeight: 700 }}>
+        Don libre au club
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Vous pouvez soutenir le club par un don libre. Une remise de 25 % de ce don
+        sera appliquée sur le montant de l&apos;adhésion, dans la limite de 73 €.
+      </Typography>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={wantsDonation}
+            disabled={disabled}
+            onChange={(e) => toggleDonation(e.target.checked)}
+          />
+        }
+        label="Je souhaite faire un don libre au club"
+      />
+      {wantsDonation ? (
+        <EuroMonetaryInputField
+          id={`${idPrefix}-amount`}
+          label="Montant du don"
+          amountCents={voluntaryDonationCents}
+          onCommitCents={commitDonation}
+          onDraftCents={setDraftDonationCents}
+          minCentsOnBlur={VOLUNTARY_DONATION_MIN_CENTS}
+          fullWidth
+          disabled={disabled}
+          dataField="voluntaryDonationCents"
+          helperText={`Minimum ${formatCentsAsEuros(VOLUNTARY_DONATION_MIN_CENTS)}`}
+          endAdornment="€"
+        />
+      ) : null}
+      {preview ? (
+        <Box
+          sx={{
+            p: 1.5,
+            borderRadius: 1,
+            border: 1,
+            borderColor: "divider",
+            bgcolor: "action.hover",
+          }}
+        >
+          <Stack spacing={0.5}>
+            <Typography variant="body2">
+              Don : <strong>{formatCentsAsEuros(previewCents)}</strong>
+            </Typography>
+            <Typography variant="body2">
+              Remise 25 % (plaf. 73 €) :{" "}
+              <strong>−{formatCentsAsEuros(preview.discount)}</strong>
+            </Typography>
+            <Typography variant="subtitle2" fontWeight={700}>
+              Total avec don : {formatCentsAsEuros(preview.total)}
+            </Typography>
+          </Stack>
+        </Box>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/components/club-registration/membership-requests/MembershipRequestCardQuickActions.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestCardQuickActions.tsx
@@ -9,11 +9,13 @@ import {
   canMarkCertificateReceived,
   canMarkCertificateValidated,
   canQuickRequestPayment,
+  canQuickResendPaymentLink,
   resolveQuickPaymentAmountCents,
 } from "@/lib/club-registration/membership-requests/registration-card-quick-actions";
+import { SECRETARIAT_QUICK_RESEND_PAYMENT_LABEL } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import type { MembershipListReloadFn, RegistrationSummary } from "./types";
 
-type BusyAction = "certificate" | "validate" | "payment";
+type BusyAction = "certificate" | "validate" | "payment" | "resend";
 
 type Props = {
   registration: RegistrationSummary;
@@ -48,8 +50,9 @@ export function MembershipRequestCardQuickActions({
   const showReceivedAction = canMarkCertificateReceived(registration);
   const showValidatedAction = canMarkCertificateValidated(registration);
   const showPaymentAction = canQuickRequestPayment(registration);
+  const showResendPaymentAction = canQuickResendPaymentLink(registration);
 
-  if (!showReceivedAction && !showValidatedAction && !showPaymentAction) {
+  if (!showReceivedAction && !showValidatedAction && !showPaymentAction && !showResendPaymentAction) {
     return null;
   }
 
@@ -72,13 +75,13 @@ export function MembershipRequestCardQuickActions({
     }
   };
 
-  const requestPayment = async () => {
+  const requestPayment = async (busy: BusyAction) => {
     const amountCents = resolveQuickPaymentAmountCents(registration);
     if (!amountCents || amountCents <= 0) {
       return;
     }
 
-    setBusyAction("payment");
+    setBusyAction(busy);
     setError(null);
     try {
       const res = await fetch(
@@ -153,9 +156,27 @@ export function MembershipRequestCardQuickActions({
               )
             }
             disabled={busyAction !== null}
-            onClick={() => void requestPayment()}
+            onClick={() => void requestPayment("payment")}
           >
             Demander paiement
+          </Button>
+        ) : null}
+        {showResendPaymentAction ? (
+          <Button
+            size="small"
+            variant="outlined"
+            color="secondary"
+            startIcon={
+              busyAction === "resend" ? (
+                <CircularProgress size={14} color="inherit" />
+              ) : (
+                <MarkEmailReadIcon />
+              )
+            }
+            disabled={busyAction !== null}
+            onClick={() => void requestPayment("resend")}
+          >
+            {SECRETARIAT_QUICK_RESEND_PAYMENT_LABEL}
           </Button>
         ) : null}
       </Stack>

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
@@ -9,7 +9,6 @@ import {
   MenuItem,
   Stack,
   TextField,
-  Typography,
 } from "@mui/material";
 import { Refresh as RefreshIcon } from "@mui/icons-material";
 import { isMedicalCertificateRequired, type MedicalCertificateStatus } from "@/lib/club-registration/medical-certificate";
@@ -27,12 +26,12 @@ import { DetailSectionTitle } from "./DetailSectionTitle";
 import {
   BOOLEAN_CONSENT_OPTIONS,
   FAMILY_ORDER_OPTIONS,
-  formatRegistrationDate,
   MEDICAL_CERTIFICATE_STATUS_OPTIONS,
   MEDICAL_OPTIONS,
 } from "./membership-request-detail-shared";
-import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
+import { MembershipRequestDonationSection } from "./MembershipRequestDonationSection";
 import { DeleteRegistrationSection } from "./DeleteRegistrationSection";
+import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import type { MembershipRequestDetailState } from "./useMembershipRequestDetail";
 import type { EditableRegistration, MembershipListReloadFn } from "./types";
 
@@ -260,10 +259,21 @@ export function MembershipRequestDetailFormSecondary({
 
       <DetailSectionTitle>Tarification</DetailSectionTitle>
       <Stack spacing={2}>
+        <MembershipRequestDonationSection
+          liveQuote={liveQuote}
+          voluntaryDonationCents={form.voluntaryDonationCents ?? 0}
+          pricingQuoteComputedAt={selected.pricingQuoteComputedAt}
+          onDonationChange={(voluntaryDonationCents) =>
+            updateField("voluntaryDonationCents", voluntaryDonationCents)
+          }
+        />
+
         <PricingBreakdown
           draft={{
             birthDate: form.birthDate,
             mainSectionId: form.mainSectionId,
+            slotIds: form.slotIds,
+            additionalSectionIds: form.additionalSectionIds,
             wantsCompetitorExtras: form.wantsCompetitorExtras,
             wantsOptionalJersey: form.wantsOptionalJersey,
             competitionIds: form.competitionIds,
@@ -273,18 +283,10 @@ export function MembershipRequestDetailFormSecondary({
             firstFemaleRegistrationSqy: form.firstFemaleRegistrationSqy,
             reductionTypes: form.reductionTypes,
             paymentAids: form.paymentAids,
+            voluntaryDonationCents: form.voluntaryDonationCents ?? 0,
           }}
           variant="full"
         />
-
-        {liveQuote && liveQuote.totalCents > 0 ? (
-          <Typography variant="body2" color="text.secondary">
-            Total calculé : <strong>{formatCentsAsEuros(liveQuote.totalCents)}</strong>
-            {selected.pricingQuoteComputedAt
-              ? ` — dernier devis serveur : ${formatRegistrationDate(selected.pricingQuoteComputedAt)}`
-              : null}
-          </Typography>
-        ) : null}
 
         {amountDiffersFromQuote ? (
           <Alert severity="warning">
@@ -355,6 +357,9 @@ export function MembershipRequestDetailFormSecondary({
         reviewNotes={form.reviewNotes}
         onAmountEurosChange={(value) => updateField("amountEuros", value)}
         onReviewNotesChange={(value) => updateField("reviewNotes", value)}
+        registrationStatus={selected.status ?? null}
+        paymentRequestedAt={selected.paymentRequestedAt ?? null}
+        paymentAmountCents={selected.paymentAmountCents ?? null}
         paymentEmailSentTo={selected.paymentEmailSentTo ?? null}
         paymentMethod={selectedPayment?.paymentMethod}
         saving={saving}

--- a/src/components/club-registration/membership-requests/MembershipRequestDonationSection.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDonationSection.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Stack, Typography } from "@mui/material";
+import { formatCentsAsEuros } from "@/lib/pricing";
+import { resolveDonationPricing } from "@/lib/pricing/donation-discount";
+import type { PriceQuote } from "@/lib/pricing/types";
+import { VoluntaryDonationFields } from "../VoluntaryDonationFields";
+import { formatRegistrationDate } from "./membership-request-detail-shared";
+
+type Props = {
+  liveQuote: PriceQuote | null;
+  voluntaryDonationCents: number;
+  pricingQuoteComputedAt?: string | null | undefined;
+  onDonationChange: (voluntaryDonationCents: number) => void;
+};
+
+export function MembershipRequestDonationSection({
+  liveQuote,
+  voluntaryDonationCents,
+  pricingQuoteComputedAt,
+  onDonationChange,
+}: Props) {
+  return (
+    <Stack spacing={2}>
+      <VoluntaryDonationFields
+        quote={liveQuote}
+        voluntaryDonationCents={voluntaryDonationCents}
+        onChange={onDonationChange}
+      />
+      {liveQuote && liveQuote.totalCents > 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Total catalogue : <strong>{formatCentsAsEuros(liveQuote.totalCents)}</strong>
+          {voluntaryDonationCents > 0 ? (
+            <>
+              {" "}
+              — avec don :{" "}
+              <strong>
+                {formatCentsAsEuros(
+                  resolveDonationPricing(liveQuote, voluntaryDonationCents).invoiceTotalCents
+                )}
+              </strong>
+            </>
+          ) : null}
+          {pricingQuoteComputedAt
+            ? ` — dernier devis serveur : ${formatRegistrationDate(pricingQuoteComputedAt)}`
+            : null}
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/components/club-registration/membership-requests/membership-request-detail-shared.ts
+++ b/src/components/club-registration/membership-requests/membership-request-detail-shared.ts
@@ -98,6 +98,8 @@ export function formToPricingInput(form: EditableRegistration) {
   const input: Parameters<typeof buildPricingContext>[0] = {
     birthDate: form.birthDate,
     mainSectionId: form.mainSectionId,
+    slotIds: form.slotIds,
+    additionalSectionIds: form.additionalSectionIds,
     wantsCompetitorExtras: form.wantsCompetitorExtras,
     wantsOptionalJersey: form.wantsCompetitorExtras ? false : form.wantsOptionalJersey,
     competitionIds: form.competitionIds,

--- a/src/components/club-registration/membership-requests/to-editable-registration.ts
+++ b/src/components/club-registration/membership-requests/to-editable-registration.ts
@@ -91,5 +91,9 @@ export function toEditableRegistration(
         ? String(registration.paymentAmountCents / 100)
         : "",
     paymentAids: resolveRegistrationPaymentAids(registration, payment),
+    voluntaryDonationCents:
+      typeof registration.voluntaryDonationCents === "number"
+        ? registration.voluntaryDonationCents
+        : 0,
   };
 }

--- a/src/components/club-registration/membership-requests/types.ts
+++ b/src/components/club-registration/membership-requests/types.ts
@@ -31,6 +31,8 @@ export type RegistrationSummary = {
   medicalCertificateStatus?: MedicalCertificateStatus;
   status?: string;
   paymentAmountCents?: number;
+  voluntaryDonationCents?: number;
+  donationDiscountCents?: number;
   pricingQuote?: PriceQuote;
   pricingQuoteStatus?: string;
   pricingQuoteComputedAt?: string | null;
@@ -38,6 +40,9 @@ export type RegistrationSummary = {
   handisportPracticeLevel?: "leisure" | "competition";
   paymentStatus?: string;
   payment?: RegistrationPayment;
+  paymentRequestedAt?: string | null;
+  paidAt?: string | null;
+  paymentEmailSentTo?: string;
   submittedAt?: string | null;
   updatedAt?: string | null;
 };
@@ -85,6 +90,8 @@ export type RegistrationDetail = RegistrationSummary & {
   paymentEmailSentTo?: string;
   stripeCheckoutUrl?: string;
   paymentAids?: PaymentAid[];
+  voluntaryDonationCents?: number;
+  donationDiscountCents?: number;
 };
 
 export type EditableRegistration = {
@@ -129,4 +136,5 @@ export type EditableRegistration = {
   reviewNotes: string;
   amountEuros: string;
   paymentAids: PaymentAid[];
+  voluntaryDonationCents: number;
 };

--- a/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
+++ b/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
@@ -9,7 +9,7 @@ import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/no
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
 import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
 import type { Representative } from "@/lib/club-registration/schema";
-import { buildPricingContext, calculateQuote } from "@/lib/pricing";
+import { buildPricingContext, calculateQuote, resolveDonationPricing } from "@/lib/pricing";
 import type { RegistrationFfttPatch } from "./RegistrationSupplementarySections";
 import { toEditableRegistration } from "./to-editable-registration";
 import {
@@ -108,8 +108,12 @@ export function useMembershipRequestDetail(
 
   const expectedPayableAfterAidsCents = useMemo(() => {
     if (!form || !liveQuote || liveQuote.totalCents <= 0) return null;
+    const invoiceTotal = resolveDonationPricing(
+      liveQuote,
+      form.voluntaryDonationCents ?? 0
+    ).invoiceTotalCents;
     return calculatePaymentSummary({
-      totalAmountCents: liveQuote.totalCents,
+      totalAmountCents: invoiceTotal,
       aids: normalizePaymentAidList(form.paymentAids ?? []),
       receivedPayments: [],
     }).amountToPayCents;
@@ -258,6 +262,7 @@ export function useMembershipRequestDetail(
             competitionIds: form.competitionIds,
             applicantNotes: form.applicantNotes.trim() || undefined,
             reviewNotes: form.reviewNotes,
+            voluntaryDonationCents: form.voluntaryDonationCents,
             ...(amountCents !== null ? { paymentAmountCents: amountCents } : {}),
           }),
         }
@@ -284,8 +289,12 @@ export function useMembershipRequestDetail(
       setError("Impossible d'appliquer un montant : devis incomplet ou nul.");
       return;
     }
+    const invoiceTotal = resolveDonationPricing(
+      liveQuote,
+      form.voluntaryDonationCents ?? 0
+    ).invoiceTotalCents;
     const payable = calculatePaymentSummary({
-      totalAmountCents: liveQuote.totalCents,
+      totalAmountCents: invoiceTotal,
       aids: normalizePaymentAidList(form.paymentAids ?? []),
       receivedPayments: [],
     }).amountToPayCents;
@@ -337,6 +346,10 @@ export function useMembershipRequestDetail(
       return;
     }
 
+    const isResend = selected?.status === "payment_requested";
+    const paymentEmail =
+      typeof selected?.paymentEmailSentTo === "string" ? selected.paymentEmailSentTo : null;
+
     setRequestingPayment(true);
     setError(null);
     setSuccess(null);
@@ -360,11 +373,19 @@ export function useMembershipRequestDetail(
         setSuccess(
           typeof json.message === "string"
             ? json.message
-            : "Dossier validé. Un e-mail d'instructions de règlement a été envoyé au contact du dossier."
+            : isResend
+              ? `Instructions de règlement renvoyées${paymentEmail ? ` à ${paymentEmail}` : ""}.`
+              : "Dossier validé. Un e-mail d'instructions de règlement a été envoyé au contact du dossier."
+        );
+      } else if (isResend) {
+        setSuccess(
+          paymentEmail
+            ? `Rappel envoyé à ${paymentEmail} — l'adhérent peut régler depuis Mes dossiers.`
+            : "Rappel envoyé au contact du dossier — paiement via Mes dossiers."
         );
       } else {
         setSuccess(
-          "Un e-mail avec un lien de paiement sécurisé a été envoyé au contact du dossier."
+          "Dossier validé. Un e-mail avec le lien vers Mes dossiers a été envoyé au contact du dossier."
         );
       }
       await reloadQueueAndRefreshDetail("always");

--- a/src/components/club-registration/mes-inscriptions-shared.ts
+++ b/src/components/club-registration/mes-inscriptions-shared.ts
@@ -1,0 +1,93 @@
+import type { MedicalCertificateStatus } from "@/lib/club-registration/medical-certificate";
+import { getEnabledSections } from "@/lib/club-registration-config/helpers";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+
+export type MesInscriptionSummary = {
+  id: string;
+  adherentRole?: "self" | "minor_dependent" | "other_adult";
+  firstName?: string;
+  lastName?: string;
+  mainSectionId?: string;
+  medicalCertificateStatus?: MedicalCertificateStatus;
+  status?: string;
+  paymentAmountCents?: number;
+  paymentStatus?: string;
+  payment?: Record<string, unknown>;
+  invoiceAvailable?: boolean;
+  submittedAt?: string | null;
+};
+
+export type MesInscriptionsApiResponse =
+  | { registrations: MesInscriptionSummary[] }
+  | { error: string };
+
+export const MES_INSCRIPTION_ROLE_LABEL: Record<
+  NonNullable<MesInscriptionSummary["adherentRole"]>,
+  string
+> = {
+  self: "Inscription pour moi",
+  minor_dependent: "Mineur dont je suis le représentant légal",
+  other_adult: "Autre adulte",
+};
+
+export const MES_INSCRIPTION_STATUS_COLOR: Record<
+  string,
+  "default" | "warning" | "success" | "error"
+> = {
+  submitted: "warning",
+  in_review: "warning",
+  payment_requested: "warning",
+  paid: "success",
+  approved: "success",
+  rejected: "error",
+};
+
+export const MES_INSCRIPTION_STATUS_LABEL: Record<string, string> = {
+  submitted: "En cours d’examen",
+  in_review: "En cours de relecture",
+  payment_requested: "Paiement demandé",
+  paid: "Paiement reçu",
+  approved: "Approuvé",
+  rejected: "Refusé",
+};
+
+export const MES_INSCRIPTION_MEDICAL_COLOR: Record<
+  MedicalCertificateStatus,
+  "default" | "warning" | "success"
+> = {
+  not_required: "default",
+  required_not_received: "warning",
+  received: "warning",
+  validated: "success",
+};
+
+export function formatMesInscriptionAmount(cents: number | undefined): string | null {
+  if (typeof cents !== "number") return null;
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+  }).format(cents / 100);
+}
+
+export function formatMesInscriptionDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+export function findMesInscriptionSectionLabel(id: string | undefined): string {
+  if (!id) return "";
+  const found = getEnabledSections(getDefaultRegistrationConfig()).find((s) => s.id === id);
+  return found?.label ?? id;
+}
+
+export function isMesInscriptionPaid(r: MesInscriptionSummary): boolean {
+  return (
+    r.status === "paid" ||
+    r.paymentStatus === "paid" ||
+    r.paymentStatus === "complete"
+  );
+}

--- a/src/components/club-registration/pricing-breakdown-donation.tsx
+++ b/src/components/club-registration/pricing-breakdown-donation.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { TableCell, TableRow } from "@mui/material";
+import { formatCentsAsEuros } from "@/lib/pricing";
+import {
+  resolveDonationPricing,
+  type DonationPricingBreakdown,
+} from "@/lib/pricing/donation-discount";
+import type { PriceQuote } from "@/lib/pricing/types";
+import type { PricingBreakdownDraft } from "./PricingBreakdown";
+
+export function useDonationPricing(
+  quote: PriceQuote | null,
+  draft: PricingBreakdownDraft
+): DonationPricingBreakdown | null {
+  return useMemo(() => {
+    if (!quote) {
+      return null;
+    }
+    const donationCents = draft.voluntaryDonationCents ?? 0;
+    if (donationCents <= 0) {
+      return null;
+    }
+    return resolveDonationPricing(quote, donationCents);
+  }, [quote, draft.voluntaryDonationCents]);
+}
+
+export function useEstimatedInvoiceTotalCents(
+  quote: PriceQuote | null,
+  draft: PricingBreakdownDraft
+): number | null {
+  return useMemo(() => {
+    if (!quote) {
+      return null;
+    }
+    const donationCents = draft.voluntaryDonationCents ?? 0;
+    if (donationCents <= 0) {
+      return quote.totalCents;
+    }
+    return resolveDonationPricing(quote, donationCents).invoiceTotalCents;
+  }, [quote, draft.voluntaryDonationCents]);
+}
+
+type DonationRowsProps = {
+  donationPricing: DonationPricingBreakdown;
+  cellSx: Record<string, unknown>;
+};
+
+export function PricingBreakdownDonationRows({
+  donationPricing,
+  cellSx,
+}: DonationRowsProps) {
+  return (
+    <>
+      <TableRow>
+        <TableCell sx={{ ...cellSx, pl: 0, pt: 0.5 }}>Don libre au club</TableCell>
+        <TableCell align="right" sx={{ ...cellSx, pr: 0, pt: 0.5, whiteSpace: "nowrap" }}>
+          {formatCentsAsEuros(donationPricing.voluntaryDonationCents)}
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell sx={{ ...cellSx, pl: 0 }}>Remise don 25 % (plaf. 73 €)</TableCell>
+        <TableCell
+          align="right"
+          sx={{
+            ...cellSx,
+            pr: 0,
+            whiteSpace: "nowrap",
+            fontWeight: 600,
+            color: "success.dark",
+          }}
+        >
+          {formatCentsAsEuros(-donationPricing.donationDiscountCents)}
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}

--- a/src/components/club-registration/registration-defaults.ts
+++ b/src/components/club-registration/registration-defaults.ts
@@ -134,5 +134,6 @@ export function createEmptyDraft(): RegistrationDraft {
     remainingPaymentMethod: "" as RemainingPaymentMethodId | "",
     paymentNote: "",
     specialPaymentNote: "",
+    voluntaryDonationCents: 0,
   };
 }

--- a/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
+++ b/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
@@ -18,6 +18,11 @@ import {
 import {
   BNPL_SECRETARIAT_ALERT,
   BNPL_SECRETARIAT_PAYMENT_TOOLTIP,
+  CHECKOUT_LINK_VALIDITY_NOTICE,
+  SECRETARIAT_INITIAL_PAYMENT_BUTTON,
+  SECRETARIAT_RESEND_PAYMENT_BUTTON,
+  SECRETARIAT_RESEND_PAYMENT_TOOLTIP,
+  SECRETARIAT_SELF_SERVICE_HINT,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import {
   PAYMENT_METHOD_LABELS,
@@ -29,6 +34,9 @@ type Props = {
   reviewNotes: string;
   onAmountEurosChange: (value: string) => void;
   onReviewNotesChange: (value: string) => void;
+  registrationStatus?: string | null;
+  paymentRequestedAt?: string | null;
+  paymentAmountCents?: number | null;
   paymentEmailSentTo?: string | null | undefined;
   paymentMethod?: PaymentMethodId | null | undefined;
   saving: boolean;
@@ -40,11 +48,35 @@ type Props = {
 
 const tooltipEnterProps = { enterDelay: 400, enterNextDelay: 400 } as const;
 
+function formatPaymentRequestedAt(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return null;
+  }
+}
+
+function formatAmountCents(cents: number | null | undefined): string | null {
+  if (typeof cents !== "number") return null;
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+  }).format(cents / 100);
+}
+
 export function SecretariatPaymentNotesSection({
   amountEuros,
   reviewNotes,
   onAmountEurosChange,
   onReviewNotesChange,
+  registrationStatus,
+  paymentRequestedAt,
+  paymentAmountCents,
   paymentEmailSentTo,
   paymentMethod,
   saving,
@@ -54,6 +86,22 @@ export function SecretariatPaymentNotesSection({
   onRequestPayment,
 }: Props) {
   const canSendStripeEmail = paymentMethod === "card";
+  const isPaid = registrationStatus === "paid";
+  const isPaymentResend = registrationStatus === "payment_requested" && !isPaid;
+  const paymentButtonLabel = isPaymentResend
+    ? canSendStripeEmail
+      ? SECRETARIAT_RESEND_PAYMENT_BUTTON
+      : "Renvoyer les instructions de règlement"
+    : SECRETARIAT_INITIAL_PAYMENT_BUTTON;
+  const paymentTooltip = isPaymentResend
+    ? canSendStripeEmail
+      ? SECRETARIAT_RESEND_PAYMENT_TOOLTIP
+      : "Renvoie l'e-mail d'instructions de règlement au contact du dossier."
+    : canSendStripeEmail
+      ? BNPL_SECRETARIAT_PAYMENT_TOOLTIP
+      : "Enregistre le dossier puis bascule en suivi adapté : pas de lien de paiement automatique pour ce mode de règlement.";
+  const requestedAtLabel = formatPaymentRequestedAt(paymentRequestedAt);
+  const formattedAmount = formatAmountCents(paymentAmountCents);
 
   return (
     <>
@@ -64,7 +112,8 @@ export function SecretariatPaymentNotesSection({
       {paymentMethod === "card" ? (
         <Alert severity="info" variant="outlined">
           Mode <strong>carte bancaire</strong> : un lien Stripe Checkout sera envoyé par
-          e-mail. {BNPL_SECRETARIAT_ALERT}
+          e-mail. {BNPL_SECRETARIAT_ALERT} {CHECKOUT_LINK_VALIDITY_NOTICE}{" "}
+          {SECRETARIAT_SELF_SERVICE_HINT}
         </Alert>
       ) : null}
 
@@ -105,7 +154,19 @@ export function SecretariatPaymentNotesSection({
         </Grid>
       </Grid>
 
-      {paymentEmailSentTo ? (
+      {isPaymentResend && canSendStripeEmail ? (
+        <Alert severity="warning" variant="outlined">
+          Paiement en attente
+          {requestedAtLabel ? ` depuis le ${requestedAtLabel}` : ""}
+          {formattedAmount ? ` — montant : ${formattedAmount}` : ""}.
+          {paymentEmailSentTo ? (
+            <>
+              {" "}
+              Dernier e-mail envoyé à <strong>{paymentEmailSentTo}</strong>.
+            </>
+          ) : null}
+        </Alert>
+      ) : paymentEmailSentTo ? (
         <Alert severity="info">
           Dernière demande de paiement par e-mail envoyée à {paymentEmailSentTo}.
         </Alert>
@@ -128,27 +189,25 @@ export function SecretariatPaymentNotesSection({
             </Button>
           </span>
         </Tooltip>
-        <Tooltip
-          title={
-            canSendStripeEmail
-              ? BNPL_SECRETARIAT_PAYMENT_TOOLTIP
-              : "Enregistre le dossier puis bascule en suivi adapté : pas de lien de paiement automatique pour ce mode de règlement."
-          }
-          slotProps={{ popper: { sx: { maxWidth: 340 } } }}
-          {...tooltipEnterProps}
-        >
-          <span>
-            <Button
-              variant="contained"
-              color="secondary"
-              startIcon={<MarkEmailReadIcon />}
-              onClick={() => void onRequestPayment()}
-              disabled={saving || requestingPayment || persistingQuote}
-            >
-              {requestingPayment ? "Envoi..." : "Valider et demander le paiement"}
-            </Button>
-          </span>
-        </Tooltip>
+        {isPaid ? null : (
+          <Tooltip
+            title={paymentTooltip}
+            slotProps={{ popper: { sx: { maxWidth: 340 } } }}
+            {...tooltipEnterProps}
+          >
+            <span>
+              <Button
+                variant="contained"
+                color="secondary"
+                startIcon={<MarkEmailReadIcon />}
+                onClick={() => void onRequestPayment()}
+                disabled={saving || requestingPayment || persistingQuote}
+              >
+                {requestingPayment ? "Envoi..." : paymentButtonLabel}
+              </Button>
+            </span>
+          </Tooltip>
+        )}
       </Stack>
     </>
   );

--- a/src/components/club-registration/spreadsheet/SpreadsheetDataCell.tsx
+++ b/src/components/club-registration/spreadsheet/SpreadsheetDataCell.tsx
@@ -3,10 +3,8 @@
 import { Chip } from "@mui/material";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationClientRecord } from "@/lib/club-registration/map-registration-doc-to-client";
-import {
-  PAYMENT_STATUS_LABELS,
-  type PaymentStatusId,
-} from "@/lib/club-registration/payment-constants";
+import { PAYMENT_STATUS_LABELS } from "@/lib/club-registration/payment-constants";
+import { resolveRegistrationPaymentStatus } from "@/lib/club-registration/resolve-registration-payment-status";
 import {
   REGISTRATION_STATUS_COLORS,
   REGISTRATION_STATUS_LABELS,
@@ -57,11 +55,11 @@ export function SpreadsheetDataCell({ columnId, row, config, context }: Props) {
   }
 
   if (columnId === "paymentStatus") {
-    const status = typeof row.paymentStatus === "string" ? row.paymentStatus : "";
-    if (status in PAYMENT_STATUS_LABELS) {
+    const status = resolveRegistrationPaymentStatus(row);
+    if (status) {
       return (
         <StatusChip
-          label={PAYMENT_STATUS_LABELS[status as PaymentStatusId]}
+          label={PAYMENT_STATUS_LABELS[status]}
           color={status === "paid" ? "success" : status === "partially_paid" ? "warning" : "info"}
         />
       );

--- a/src/lib/club-registration-config/default-config.ts
+++ b/src/lib/club-registration-config/default-config.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_JERSEY_SIZE_HELPER,
   DEFAULT_OPTIONAL_JERSEY_OPT_IN_LABEL,
 } from "./repair-jersey";
+import { buildDefaultPricingDevices } from "./pricing-devices";
 
 function sectionPricingProfile(id: string): RegistrationSection["pricingProfile"] {
   if (id === "handisport") return "handisport";
@@ -177,7 +178,34 @@ function buildRateTable(): RateTableEntry[] {
       segmentLabel: "Sport adapté — Compétiteur (21 ans et plus)",
     },
   ];
-  return [...classicAndSpecialty, ...buildEcoleRateEntries(classicAndSpecialty)];
+  return [...classicAndSpecialty, ...buildEcoleRateEntries(classicAndSpecialty), ...buildChampYonRateEntries()];
+}
+
+function buildChampYonRateEntries(): RateTableEntry[] {
+  return [
+    {
+      id: "champ_yon_leisure_under15",
+      match: {
+        pricingProfile: "champ_yon",
+        ageBandId: "under_15",
+        wantsCompetitorExtras: false,
+      },
+      membershipCents: 10_500,
+      licenseCents: 0,
+      segmentLabel: "Loisirs — Moins de 15 ans",
+    },
+    {
+      id: "champ_yon_leisure_adult",
+      match: {
+        pricingProfile: "champ_yon",
+        ageBandId: "adult_15_plus",
+        wantsCompetitorExtras: false,
+      },
+      membershipCents: 11_500,
+      licenseCents: 0,
+      segmentLabel: "Loisirs — 15 ans et plus",
+    },
+  ];
 }
 
 function buildCompetitionBundles(): CompetitionBundle[] {
@@ -276,6 +304,14 @@ export function buildDefaultRegistrationConfig(): RegistrationConfigV1 {
           { id: "adult_15_plus", minAge: 15, label: "15 ans et plus" },
         ],
       },
+      champ_yon: {
+        id: "champ_yon",
+        label: "CHAMP'YON",
+        bands: [
+          { id: "under_15", minAge: 0, maxAge: 14, label: "Moins de 15 ans" },
+          { id: "adult_15_plus", minAge: 15, label: "15 ans et plus" },
+        ],
+      },
     },
     rateTable: buildRateTable(),
     discountRules: [
@@ -318,6 +354,8 @@ export function buildDefaultRegistrationConfig(): RegistrationConfigV1 {
         "Maillot compétiteur inclus dans l'adhésion (15 € — renouvellement tous les deux ans)",
       invoiceHeaderTemplate: "Adhésion {{clubName}} — dossier {{registrationId}}",
       discountCustomFieldName: "Remises sur adhésion",
+      donationLabel: "Don libre au club",
+      donationDiscountCouponName: "Remise don — 25 % (plaf. 73 €)",
     },
     jersey: { ...DEFAULT_JERSEY_CATALOG },
     uiCopy: {
@@ -336,6 +374,7 @@ export function buildDefaultRegistrationConfig(): RegistrationConfigV1 {
       jerseySizeHelper: DEFAULT_JERSEY_SIZE_HELPER,
       optionalJerseyOptInLabel: DEFAULT_OPTIONAL_JERSEY_OPT_IN_LABEL,
     },
+    pricingDevices: buildDefaultPricingDevices(),
   };
 }
 

--- a/src/lib/club-registration-config/index.ts
+++ b/src/lib/club-registration-config/index.ts
@@ -3,5 +3,6 @@ export * from "./schema";
 export * from "./default-config";
 export * from "./helpers";
 export * from "./pricing-engine";
+export * from "./pricing-devices";
 export * from "./validate-config";
 export * from "./export-import";

--- a/src/lib/club-registration-config/normalize-sort-orders.ts
+++ b/src/lib/club-registration-config/normalize-sort-orders.ts
@@ -2,6 +2,8 @@ import type { RegistrationConfigV1, RegistrationSiteSlot } from "./types";
 import { repairAidRulesForm } from "./aid-rules";
 import { repairPricingProfiles } from "./pricing-profiles";
 import { repairSiteLinkedSectionIds } from "./site-section-links";
+import { repairPricingDevices } from "./pricing-devices";
+import { repairChampYonCatalog } from "./repair-champ-yon-catalog";
 import { sortBySortOrder } from "./sort-order";
 
 /** Normalise sortOrder pour les configs importées ou legacy (créneaux sans ordre). */
@@ -34,7 +36,11 @@ export function normalizeRegistrationConfigSortOrders(
     }),
   };
 
-  return repairPricingProfiles(repairAidRulesForm(repairSiteLinkedSectionIds(withSortOrders)));
+  return repairPricingProfiles(
+    repairPricingDevices(
+      repairChampYonCatalog(repairAidRulesForm(repairSiteLinkedSectionIds(withSortOrders)))
+    )
+  );
 }
 
 export function getSortedSiteSlots(slots: readonly RegistrationSiteSlot[]): RegistrationSiteSlot[] {

--- a/src/lib/club-registration-config/pricing-devices.test.ts
+++ b/src/lib/club-registration-config/pricing-devices.test.ts
@@ -1,0 +1,116 @@
+import { buildDefaultRegistrationConfig } from "./default-config";
+import {
+  CHAMP_YON_DEVICE_ID,
+  evaluatePricingDeviceConditions,
+  resolveActivePricingDevice,
+} from "./pricing-devices";
+import type { PricingContext } from "@/lib/pricing/types";
+
+const config = buildDefaultRegistrationConfig();
+const PRICING_DATE = "2025-09-01";
+
+function ctx(
+  patch: Partial<PricingContext> & Pick<PricingContext, "birthDate">
+): PricingContext {
+  return {
+    mainSectionId: "trappes",
+    slotIds: ["trappes-mer-1730-jeunes-loisir-compet"],
+    additionalSectionIds: [],
+    wantsCompetitorExtras: false,
+    wantsOptionalJersey: false,
+    competitionIds: [],
+    familyRegistrationOrder: "none",
+    sex: "male",
+    pricingDate: PRICING_DATE,
+    ...patch,
+  };
+}
+
+describe("resolveActivePricingDevice — CHAMP'YON", () => {
+  it("s'applique pour Trappes, 1 créneau, loisir sans compétition", () => {
+    const device = resolveActivePricingDevice(ctx({ birthDate: "2014-06-01" }), config);
+    expect(device?.id).toBe(CHAMP_YON_DEVICE_ID);
+  });
+
+  it("s'applique pour La Verrière dans les mêmes conditions", () => {
+    const device = resolveActivePricingDevice(
+      ctx({
+        birthDate: "2014-06-01",
+        mainSectionId: "la-verriere",
+        slotIds: ["lv-jeu-1800-jeunes-loisirs"],
+      }),
+      config
+    );
+    expect(device?.id).toBe(CHAMP_YON_DEVICE_ID);
+  });
+
+  it("ne s'applique pas avec 2 créneaux", () => {
+    const device = resolveActivePricingDevice(
+      ctx({
+        birthDate: "2014-06-01",
+        slotIds: ["trappes-mer-1730-jeunes-loisir-compet", "lv-jeu-1800-jeunes-loisirs"],
+      }),
+      config
+    );
+    expect(device).toBeNull();
+  });
+
+  it("ne s'applique pas avec une section complémentaire", () => {
+    const device = resolveActivePricingDevice(
+      ctx({
+        birthDate: "2014-06-01",
+        additionalSectionIds: ["voisins"],
+      }),
+      config
+    );
+    expect(device).toBeNull();
+  });
+
+  it("ne s'applique pas en mode compétiteur", () => {
+    const device = resolveActivePricingDevice(
+      ctx({ birthDate: "2014-06-01", wantsCompetitorExtras: true }),
+      config
+    );
+    expect(device).toBeNull();
+  });
+
+  it("ne s'applique pas avec une compétition cochée", () => {
+    const device = resolveActivePricingDevice(
+      ctx({ birthDate: "2014-06-01", competitionIds: ["championnat_paris"] }),
+      config
+    );
+    expect(device).toBeNull();
+  });
+
+  it("ne s'applique pas pour une autre section", () => {
+    const device = resolveActivePricingDevice(
+      ctx({ birthDate: "2014-06-01", mainSectionId: "voisins", slotIds: ["voisins-lun-1730-jeunes-loisirs"] }),
+      config
+    );
+    expect(device).toBeNull();
+  });
+
+  it("ne s'applique pas sans créneau", () => {
+    const device = resolveActivePricingDevice(
+      ctx({ birthDate: "2014-06-01", slotIds: [] }),
+      config
+    );
+    expect(device).toBeNull();
+  });
+});
+
+describe("evaluatePricingDeviceConditions", () => {
+  it("ignore un dispositif désactivé", () => {
+    const device = config.pricingDevices.find((d) => d.id === CHAMP_YON_DEVICE_ID);
+    expect(device).toBeDefined();
+    if (!device) return;
+
+    expect(
+      evaluatePricingDeviceConditions(
+        { ...device, enabled: false },
+        ctx({ birthDate: "2014-06-01" }),
+        config
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/club-registration-config/pricing-devices.ts
+++ b/src/lib/club-registration-config/pricing-devices.ts
@@ -1,0 +1,144 @@
+import { getAllSlotIds } from "./helpers";
+import { sortBySortOrder } from "./sort-order";
+import type { PricingDevice, RegistrationConfigV1 } from "./types";
+import type { PricingContext } from "@/lib/pricing/types";
+
+export const CHAMP_YON_DEVICE_ID = "champ-yon" as const;
+export const CHAMP_YON_PRICING_PROFILE_ID = "champ_yon" as const;
+
+export function buildDefaultChampYonDevice(): PricingDevice {
+  return {
+    id: CHAMP_YON_DEVICE_ID,
+    label: "DISPOSITIF CLUB CHAMP'YON",
+    enabled: true,
+    sortOrder: 0,
+    priority: 10,
+    builtIn: true,
+    conditions: {
+      sectionIds: ["trappes", "la-verriere"],
+      exactSlotCount: 1,
+      requiresNoAdditionalSections: true,
+      requiresNoCompetitorExtras: true,
+      requiresNoCompetitionSelection: true,
+    },
+    pricingProfileId: CHAMP_YON_PRICING_PROFILE_ID,
+    ageBandProfileId: CHAMP_YON_PRICING_PROFILE_ID,
+    stackableWithDiscounts: false,
+    includesFfttLicense: false,
+    uiCopy: {
+      recapHint:
+        "Tarif CHAMP'YON appliqué (1 section, 1 créneau, pratique loisir sans compétition).",
+      adminBadge: "CHAMP'YON",
+      segmentLabelPrefix: "CHAMP'YON —",
+    },
+  };
+}
+
+export function buildDefaultPricingDevices(): PricingDevice[] {
+  return [buildDefaultChampYonDevice()];
+}
+
+export function repairPricingDevices(config: RegistrationConfigV1): RegistrationConfigV1 {
+  const existing = config.pricingDevices ?? [];
+  const existingIds = new Set(existing.map((device) => device.id));
+  const merged = [...existing];
+
+  for (const builtIn of buildDefaultPricingDevices()) {
+    if (builtIn.builtIn && !existingIds.has(builtIn.id)) {
+      merged.push(builtIn);
+    }
+  }
+
+  return {
+    ...config,
+    pricingDevices: sortBySortOrder(merged).map((device, index) => {
+      const builtInDefault = buildDefaultPricingDevices().find(
+        (candidate) => candidate.id === device.id && candidate.builtIn
+      );
+      return {
+        ...device,
+        sortOrder: index,
+        includesFfttLicense:
+          device.includesFfttLicense ?? builtInDefault?.includesFfttLicense ?? true,
+      };
+    }),
+  };
+}
+
+export function evaluatePricingDeviceConditions(
+  device: PricingDevice,
+  ctx: PricingContext,
+  config: RegistrationConfigV1
+): boolean {
+  if (!device.enabled) {
+    return false;
+  }
+
+  const { conditions } = device;
+
+  if (!conditions.sectionIds.includes(ctx.mainSectionId)) {
+    return false;
+  }
+
+  if (conditions.requiresNoAdditionalSections) {
+    if ((ctx.additionalSectionIds?.length ?? 0) > 0) {
+      return false;
+    }
+  }
+
+  const slotIds = ctx.slotIds ?? [];
+  if (slotIds.length !== conditions.exactSlotCount) {
+    return false;
+  }
+
+  if (conditions.exactSlotCount > 0) {
+    const validSlotIds = getAllSlotIds(config);
+    for (const slotId of slotIds) {
+      if (!validSlotIds.has(slotId)) {
+        return false;
+      }
+    }
+  }
+
+  if (conditions.requiresNoCompetitorExtras && ctx.wantsCompetitorExtras) {
+    return false;
+  }
+
+  if (conditions.requiresNoCompetitionSelection && ctx.competitionIds.length > 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export function resolveActivePricingDevice(
+  ctx: PricingContext,
+  config: RegistrationConfigV1
+): PricingDevice | null {
+  const devices = sortBySortOrder(config.pricingDevices ?? []);
+  const sorted = [...devices].sort((a, b) => {
+    if (b.priority !== a.priority) {
+      return b.priority - a.priority;
+    }
+    return a.sortOrder - b.sortOrder;
+  });
+
+  for (const device of sorted) {
+    if (evaluatePricingDeviceConditions(device, ctx, config)) {
+      return device;
+    }
+  }
+
+  return null;
+}
+
+export function formatSegmentLabelWithDevice(
+  segmentLabel: string,
+  device: PricingDevice | null
+): string {
+  const prefix = device?.uiCopy?.segmentLabelPrefix?.trim();
+  if (!prefix) {
+    return segmentLabel;
+  }
+  return `${prefix} ${segmentLabel}`;
+}

--- a/src/lib/club-registration-config/pricing-engine.test.ts
+++ b/src/lib/club-registration-config/pricing-engine.test.ts
@@ -10,6 +10,8 @@ function ctx(
 ): PricingContext {
   return {
     mainSectionId: "voisins",
+    slotIds: [],
+    additionalSectionIds: [],
     wantsCompetitorExtras: false,
     wantsOptionalJersey: false,
     competitionIds: [],
@@ -27,7 +29,11 @@ function expectTotals(
   const membership = quote.lines.find((l) => l.id === "membership");
   const license = quote.lines.find((l) => l.id === "fftt_license");
   expect(membership?.amountCents).toBe(expected.membership);
-  expect(license?.amountCents).toBe(expected.license);
+  if (expected.license === 0) {
+    expect(license).toBeUndefined();
+  } else {
+    expect(license?.amountCents).toBe(expected.license);
+  }
   expect(quote.totalCents).toBe(expected.total);
 }
 
@@ -118,5 +124,68 @@ describe("calculateQuoteFromConfig — aides admin_review", () => {
     );
     expect(quote.requiresAdminReview).toBe(true);
     expect(quote.warnings).toHaveLength(0);
+  });
+});
+
+describe("calculateQuoteFromConfig — dispositif CHAMP'YON", () => {
+  const champYonCtx = {
+    mainSectionId: "trappes",
+    slotIds: ["trappes-mer-1730-jeunes-loisir-compet"],
+    additionalSectionIds: [] as string[],
+  };
+
+  it("applique 105 € sans licence pour moins de 15 ans", () => {
+    const quote = calculateQuoteFromConfig(
+      ctx({ birthDate: "2014-06-01", ...champYonCtx }),
+      config
+    );
+    expect(quote.appliedPricingDeviceId).toBe("champ-yon");
+    expect(quote.segmentLabel).toContain("CHAMP'YON");
+    expect(quote.lines.some((line) => line.id === "fftt_license")).toBe(false);
+    expectTotals(quote, { membership: 10_500, license: 0, total: 10_500 });
+  });
+
+  it("applique 115 € sans licence pour 15 ans et plus", () => {
+    const quote = calculateQuoteFromConfig(
+      ctx({ birthDate: "2005-01-01", ...champYonCtx }),
+      config
+    );
+    expect(quote.lines.some((line) => line.id === "fftt_license")).toBe(false);
+    expectTotals(quote, { membership: 11_500, license: 0, total: 11_500 });
+  });
+
+  it("inclut Baby Ping dans la tranche moins de 15 ans", () => {
+    const quote = calculateQuoteFromConfig(
+      ctx({ birthDate: "2020-01-01", ...champYonCtx }),
+      config
+    );
+    expectTotals(quote, { membership: 10_500, license: 0, total: 10_500 });
+  });
+
+  it("n'applique pas les remises famille", () => {
+    const quote = calculateQuoteFromConfig(
+      ctx({
+        birthDate: "2014-06-01",
+        ...champYonCtx,
+        familyRegistrationOrder: "second",
+      }),
+      config
+    );
+    expect(quote.lines.some((line) => line.kind === "discount_family")).toBe(false);
+    expect(quote.totalCents).toBe(10_500);
+  });
+
+  it("retombe sur la grille classique avec 2 créneaux", () => {
+    const quote = calculateQuoteFromConfig(
+      ctx({
+        birthDate: "2014-06-01",
+        mainSectionId: "trappes",
+        slotIds: ["trappes-mer-1730-jeunes-loisir-compet", "lv-jeu-1800-jeunes-loisirs"],
+        additionalSectionIds: [],
+      }),
+      config
+    );
+    expect(quote.appliedPricingDeviceId).toBeUndefined();
+    expectTotals(quote, { membership: 16_000, license: 4_500, total: 20_500 });
   });
 });

--- a/src/lib/club-registration-config/pricing-engine.ts
+++ b/src/lib/club-registration-config/pricing-engine.ts
@@ -2,14 +2,24 @@ import { computeAgeAt } from "@/lib/club-registration/age";
 import type { PriceLine, PriceQuote, PricingContext } from "@/lib/pricing/types";
 import { getPricingProfileBehavior } from "./pricing-profiles";
 import { getSectionById } from "./helpers";
+import {
+  formatSegmentLabelWithDevice,
+  resolveActivePricingDevice,
+} from "./pricing-devices";
 import type {
   AgeBand,
   AgeBandProfile,
   DiscountRule,
+  PricingDevice,
   RateTableEntry,
   RegistrationConfigV1,
 } from "./types";
 import { normalizeCompetitionIdsFromConfig } from "./helpers";
+
+type RateResolutionOverrides = {
+  pricingProfile: string;
+  ageBandProfileId: string;
+};
 
 function parsePricingDate(isoDate?: string): Date {
   if (!isoDate) return new Date();
@@ -62,7 +72,8 @@ function matchesRateEntry(match: RateTableEntry["match"], ctx: RateLookupContext
 
 function resolveRatesFromConfig(
   config: RegistrationConfigV1,
-  ctx: PricingContext
+  ctx: PricingContext,
+  overrides?: RateResolutionOverrides
 ):
   | { ok: true; rates: { membershipCents: number; licenseCents: number; segmentLabel: string } }
   | { ok: false; warning: string } {
@@ -71,7 +82,9 @@ function resolveRatesFromConfig(
     return { ok: false, warning: "Section principale inconnue ou désactivée." };
   }
 
-  const profile = config.ageBandProfiles[section.ageBandProfileId];
+  const pricingProfile = overrides?.pricingProfile ?? section.pricingProfile;
+  const ageBandProfileId = overrides?.ageBandProfileId ?? section.ageBandProfileId;
+  const profile = config.ageBandProfiles[ageBandProfileId];
   if (!profile) {
     return {
       ok: false,
@@ -80,10 +93,10 @@ function resolveRatesFromConfig(
   }
 
   const lookup: RateLookupContext = {
-    pricingProfile: section.pricingProfile,
+    pricingProfile,
   };
 
-  const behavior = getPricingProfileBehavior(config, section.pricingProfile);
+  const behavior = getPricingProfileBehavior(config, pricingProfile);
 
   if (behavior === "handisport") {
     lookup.wantsCompetitorExtras = ctx.wantsCompetitorExtras;
@@ -280,6 +293,16 @@ function applyAidRules(
   return { lines, warnings, requiresAdminReview };
 }
 
+function buildRateResolutionOverrides(
+  device: PricingDevice,
+  section: NonNullable<ReturnType<typeof getSectionById>>
+): RateResolutionOverrides {
+  return {
+    pricingProfile: device.pricingProfileId,
+    ageBandProfileId: device.ageBandProfileId ?? section.ageBandProfileId,
+  };
+}
+
 /**
  * Calcule un devis à partir du contexte et d'une configuration paramétrable.
  */
@@ -291,7 +314,12 @@ export function calculateQuoteFromConfig(
   let requiresAdminReview = false;
   const stripe = config.stripePresentation;
 
-  const base = resolveRatesFromConfig(config, ctx);
+  const activeDevice = resolveActivePricingDevice(ctx, config);
+  const section = getSectionById(config, ctx.mainSectionId);
+  const rateOverrides =
+    activeDevice && section ? buildRateResolutionOverrides(activeDevice, section) : undefined;
+
+  const base = resolveRatesFromConfig(config, ctx, rateOverrides);
   if (!base.ok) {
     return {
       catalogVersion: config.meta.catalogVersion,
@@ -305,6 +333,9 @@ export function calculateQuoteFromConfig(
   }
 
   const { rates } = base;
+  const segmentLabel = formatSegmentLabelWithDevice(rates.segmentLabel, activeDevice);
+  const includeFfttLicense = activeDevice ? activeDevice.includesFfttLicense : true;
+  const licenseCents = includeFfttLicense ? rates.licenseCents : 0;
   const lines: PriceLine[] = [
     {
       id: "membership",
@@ -313,16 +344,18 @@ export function calculateQuoteFromConfig(
       amountCents: rates.membershipCents,
       source: "catalog",
     },
-    {
+  ];
+
+  if (licenseCents > 0) {
+    lines.push({
       id: "fftt_license",
       kind: "fftt_license",
       label: stripe.licenseLabel,
-      amountCents: rates.licenseCents,
+      amountCents: licenseCents,
       source: "catalog",
-    },
-  ];
+    });
+  }
 
-  const section = getSectionById(config, ctx.mainSectionId);
   if (ctx.wantsCompetitorExtras && section) {
     lines.push({
       id: "competitor_jersey_info",
@@ -345,7 +378,10 @@ export function calculateQuoteFromConfig(
   lines.push(...competitions.lines);
   warnings.push(...competitions.warnings);
 
-  lines.push(...buildMembershipDiscountLines(config, ctx, rates.membershipCents));
+  const applyDiscounts = activeDevice?.stackableWithDiscounts !== false;
+  if (applyDiscounts) {
+    lines.push(...buildMembershipDiscountLines(config, ctx, rates.membershipCents));
+  }
 
   const aids = applyAidRules(config, ctx, rates.membershipCents);
   lines.push(...aids.lines);
@@ -357,13 +393,23 @@ export function calculateQuoteFromConfig(
   );
   const totalCents = sumLines(lines.filter((l) => l.kind !== "info"));
 
+  if (activeDevice?.uiCopy?.recapHint) {
+    warnings.push(activeDevice.uiCopy.recapHint);
+  }
+
   return {
     catalogVersion: config.meta.catalogVersion,
-    segmentLabel: rates.segmentLabel,
+    segmentLabel,
     lines,
     subtotalCents,
     totalCents: Math.max(0, totalCents),
     warnings: [...new Set(warnings)],
     requiresAdminReview,
+    ...(activeDevice
+      ? {
+          appliedPricingDeviceId: activeDevice.id,
+          appliedPricingDeviceLabel: activeDevice.label,
+        }
+      : {}),
   };
 }

--- a/src/lib/club-registration-config/pricing-profiles.ts
+++ b/src/lib/club-registration-config/pricing-profiles.ts
@@ -13,6 +13,7 @@ export const BUILTIN_PRICING_PROFILE_IDS = [
   "handisport",
   "sport_adapte",
   "ecole",
+  "champ_yon",
 ] as const;
 
 export type BuiltinPricingProfileId = (typeof BUILTIN_PRICING_PROFILE_IDS)[number];
@@ -55,6 +56,15 @@ export function buildDefaultPricingProfilesRecord(): Record<string, PricingProfi
       sortOrder: 3,
       accent: "success",
       iconKey: "school",
+      behavior: "classic_like",
+      builtIn: true,
+    },
+    {
+      id: "champ_yon",
+      label: "CHAMP'YON",
+      sortOrder: 4,
+      accent: "warning",
+      iconKey: "emoji_events",
       behavior: "classic_like",
       builtIn: true,
     },

--- a/src/lib/club-registration-config/repair-champ-yon-catalog.ts
+++ b/src/lib/club-registration-config/repair-champ-yon-catalog.ts
@@ -1,0 +1,55 @@
+import { getDefaultRegistrationConfig } from "./default-config";
+import { CHAMP_YON_PRICING_PROFILE_ID } from "./pricing-devices";
+import type { RegistrationConfigV1 } from "./types";
+
+/** Réinjecte le profil CHAMP'YON (grille + tranches d'âge) si absent d'une config legacy. */
+export function repairChampYonCatalog(config: RegistrationConfigV1): RegistrationConfigV1 {
+  const defaults = getDefaultRegistrationConfig();
+  const defaultProfile = defaults.pricingProfiles[CHAMP_YON_PRICING_PROFILE_ID];
+  const defaultAgeProfile = defaults.ageBandProfiles[CHAMP_YON_PRICING_PROFILE_ID];
+  const defaultRates = defaults.rateTable.filter(
+    (entry) => entry.match.pricingProfile === CHAMP_YON_PRICING_PROFILE_ID
+  );
+
+  if (!defaultProfile || !defaultAgeProfile || defaultRates.length === 0) {
+    return config;
+  }
+
+  const pricingProfiles = { ...config.pricingProfiles };
+  if (!pricingProfiles[CHAMP_YON_PRICING_PROFILE_ID]) {
+    pricingProfiles[CHAMP_YON_PRICING_PROFILE_ID] = defaultProfile;
+  }
+
+  const ageBandProfiles = { ...config.ageBandProfiles };
+  if (!ageBandProfiles[CHAMP_YON_PRICING_PROFILE_ID]) {
+    ageBandProfiles[CHAMP_YON_PRICING_PROFILE_ID] = defaultAgeProfile;
+  }
+
+  const existingRateIds = new Set(config.rateTable.map((entry) => entry.id));
+  const rateTable = config.rateTable.map((entry) => {
+    const defaultEntry = defaultRates.find((candidate) => candidate.id === entry.id);
+    if (
+      defaultEntry &&
+      entry.match.pricingProfile === CHAMP_YON_PRICING_PROFILE_ID
+    ) {
+      return {
+        ...entry,
+        licenseCents: defaultEntry.licenseCents,
+        membershipCents: defaultEntry.membershipCents,
+      };
+    }
+    return entry;
+  });
+  for (const entry of defaultRates) {
+    if (!existingRateIds.has(entry.id)) {
+      rateTable.push(entry);
+    }
+  }
+
+  return {
+    ...config,
+    pricingProfiles,
+    ageBandProfiles,
+    rateTable,
+  };
+}

--- a/src/lib/club-registration-config/schema.ts
+++ b/src/lib/club-registration-config/schema.ts
@@ -5,6 +5,8 @@ import { REGISTRATION_CONFIG_SCHEMA_VERSION } from "./types";
 import type { RegistrationConfigV1 } from "./types";
 import { repairPricingProfiles } from "./pricing-profiles";
 import { repairJerseyConfig } from "./repair-jersey";
+import { repairPricingDevices } from "./pricing-devices";
+import { repairChampYonCatalog } from "./repair-champ-yon-catalog";
 
 const pricingProfileBehaviorSchema = z.enum(["classic_like", "handisport", "sport_adapte"]);
 
@@ -152,11 +154,47 @@ const stripePresentationSchema = z.object({
   competitorJerseyInfoLabel: z.string().trim().min(1).max(300),
   invoiceHeaderTemplate: z.string().trim().min(1).max(300),
   discountCustomFieldName: z.string().trim().min(1).max(200),
+  donationLabel: z.string().trim().min(1).max(200).default("Don libre au club"),
+  donationDiscountCouponName: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .default("Remise don — 25 % (plaf. 73 €)"),
 });
 
 const jerseyCatalogSchema = z.object({
   optionalPriceCents: z.number().int().min(0),
   optionalStripeLabel: z.string().trim().min(1).max(300),
+});
+
+const pricingDeviceConditionsSchema = z.object({
+  sectionIds: z.array(z.string().trim().min(1).max(80)).min(1),
+  exactSlotCount: z.number().int().min(0),
+  requiresNoAdditionalSections: z.boolean(),
+  requiresNoCompetitorExtras: z.boolean(),
+  requiresNoCompetitionSelection: z.boolean(),
+});
+
+const pricingDeviceUiCopySchema = z.object({
+  recapHint: z.string().trim().min(1).max(500).optional(),
+  adminBadge: z.string().trim().min(1).max(80).optional(),
+  segmentLabelPrefix: z.string().trim().min(1).max(120).optional(),
+});
+
+const pricingDeviceSchema = z.object({
+  id: z.string().trim().min(1).max(80),
+  label: z.string().trim().min(1).max(200),
+  enabled: z.boolean(),
+  sortOrder: z.number().int().min(0),
+  priority: z.number().int().min(0),
+  conditions: pricingDeviceConditionsSchema,
+  pricingProfileId: pricingProfileIdSchema,
+  ageBandProfileId: z.string().trim().min(1).max(80).optional(),
+  stackableWithDiscounts: z.boolean(),
+  includesFfttLicense: z.boolean().default(true),
+  uiCopy: pricingDeviceUiCopySchema.optional(),
+  builtIn: z.boolean().optional(),
 });
 
 const registrationUiCopySchema = z.object({
@@ -200,9 +238,12 @@ export const registrationConfigV1Schema = z
   stripePresentation: stripePresentationSchema,
   jersey: jerseyCatalogSchema.optional(),
   uiCopy: registrationUiCopySchema,
+  pricingDevices: z.array(pricingDeviceSchema).optional(),
 })
   .transform((config) => repairPricingProfiles(config as RegistrationConfigV1))
-  .transform((config) => repairJerseyConfig(config as RegistrationConfigV1));
+  .transform((config) => repairJerseyConfig(config as RegistrationConfigV1))
+  .transform((config) => repairChampYonCatalog(config as RegistrationConfigV1))
+  .transform((config) => repairPricingDevices(config as RegistrationConfigV1));
 
 export const registrationConfigExportSchema = z.object({
   schemaVersion: z.literal(REGISTRATION_CONFIG_SCHEMA_VERSION),

--- a/src/lib/club-registration-config/types.ts
+++ b/src/lib/club-registration-config/types.ts
@@ -147,12 +147,56 @@ export type StripePresentationConfig = {
   competitorJerseyInfoLabel: string;
   invoiceHeaderTemplate: string;
   discountCustomFieldName: string;
+  /** Ligne facture Stripe pour le don libre. */
+  donationLabel: string;
+  /** Libellé du coupon de remise don affiché sur la facture. */
+  donationDiscountCouponName: string;
 };
 
 /** Tarification et libellé Stripe du maillot commandé hors section compétiteur. */
 export type JerseyCatalogConfig = {
   optionalPriceCents: number;
   optionalStripeLabel: string;
+};
+
+export type PricingDeviceConditions = {
+  /** Sections principales éligibles (ex. trappes, la-verriere). */
+  sectionIds: string[];
+  /** Nombre exact de créneaux requis (ex. 1). */
+  exactSlotCount: number;
+  /** Aucune section complémentaire cochée. */
+  requiresNoAdditionalSections: boolean;
+  /** Section compétiteur désactivée. */
+  requiresNoCompetitorExtras: boolean;
+  /** Aucune compétition sélectionnée. */
+  requiresNoCompetitionSelection: boolean;
+};
+
+export type PricingDeviceUiCopy = {
+  recapHint?: string | undefined;
+  adminBadge?: string | undefined;
+  segmentLabelPrefix?: string | undefined;
+};
+
+export type PricingDevice = {
+  id: string;
+  label: string;
+  enabled: boolean;
+  sortOrder: number;
+  /** Priorité de résolution (plus élevé = évalué en premier). */
+  priority: number;
+  conditions: PricingDeviceConditions;
+  /** Profil tarifaire substitué lorsque le dispositif s'applique. */
+  pricingProfileId: string;
+  /** Profil de tranches d'âge (défaut : celui de la section). */
+  ageBandProfileId?: string | undefined;
+  /** Remises catalogue (famille, 1re féminine) cumulables ou non. */
+  stackableWithDiscounts: boolean;
+  /** Facturer la ligne licence FFTT lorsque le dispositif s'applique. */
+  includesFfttLicense: boolean;
+  uiCopy?: PricingDeviceUiCopy | undefined;
+  /** Livré avec l'application : réinjecté si absent d'une config importée. */
+  builtIn?: boolean | undefined;
 };
 
 export type SchoolPickupServiceCopy = {
@@ -188,6 +232,7 @@ export type RegistrationConfigV1 = {
   stripePresentation: StripePresentationConfig;
   jersey: JerseyCatalogConfig;
   uiCopy: RegistrationUiCopy;
+  pricingDevices: PricingDevice[];
 };
 
 export type RegistrationConfigExport = {

--- a/src/lib/club-registration-config/validate-config.ts
+++ b/src/lib/club-registration-config/validate-config.ts
@@ -154,6 +154,42 @@ function validateAidRules(config: RegistrationConfigV1, issues: ConfigValidation
   );
 }
 
+function validatePricingDevices(config: RegistrationConfigV1, issues: ConfigValidationIssue[]): void {
+  collectUniqueIds(
+    (config.pricingDevices ?? []).map((device) => device.id),
+    "pricingDevices",
+    issues
+  );
+
+  const sectionIds = new Set(config.sections.map((section) => section.id));
+
+  for (const device of config.pricingDevices ?? []) {
+    if (!config.pricingProfiles[device.pricingProfileId]) {
+      issues.push({
+        path: `pricingDevices.${device.id}`,
+        message: `Profil tarifaire inconnu : ${device.pricingProfileId}`,
+      });
+    }
+
+    const ageBandProfileId = device.ageBandProfileId ?? device.pricingProfileId;
+    if (!config.ageBandProfiles[ageBandProfileId]) {
+      issues.push({
+        path: `pricingDevices.${device.id}`,
+        message: `Profil de tranche d'âge inconnu : ${ageBandProfileId}`,
+      });
+    }
+
+    for (const sectionId of device.conditions.sectionIds) {
+      if (!sectionIds.has(sectionId)) {
+        issues.push({
+          path: `pricingDevices.${device.id}`,
+          message: `Section inconnue : ${sectionId}`,
+        });
+      }
+    }
+  }
+}
+
 /** Validation croisée métier au-delà du schéma Zod. */
 export function validateRegistrationConfigCrossRefs(
   config: RegistrationConfigV1
@@ -166,6 +202,7 @@ export function validateRegistrationConfigCrossRefs(
   validateCompetitions(config, issues);
   validateRateTable(config, issues);
   validateAidRules(config, issues);
+  validatePricingDevices(config, issues);
   return issues;
 }
 
@@ -175,6 +212,18 @@ const SAMPLE_QUOTE_CONTEXTS: Array<Partial<PricingContext> & Pick<PricingContext
   { birthDate: "1990-01-01", mainSectionId: "handisport", wantsCompetitorExtras: false },
   { birthDate: "2010-01-01", mainSectionId: "handisport", wantsCompetitorExtras: true },
   { birthDate: "2010-01-01", mainSectionId: "sport-adapte" },
+  {
+    birthDate: "2014-06-01",
+    mainSectionId: "trappes",
+    slotIds: ["trappes-mer-1730-jeunes-loisir-compet"],
+    additionalSectionIds: [],
+  },
+  {
+    birthDate: "2005-01-01",
+    mainSectionId: "la-verriere",
+    slotIds: ["lv-jeu-1800-jeunes-loisirs"],
+    additionalSectionIds: [],
+  },
 ];
 
 /** Quotes témoins exécutées avant publication. */
@@ -185,6 +234,8 @@ export function runSampleQuoteChecks(config: RegistrationConfigV1): ConfigValida
   for (const partial of SAMPLE_QUOTE_CONTEXTS) {
     const ctx: PricingContext = {
       mainSectionId: partial.mainSectionId ?? "voisins",
+      slotIds: partial.slotIds ?? [],
+      additionalSectionIds: partial.additionalSectionIds ?? [],
       wantsCompetitorExtras: partial.wantsCompetitorExtras ?? false,
       wantsOptionalJersey: partial.wantsOptionalJersey ?? false,
       competitionIds: [],

--- a/src/lib/club-registration/apply-donation-pricing-patch.ts
+++ b/src/lib/club-registration/apply-donation-pricing-patch.ts
@@ -1,0 +1,35 @@
+import type { PriceQuote } from "@/lib/pricing/types";
+import { isValidVoluntaryDonationCents } from "@/lib/pricing/donation-discount";
+import {
+  readVoluntaryDonationCents,
+  resolveRegistrationDonationPricing,
+} from "./resolve-registration-donation";
+
+/** Enrichit un patch admin avec remise don et montant aligné si pertinent. */
+export function applyDonationPricingPatch(
+  pricingPatch: Record<string, unknown>,
+  quote: PriceQuote,
+  mergedForPricing: Record<string, unknown>,
+  currentData: Record<string, unknown>
+): void {
+  const donationCents = readVoluntaryDonationCents(mergedForPricing);
+  if (!isValidVoluntaryDonationCents(donationCents)) {
+    return;
+  }
+
+  const donation = resolveRegistrationDonationPricing(quote, mergedForPricing);
+  pricingPatch.donationDiscountCents = donation.donationDiscountCents;
+
+  const currentPaymentAmount =
+    typeof currentData.paymentAmountCents === "number"
+      ? currentData.paymentAmountCents
+      : quote.totalCents;
+  const mergedPaymentAmount = mergedForPricing.paymentAmountCents;
+
+  if (
+    typeof mergedPaymentAmount === "number" &&
+    mergedPaymentAmount === currentPaymentAmount
+  ) {
+    pricingPatch.paymentAmountCents = donation.invoiceTotalCents;
+  }
+}

--- a/src/lib/club-registration/build-manager-registration-pricing-patch.ts
+++ b/src/lib/club-registration/build-manager-registration-pricing-patch.ts
@@ -1,0 +1,27 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { ensureRegistrationConfigSeeded, getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { calculateQuoteWithConfig } from "@/lib/club-registration-config/pricing-resolve";
+import { buildPricingContextFromRecord } from "@/lib/pricing/from-registration-record";
+import { applyDonationPricingPatch } from "./apply-donation-pricing-patch";
+
+export async function buildManagerRegistrationPricingPatch(
+  mergedForPricing: Record<string, unknown>,
+  currentData: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const pricingCtx = buildPricingContextFromRecord(mergedForPricing);
+  if (!pricingCtx) {
+    return {};
+  }
+
+  await ensureRegistrationConfigSeeded();
+  const config = await getActiveRegistrationConfig();
+  const quote = calculateQuoteWithConfig(pricingCtx, config);
+
+  const pricingPatch: Record<string, unknown> = {
+    pricingQuote: quote,
+    pricingQuoteStatus: "proposed",
+    pricingQuoteComputedAt: FieldValue.serverTimestamp(),
+  };
+  applyDonationPricingPatch(pricingPatch, quote, mergedForPricing, currentData);
+  return pricingPatch;
+}

--- a/src/lib/club-registration/build-payload-schema.ts
+++ b/src/lib/club-registration/build-payload-schema.ts
@@ -24,6 +24,7 @@ import {
 } from "./payment-payload-schema";
 import { isValidFrenchPhoneSurface, normalizeFrenchPhoneInput } from "./phone-fr";
 import { calculateQuoteFromConfig } from "@/lib/club-registration-config/pricing-engine";
+import { isValidVoluntaryDonationCents, getMembershipNetCents, computeInvoiceTotalCents } from "@/lib/pricing/donation-discount";
 import { buildPricingContext } from "@/lib/pricing/build-context";
 import {
   adherentRoleSchema,
@@ -418,6 +419,8 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
       const pricingCtx = buildPricingContext({
         birthDate: data.birthDate,
         mainSectionId: data.mainSectionId,
+        slotIds: data.slotIds,
+        additionalSectionIds: data.additionalSectionIds,
         wantsCompetitorExtras: data.wantsCompetitorExtras,
         wantsOptionalJersey: data.wantsOptionalJersey,
         competitionIds: data.competitionIds,
@@ -427,7 +430,22 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
         reductionTypes: data.reductionTypes,
       });
       const quote = calculateQuoteFromConfig(pricingCtx, config);
-      refinePaymentPayload(data, ctx, quote.totalCents);
+
+      if (!isValidVoluntaryDonationCents(data.voluntaryDonationCents)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Le don libre doit être de 0 € ou d'au moins 1 €.",
+          path: ["voluntaryDonationCents"],
+        });
+      }
+
+      const membershipNet = getMembershipNetCents(quote);
+      const invoiceTotalCents = computeInvoiceTotalCents(
+        quote.totalCents,
+        data.voluntaryDonationCents,
+        membershipNet
+      );
+      refinePaymentPayload(data, ctx, invoiceTotalCents);
     })
   );
 }

--- a/src/lib/club-registration/membership-requests/registration-card-quick-actions.test.ts
+++ b/src/lib/club-registration/membership-requests/registration-card-quick-actions.test.ts
@@ -2,6 +2,7 @@ import {
   canMarkCertificateReceived,
   canMarkCertificateValidated,
   canQuickRequestPayment,
+  canQuickResendPaymentLink,
   resolveQuickPaymentAmountCents,
 } from "./registration-card-quick-actions";
 import type { RegistrationSummary } from "@/components/club-registration/membership-requests/types";
@@ -44,6 +45,58 @@ describe("registration-card-quick-actions", () => {
     expect(
       canQuickRequestPayment(
         baseSummary({ status: "payment_requested", paymentAmountCents: 22_400 })
+      )
+    ).toBe(false);
+  });
+
+  it("allows quick resend for payment_requested card dossiers", () => {
+    expect(
+      canQuickResendPaymentLink(
+        baseSummary({
+          status: "payment_requested",
+          paymentAmountCents: 22_400,
+          payment: {
+            paymentMethod: "card",
+            amountToPayCents: 22_400,
+            totalAmountCents: 22_400,
+            assistanceTotalAmountCents: 0,
+            aids: [],
+            paymentInstallments: 1,
+            expectedPayments: [],
+            receivedPayments: [],
+            paidAmountCents: 0,
+            remainingAmountCents: 22_400,
+            paymentStatus: "waiting_payment",
+          },
+        })
+      )
+    ).toBe(true);
+    expect(
+      canQuickResendPaymentLink(
+        baseSummary({ status: "in_review", paymentAmountCents: 22_400 })
+      )
+    ).toBe(false);
+    expect(
+      canQuickResendPaymentLink(
+        baseSummary({
+          status: "payment_requested",
+          paymentStatus: "pending",
+          paidAt: "2026-06-27T08:31:30.000Z",
+          paymentAmountCents: 22_400,
+          payment: {
+            paymentMethod: "card",
+            amountToPayCents: 22_400,
+            totalAmountCents: 22_400,
+            assistanceTotalAmountCents: 0,
+            aids: [],
+            paymentInstallments: 1,
+            expectedPayments: [],
+            receivedPayments: [],
+            paidAmountCents: 0,
+            remainingAmountCents: 22_400,
+            paymentStatus: "waiting_payment",
+          },
+        })
       )
     ).toBe(false);
   });

--- a/src/lib/club-registration/membership-requests/registration-card-quick-actions.ts
+++ b/src/lib/club-registration/membership-requests/registration-card-quick-actions.ts
@@ -1,4 +1,5 @@
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
 import type { RegistrationSummary } from "@/components/club-registration/membership-requests/types";
 
 const QUICK_PAYMENT_ELIGIBLE_STATUSES = new Set(["submitted", "in_review"]);
@@ -38,7 +39,24 @@ export function canQuickRequestPayment(registration: RegistrationSummary): boole
   if (!status || !QUICK_PAYMENT_ELIGIBLE_STATUSES.has(status)) {
     return false;
   }
-  if (registration.paymentStatus === "paid") {
+  if (registration.paymentStatus === "paid" || isRegistrationPaidRecord(registration)) {
+    return false;
+  }
+  const amountCents = resolveQuickPaymentAmountCents(registration);
+  return amountCents !== null && amountCents > 0;
+}
+
+export function canQuickResendPaymentLink(registration: RegistrationSummary): boolean {
+  if (registration.status !== "payment_requested") {
+    return false;
+  }
+  if (registration.paymentStatus === "paid" || isRegistrationPaidRecord(registration)) {
+    return false;
+  }
+  const payment =
+    registration.payment ??
+    normalizeRegistrationPayment(registration as unknown as Record<string, unknown>);
+  if (payment?.paymentMethod !== "card") {
     return false;
   }
   const amountCents = resolveQuickPaymentAmountCents(registration);

--- a/src/lib/club-registration/mes-inscriptions-url.ts
+++ b/src/lib/club-registration/mes-inscriptions-url.ts
@@ -1,0 +1,11 @@
+/** URL Mes dossiers, avec focus optionnel sur un dossier (lien e-mail de paiement). */
+export function buildMesInscriptionsUrl(
+  appOrigin: string,
+  registrationId?: string
+): string {
+  const base = `${appOrigin.replace(/\/$/, "")}/club/mes-inscriptions`;
+  if (!registrationId) {
+    return base;
+  }
+  return `${base}?registration=${encodeURIComponent(registrationId)}`;
+}

--- a/src/lib/club-registration/payment-payload-schema.ts
+++ b/src/lib/club-registration/payment-payload-schema.ts
@@ -37,6 +37,7 @@ export const paymentPayloadFieldsSchema = {
     (val) => (typeof val === "string" && val.trim() === "" ? undefined : val),
     z.string().trim().max(PAYMENT_NOTE_MAX_LENGTH).optional()
   ),
+  voluntaryDonationCents: z.number().int().min(0).default(0),
 };
 
 export function refinePaymentPayload(

--- a/src/lib/club-registration/payment-proof.test.ts
+++ b/src/lib/club-registration/payment-proof.test.ts
@@ -15,4 +15,14 @@ describe("payment-proof", () => {
   it("refuse une preuve si le dossier n'est pas payé", () => {
     expect(isRegistrationPaidRecord({ status: "payment_requested" })).toBe(false);
   });
+
+  it("considère réglé si paidAt est renseigné même avec statuts legacy", () => {
+    expect(
+      isRegistrationPaidRecord({
+        status: "payment_requested",
+        paymentStatus: "pending",
+        paidAt: "2026-06-27T08:31:30.000Z",
+      })
+    ).toBe(true);
+  });
 });

--- a/src/lib/club-registration/payment-proof.ts
+++ b/src/lib/club-registration/payment-proof.ts
@@ -1,7 +1,22 @@
 type RegistrationRecord = Record<string, unknown>;
 
+function hasPaidAtRecorded(data: RegistrationRecord): boolean {
+  const paidAt = data.paidAt;
+  if (paidAt == null) {
+    return false;
+  }
+  if (typeof paidAt === "string") {
+    return paidAt.trim().length > 0;
+  }
+  if (typeof paidAt === "object" && typeof (paidAt as { toDate?: () => Date }).toDate === "function") {
+    return true;
+  }
+  return false;
+}
+
 export function isRegistrationPaidRecord(data: RegistrationRecord): boolean {
   return (
+    hasPaidAtRecorded(data) ||
     data.status === "paid" ||
     data.paymentStatus === "paid" ||
     data.paymentStatus === "complete"

--- a/src/lib/club-registration/payment-requested.ts
+++ b/src/lib/club-registration/payment-requested.ts
@@ -1,0 +1,210 @@
+import { FieldValue, type DocumentReference, type DocumentData } from "firebase-admin/firestore";
+import {
+  buildPaymentRequestEmail,
+  buildPaymentRequestEmailSubject,
+} from "@/lib/email/payment-email";
+import { getSqyPingLogoAttachment } from "@/lib/email/logo-attachment";
+import { sendMail } from "@/lib/mailer";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import {
+  assertStripePayableAfterDiscounts,
+  computeSecretariatAidDiscountCents,
+  sumPaymentAidDiscountCents,
+} from "@/lib/club-registration/stripe-checkout-discounts";
+import { paymentToFirestoreUpdate } from "@/lib/club-registration/payment/normalize-payment";
+import { recalculateRegistrationPayment } from "@/lib/club-registration/payment/payment-mutations";
+import {
+  assertStripeLinesMatchQuote,
+  buildStripeCheckoutLineItems,
+} from "@/lib/pricing/stripe-checkout-lines";
+import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+import type { PriceQuote } from "@/lib/pricing/types";
+
+export function validateRegistrationStripeCheckout(params: {
+  quote: PriceQuote | null;
+  donationPricing: DonationPricingBreakdown | null;
+  pricingConfig: RegistrationConfigV1;
+  payment: RegistrationPayment | null;
+  amountToPayCents: number;
+}):
+  | { ok: true }
+  | { ok: false; status: number; body: Record<string, unknown> } {
+  const useQuoteLineItems =
+    params.quote != null &&
+    params.donationPricing != null &&
+    params.donationPricing.invoiceTotalCents > 0;
+
+  if (!useQuoteLineItems || !params.quote || !params.donationPricing) {
+    return { ok: true };
+  }
+
+  const { quote, donationPricing } = params;
+  const stripePresentation = params.pricingConfig.stripePresentation;
+  const donationContext =
+    donationPricing.voluntaryDonationCents > 0
+      ? {
+          voluntaryDonationCents: donationPricing.voluntaryDonationCents,
+          donationDiscountCents: donationPricing.donationDiscountCents,
+        }
+      : undefined;
+  const stripeLineItems = buildStripeCheckoutLineItems(
+    quote,
+    stripePresentation,
+    donationContext
+  );
+  const paymentAids = params.payment?.aids ?? [];
+  assertStripeLinesMatchQuote(quote, stripeLineItems, donationContext);
+
+  const aidDiscountCents = sumPaymentAidDiscountCents(paymentAids);
+  const expectedAidDiscount = computeSecretariatAidDiscountCents(
+    donationPricing.invoiceTotalCents,
+    params.amountToPayCents
+  );
+  if (aidDiscountCents !== expectedAidDiscount) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error:
+          "Les aides enregistrées ne correspondent pas au reste à payer. Enregistrez le dossier ou alignez le montant.",
+        expectedAidDiscountCents: expectedAidDiscount,
+        recordedAidDiscountCents: aidDiscountCents,
+      },
+    };
+  }
+
+  try {
+    assertStripePayableAfterDiscounts({
+      invoiceTotalCents: donationPricing.invoiceTotalCents,
+      donationDiscountCents: donationPricing.donationDiscountCents,
+      aidDiscountCents,
+      amountToPayCents: params.amountToPayCents,
+    });
+  } catch (validationError) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error:
+          validationError instanceof Error
+            ? validationError.message
+            : "Incohérence montant / remises pour Stripe.",
+      },
+    };
+  }
+
+  return { ok: true };
+}
+
+export function buildPaymentRequestedFirestoreUpdate(params: {
+  payment: RegistrationPayment | null;
+  quote: PriceQuote | null;
+  donationPricing: DonationPricingBreakdown | null;
+  amountToPayCents: number;
+  requestedByUid: string;
+  paymentEmail: string;
+}): DocumentData {
+  const waitingPayment = params.payment
+    ? recalculateRegistrationPayment({
+        ...params.payment,
+        paymentStatus: "waiting_payment",
+      })
+    : null;
+
+  const hasValidatedQuote =
+    params.quote != null &&
+    params.donationPricing != null &&
+    params.donationPricing.invoiceTotalCents > 0;
+
+  const firestoreUpdate: DocumentData = {
+    status: "payment_requested",
+    ...(waitingPayment ? paymentToFirestoreUpdate(waitingPayment) : {}),
+    paymentAmountCents: params.amountToPayCents,
+    paymentStatus: "pending",
+    paymentRequestedAt: FieldValue.serverTimestamp(),
+    paymentRequestedBy: params.requestedByUid,
+    paymentEmailSentTo: params.paymentEmail,
+    stripeCheckoutSessionId: FieldValue.delete(),
+    stripeCheckoutUrl: FieldValue.delete(),
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+
+  if (hasValidatedQuote && params.quote && params.donationPricing) {
+    firestoreUpdate.pricingQuote = params.quote;
+    firestoreUpdate.pricingQuoteStatus = "validated";
+    firestoreUpdate.voluntaryDonationCents = params.donationPricing.voluntaryDonationCents;
+    firestoreUpdate.donationDiscountCents = params.donationPricing.donationDiscountCents;
+  }
+
+  return firestoreUpdate;
+}
+
+export async function persistPaymentRequestedAndNotify(params: {
+  docRef: DocumentReference;
+  registrationId: string;
+  payment: RegistrationPayment | null;
+  quote: PriceQuote | null;
+  donationPricing: DonationPricingBreakdown | null;
+  amountToPayCents: number;
+  paymentEmail: string;
+  adherentName: string;
+  baseUrl: string;
+  requestedByUid: string;
+  isResend?: boolean;
+}): Promise<void> {
+  await params.docRef.set(
+    buildPaymentRequestedFirestoreUpdate({
+      payment: params.payment,
+      quote: params.quote,
+      donationPricing: params.donationPricing,
+      amountToPayCents: params.amountToPayCents,
+      requestedByUid: params.requestedByUid,
+      paymentEmail: params.paymentEmail,
+    }),
+    { merge: true }
+  );
+
+  const hasValidatedQuote =
+    params.quote != null &&
+    params.donationPricing != null &&
+    params.donationPricing.invoiceTotalCents > 0;
+  const emailVariant = params.isResend ? "resend" : "initial";
+  const paymentMail = buildPaymentRequestEmail({
+    registrationId: params.registrationId,
+    adherentName: params.adherentName,
+    amountCents: params.amountToPayCents,
+    appOrigin: params.baseUrl,
+    quote: hasValidatedQuote ? params.quote : null,
+    donationPricing: hasValidatedQuote ? params.donationPricing : null,
+    variant: emailVariant,
+    ...(params.payment?.aids?.length ? { secretariatAids: params.payment.aids } : {}),
+  });
+
+  await sendMail({
+    to: params.paymentEmail,
+    subject: buildPaymentRequestEmailSubject(params.adherentName, emailVariant),
+    text: paymentMail.text,
+    html: paymentMail.html,
+    attachments: [getSqyPingLogoAttachment()],
+  });
+
+  logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_REQUESTED, params.requestedByUid, {
+    resource: "clubRegistration",
+    resourceId: params.registrationId,
+    details: {
+      amountCents: params.amountToPayCents,
+      resend: Boolean(params.isResend),
+      paymentHub: "mes_inscriptions",
+      ...(hasValidatedQuote
+        ? {
+            catalogVersion: params.quote?.catalogVersion,
+            donationCents: params.donationPricing?.voluntaryDonationCents ?? 0,
+            donationDiscountCents: params.donationPricing?.donationDiscountCents ?? 0,
+          }
+        : { legacy: true }),
+    },
+    success: true,
+  });
+}

--- a/src/lib/club-registration/payment/bnpl-checkout-copy.ts
+++ b/src/lib/club-registration/payment/bnpl-checkout-copy.ts
@@ -38,3 +38,66 @@ export const BNPL_SECRETARIAT_PAGE_SUBTITLE =
 
 /** Chaîne attendue dans les tests e-mail (repère stable). */
 export const BNPL_COPY_TEST_MARKER = "BNPL";
+
+/** Validité d'un lien Stripe Checkout. */
+export const CHECKOUT_LINK_VALIDITY_NOTICE =
+  "Ce lien de paiement est valable 24 heures.";
+
+/** Validité du lien Stripe ouvert depuis Mes dossiers. */
+export const CHECKOUT_LINK_VALIDITY_FROM_MES_DOSSIERS_NOTICE =
+  "Sur Mes dossiers, le lien Stripe ouvert via « Payer en ligne » est valable 24 heures.";
+
+/** Bouton principal e-mail demande de paiement. */
+export const PAYMENT_EMAIL_CTA_LABEL = "Finaliser mon adhésion";
+
+/** E-mail — instruction après le détail du devis. */
+export const PAYMENT_EMAIL_HUB_INSTRUCTION_HTML =
+  "Connectez-vous à votre espace <strong>Mes dossiers</strong>, puis cliquez sur <strong>Payer en ligne</strong> pour accéder à la page sécurisée Stripe.";
+
+/** E-mail — instruction (texte brut). */
+export const PAYMENT_EMAIL_HUB_INSTRUCTION_TEXT =
+  "Connectez-vous à Mes dossiers sur TeamUp, puis cliquez sur « Payer en ligne » pour régler sur Stripe.";
+
+/** Alerte Mes dossiers — arrivée depuis l'e-mail de paiement. */
+export const ADHERENT_PAYMENT_EMAIL_LANDING_ALERT =
+  "Votre dossier est prêt à être réglé. Utilisez le bouton « Payer en ligne » sur la fiche ci-dessous.";
+
+/** E-mail demande de paiement — alternative Mes dossiers (HTML). */
+export const SELF_SERVICE_MES_INSCRIPTIONS_EMAIL_HTML =
+  "Vous pouvez aussi payer depuis votre espace <strong>Mes dossiers</strong> sur TeamUp.";
+
+/** E-mail demande de paiement — alternative Mes dossiers (texte). */
+export const SELF_SERVICE_MES_INSCRIPTIONS_EMAIL_TEXT =
+  "Vous pouvez aussi payer depuis Mes dossiers sur TeamUp :";
+
+/** Bouton adhérent — Mes dossiers. */
+export const ADHERENT_PAY_ONLINE_BUTTON_LABEL = "Payer en ligne";
+
+/** Aide sous le bouton adhérent. */
+export const ADHERENT_PAY_ONLINE_HELPER =
+  "Paiement sécurisé Stripe. Carte ou paiement en plusieurs fois (BNPL) selon éligibilité.";
+
+/** Dossier en attente hors carte bancaire. */
+export const ADHERENT_NON_CARD_PAYMENT_HINT =
+  "Les instructions de règlement vous ont été envoyées par e-mail.";
+
+/** Alerte liste Mes dossiers — paiement en attente. */
+export const ADHERENT_PAYMENT_PENDING_ALERT =
+  "Un ou plusieurs dossiers attendent votre règlement pour finaliser l'inscription.";
+
+/** Bouton secrétariat — premier envoi. */
+export const SECRETARIAT_INITIAL_PAYMENT_BUTTON = "Valider et demander le paiement";
+
+/** Bouton secrétariat — renvoi lien. */
+export const SECRETARIAT_RESEND_PAYMENT_BUTTON = "Renvoyer le lien de paiement";
+
+/** Tooltip secrétariat — renvoi. */
+export const SECRETARIAT_RESEND_PAYMENT_TOOLTIP =
+  "Génère un nouveau lien Stripe (valable 24 h) et renvoie l'e-mail de paiement au contact du dossier.";
+
+/** Liste secrétariat — action rapide renvoi. */
+export const SECRETARIAT_QUICK_RESEND_PAYMENT_LABEL = "Renvoyer le lien";
+
+/** Contexte secrétariat — self-service adhérent. */
+export const SECRETARIAT_SELF_SERVICE_HINT =
+  "L'adhérent peut aussi payer depuis Mes dossiers sur TeamUp sans intervention du secrétariat.";

--- a/src/lib/club-registration/payment/build-payment-from-draft.ts
+++ b/src/lib/club-registration/payment/build-payment-from-draft.ts
@@ -1,4 +1,5 @@
 import type { PriceQuote } from "@/lib/pricing/types";
+import { resolveDonationPricing } from "@/lib/pricing/donation-discount";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { calculatePaymentSummary } from "./calculate-payment-summary";
 import { generateExpectedPayments } from "./generate-expected-payments";
@@ -10,6 +11,7 @@ export type BuildPaymentFromDraftInput = PaymentDraftFields & {
   config: RegistrationConfigV1;
   reductionTypes: string[];
   reductionReferenceCodes: Record<string, string>;
+  voluntaryDonationCents?: number;
 };
 
 function findAidLabel(config: RegistrationConfigV1, aidType: string): string {
@@ -55,7 +57,9 @@ export function buildPaymentFromDraft(
   input: BuildPaymentFromDraftInput
 ): RegistrationPayment {
   const aids = mergePaymentAidsFromDraft(input);
-  const totalAmountCents = Math.max(0, input.quote.totalCents);
+  const donationCents = input.voluntaryDonationCents ?? 0;
+  const donationPricing = resolveDonationPricing(input.quote, donationCents);
+  const totalAmountCents = Math.max(0, donationPricing.invoiceTotalCents);
   const summary = calculatePaymentSummary({
     totalAmountCents,
     aids,

--- a/src/lib/club-registration/persist-registration-on-submit.ts
+++ b/src/lib/club-registration/persist-registration-on-submit.ts
@@ -22,6 +22,8 @@ export function buildRegistrationSubmitDocument(params: {
   const pricingCtx = buildPricingContext({
     birthDate: payload.birthDate,
     mainSectionId: payload.mainSectionId,
+    slotIds: payload.slotIds,
+    additionalSectionIds: payload.additionalSectionIds,
     wantsCompetitorExtras: payload.wantsCompetitorExtras,
     wantsOptionalJersey: payload.wantsOptionalJersey,
     competitionIds: payload.competitionIds,
@@ -49,6 +51,7 @@ export function buildRegistrationSubmitDocument(params: {
     remainingPaymentMethod: payload.remainingPaymentMethod ?? "",
     paymentNote: payload.paymentNote ?? "",
     specialPaymentNote: payload.specialPaymentNote ?? "",
+    voluntaryDonationCents: payload.voluntaryDonationCents,
   });
 
   const {
@@ -72,6 +75,7 @@ export function buildRegistrationSubmitDocument(params: {
 
   return {
     ...storedPayload,
+    voluntaryDonationCents: payload.voluntaryDonationCents,
     ...paymentToFirestoreUpdate(payment),
     pricingQuote: quote,
     pricingQuoteStatus: "proposed",

--- a/src/lib/club-registration/registration-api-fields.ts
+++ b/src/lib/club-registration/registration-api-fields.ts
@@ -70,6 +70,8 @@ export const REGISTRATION_CLIENT_FIELDS = [
   "remainingPaymentMethod",
   "paymentNote",
   "specialPaymentNote",
+  "voluntaryDonationCents",
+  "donationDiscountCents",
 ] as const;
 
 export const MANAGER_EDITABLE_FIELDS = [
@@ -116,4 +118,5 @@ export const MANAGER_EDITABLE_FIELDS = [
   "reviewNotes",
   "paymentAmountCents",
   "handisportPracticeLevel",
+  "voluntaryDonationCents",
 ] as const;

--- a/src/lib/club-registration/repair-registration-payment-status.test.ts
+++ b/src/lib/club-registration/repair-registration-payment-status.test.ts
@@ -1,0 +1,32 @@
+import { needsRegistrationPaymentStatusRepair } from "./repair-registration-payment-status";
+
+describe("needsRegistrationPaymentStatusRepair", () => {
+  it("détecte paidAt + paymentStatus pending", () => {
+    expect(
+      needsRegistrationPaymentStatusRepair({
+        status: "paid",
+        paymentStatus: "pending",
+        paidAt: new Date("2026-06-27T08:31:30Z"),
+      })
+    ).toBe(true);
+  });
+
+  it("ignore les dossiers déjà payés", () => {
+    expect(
+      needsRegistrationPaymentStatusRepair({
+        status: "paid",
+        paymentStatus: "paid",
+        paidAt: new Date(),
+      })
+    ).toBe(false);
+  });
+
+  it("ignore les dossiers non réglés", () => {
+    expect(
+      needsRegistrationPaymentStatusRepair({
+        status: "payment_requested",
+        paymentStatus: "pending",
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lib/club-registration/repair-registration-payment-status.ts
+++ b/src/lib/club-registration/repair-registration-payment-status.ts
@@ -1,0 +1,22 @@
+type RegistrationPaymentRepairRecord = Record<string, unknown>;
+
+function isRegistrationSettled(data: RegistrationPaymentRepairRecord): boolean {
+  return data.status === "paid" || data.paidAt != null;
+}
+
+function storedPaymentStatusIsPaid(paymentStatus: unknown): boolean {
+  return paymentStatus === "paid" || paymentStatus === "complete";
+}
+
+/**
+ * Dossier réglé (paidAt ou status paid) mais paymentStatus Firestore racine pas aligné.
+ * On ne se fie pas à l'objet payment imbriqué : le champ plat peut rester « pending ».
+ */
+export function needsRegistrationPaymentStatusRepair(
+  data: RegistrationPaymentRepairRecord
+): boolean {
+  if (!isRegistrationSettled(data)) {
+    return false;
+  }
+  return !storedPaymentStatusIsPaid(data.paymentStatus);
+}

--- a/src/lib/club-registration/request-payment-checkout.ts
+++ b/src/lib/club-registration/request-payment-checkout.ts
@@ -1,0 +1,291 @@
+import { FieldValue, type DocumentReference } from "firebase-admin/firestore";
+import { buildPaymentInstructionsEmail } from "@/lib/email/payment-instructions-email";
+import { getSqyPingLogoAttachment } from "@/lib/email/logo-attachment";
+import { sendMail } from "@/lib/mailer";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import {
+  createLegacySingleLineCheckoutSession,
+  createMembershipCheckoutSession,
+} from "@/lib/club-registration/stripe";
+import {
+  createCheckoutDiscountCouponIds,
+  sumPaymentAidDiscountCents,
+} from "@/lib/club-registration/stripe-checkout-discounts";
+import {
+  paymentToFirestoreUpdate,
+} from "@/lib/club-registration/payment/normalize-payment";
+import {
+  recalculateRegistrationPayment,
+  regenerateExpectedPayments,
+  setManualFollowUp,
+} from "@/lib/club-registration/payment/payment-mutations";
+import { renderInvoiceHeader } from "@/lib/club-registration-config/helpers";
+import { hashPriceQuote } from "@/lib/pricing/quote-hash";
+import {
+  buildStripeCheckoutLineItems,
+  buildStripeInvoiceCustomFields,
+} from "@/lib/pricing/stripe-checkout-lines";
+import { validateRegistrationStripeCheckout } from "@/lib/club-registration/payment-requested";
+import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+import type { PriceQuote } from "@/lib/pricing/types";
+
+export {
+  buildPaymentRequestedFirestoreUpdate,
+  persistPaymentRequestedAndNotify,
+  validateRegistrationStripeCheckout,
+} from "@/lib/club-registration/payment-requested";
+
+export type StripeCheckoutSessionResult = {
+  session: { id: string; url: string | null };
+  legacy: boolean;
+  stripeLineItems?: ReturnType<typeof buildStripeCheckoutLineItems>;
+  aidDiscountCents?: number;
+};
+
+export async function processManualPaymentFollowUp(params: {
+  docRef: DocumentReference;
+  registrationId: string;
+  payment: RegistrationPayment | null;
+  quote: PriceQuote | null;
+  donationPricing: DonationPricingBreakdown | null;
+  amountToPayCents: number;
+  paymentMethod: RegistrationPayment["paymentMethod"];
+  paymentEmail: string;
+  adherentName: string;
+  baseUrl: string;
+  requestedByUid: string;
+}): Promise<{ success: true } | { success: false; error: string }> {
+  const paymentInstallments = params.payment?.paymentInstallments ?? 1;
+  const baseManualPayment: RegistrationPayment =
+    params.payment ??
+    ({
+      totalAmountCents: params.quote?.totalCents ?? params.amountToPayCents,
+      assistanceTotalAmountCents: 0,
+      amountToPayCents: params.amountToPayCents,
+      aids: [],
+      paymentMethod: params.paymentMethod,
+      paymentInstallments,
+      expectedPayments: [],
+      receivedPayments: [],
+      paidAmountCents: 0,
+      remainingAmountCents: params.amountToPayCents,
+      paymentStatus: "waiting_payment",
+    } satisfies RegistrationPayment);
+
+  const manualPayment = setManualFollowUp(baseManualPayment);
+
+  await params.docRef.set(
+    {
+      status: "payment_requested",
+      ...paymentToFirestoreUpdate(manualPayment),
+      paymentAmountCents: params.amountToPayCents,
+      voluntaryDonationCents: params.donationPricing?.voluntaryDonationCents ?? 0,
+      donationDiscountCents: params.donationPricing?.donationDiscountCents ?? 0,
+      paymentRequestedAt: FieldValue.serverTimestamp(),
+      paymentRequestedBy: params.requestedByUid,
+      paymentEmailSentTo: params.paymentEmail,
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  const instructionsMail = buildPaymentInstructionsEmail({
+    adherentName: params.adherentName,
+    amountCents: params.amountToPayCents,
+    registrationId: params.registrationId,
+    appOrigin: params.baseUrl,
+    paymentMethod: manualPayment.paymentMethod,
+    paymentInstallments: manualPayment.paymentInstallments,
+    expectedPayments: manualPayment.expectedPayments,
+    donationPricing: params.donationPricing,
+    ...(manualPayment.holidayVoucherAmountCents != null
+      ? { holidayVoucherAmountCents: manualPayment.holidayVoucherAmountCents }
+      : {}),
+    ...(manualPayment.remainingPaymentMethod
+      ? { remainingPaymentMethod: manualPayment.remainingPaymentMethod }
+      : {}),
+    ...(manualPayment.specialPaymentNote
+      ? { specialPaymentNote: manualPayment.specialPaymentNote }
+      : {}),
+    ...(manualPayment.paymentNote ? { paymentNote: manualPayment.paymentNote } : {}),
+    quote: params.quote,
+    ...(manualPayment.aids.length > 0 ? { secretariatAids: manualPayment.aids } : {}),
+  });
+
+  try {
+    await sendMail({
+      to: params.paymentEmail,
+      subject: `Instructions de règlement — adhésion ${params.adherentName}`,
+      html: instructionsMail.html,
+      text: instructionsMail.text,
+      attachments: [getSqyPingLogoAttachment()],
+    });
+  } catch (emailError) {
+    console.error("[request-payment] instructions email", emailError);
+    return {
+      success: false,
+      error: "Dossier mis à jour mais l'e-mail d'instructions n'a pas pu être envoyé.",
+    };
+  }
+
+  logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_REQUESTED, params.requestedByUid, {
+    resource: "clubRegistration",
+    resourceId: params.registrationId,
+    details: {
+      amountCents: params.amountToPayCents,
+      manualFollowUp: true,
+      paymentMethod: manualPayment.paymentMethod,
+      donationCents: params.donationPricing?.voluntaryDonationCents ?? 0,
+      donationDiscountCents: params.donationPricing?.donationDiscountCents ?? 0,
+    },
+    success: true,
+  });
+
+  return { success: true };
+}
+
+export function recalculatePaymentForRequest(
+  payment: RegistrationPayment | null,
+  quote: PriceQuote | null,
+  invoiceTotalCents: number
+): RegistrationPayment | null {
+  if (!payment || !quote) {
+    return payment;
+  }
+  let updated = recalculateRegistrationPayment({
+    ...payment,
+    totalAmountCents: invoiceTotalCents,
+  });
+  if (updated.paymentMethod === "card" || updated.paymentMethod === "cheque") {
+    updated = regenerateExpectedPayments(updated);
+  }
+  return updated;
+}
+
+export async function createStripeCheckoutForRegistration(params: {
+  registrationId: string;
+  quote: PriceQuote | null;
+  donationPricing: DonationPricingBreakdown | null;
+  pricingConfig: RegistrationConfigV1;
+  payment: RegistrationPayment | null;
+  amountToPayCents: number;
+  paymentEmail: string;
+  adherentName: string;
+  successUrl: string;
+  cancelUrl: string;
+}): Promise<
+  | { ok: true; result: StripeCheckoutSessionResult }
+  | { ok: false; status: number; body: Record<string, unknown> }
+> {
+  const useQuoteLineItems =
+    params.quote != null &&
+    params.donationPricing != null &&
+    params.donationPricing.invoiceTotalCents > 0;
+
+  if (useQuoteLineItems && params.quote && params.donationPricing) {
+    const validation = validateRegistrationStripeCheckout({
+      quote: params.quote,
+      donationPricing: params.donationPricing,
+      pricingConfig: params.pricingConfig,
+      payment: params.payment,
+      amountToPayCents: params.amountToPayCents,
+    });
+    if (!validation.ok) {
+      return validation;
+    }
+
+    const { quote, donationPricing } = params;
+    const stripePresentation = params.pricingConfig.stripePresentation;
+    const donationContext =
+      donationPricing.voluntaryDonationCents > 0
+        ? {
+            voluntaryDonationCents: donationPricing.voluntaryDonationCents,
+            donationDiscountCents: donationPricing.donationDiscountCents,
+          }
+        : undefined;
+    const stripeLineItems = buildStripeCheckoutLineItems(
+      quote,
+      stripePresentation,
+      donationContext
+    );
+    const paymentAids = params.payment?.aids ?? [];
+    const invoiceCustomFields = buildStripeInvoiceCustomFields(
+      quote,
+      stripePresentation,
+      donationContext,
+      paymentAids
+    );
+
+    const aidDiscountCents = sumPaymentAidDiscountCents(paymentAids);
+
+    const discountCouponIds = await createCheckoutDiscountCouponIds({
+      registrationId: params.registrationId,
+      donationDiscountCents: donationPricing.donationDiscountCents,
+      donationDiscountCouponName: stripePresentation.donationDiscountCouponName,
+      aids: paymentAids,
+    });
+
+    const session = await createMembershipCheckoutSession({
+      registrationId: params.registrationId,
+      lineItems: stripeLineItems,
+      customerEmail: params.paymentEmail,
+      customerName: params.adherentName,
+      invoiceDescription: renderInvoiceHeader(stripePresentation.invoiceHeaderTemplate, {
+        clubName: params.pricingConfig.meta.clubName,
+        registrationId: params.registrationId,
+        adherentName: params.adherentName,
+      }),
+      catalogVersion: quote.catalogVersion,
+      quoteHash: hashPriceQuote(quote),
+      invoiceCustomFields,
+      discountCouponIds,
+      donationCents: donationPricing.voluntaryDonationCents,
+      donationDiscountCents: donationPricing.donationDiscountCents,
+      successUrl: params.successUrl,
+      cancelUrl: params.cancelUrl,
+    });
+
+    return {
+      ok: true,
+      result: {
+        session: { id: session.id, url: session.url },
+        legacy: false,
+        stripeLineItems,
+        aidDiscountCents,
+      },
+    };
+  }
+
+  const session = await createLegacySingleLineCheckoutSession({
+    registrationId: params.registrationId,
+    amountCents: params.amountToPayCents,
+    customerEmail: params.paymentEmail,
+    adherentName: params.adherentName,
+    successUrl: params.successUrl,
+    cancelUrl: params.cancelUrl,
+  });
+
+  return {
+    ok: true,
+    result: {
+      session: { id: session.id, url: session.url },
+      legacy: true,
+    },
+  };
+}
+
+export async function persistSelfServiceStripeCheckout(params: {
+  docRef: DocumentReference;
+  checkout: StripeCheckoutSessionResult;
+}): Promise<void> {
+  await params.docRef.set(
+    {
+      stripeCheckoutSessionId: params.checkout.session.id,
+      stripeCheckoutUrl: params.checkout.session.url,
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+}

--- a/src/lib/club-registration/resolve-registration-donation.test.ts
+++ b/src/lib/club-registration/resolve-registration-donation.test.ts
@@ -1,0 +1,30 @@
+import { calculateQuote } from "@/lib/pricing/calculate-quote";
+import { isValidVoluntaryDonationCents } from "@/lib/pricing/donation-discount";
+import {
+  readVoluntaryDonationCents,
+  resolveRegistrationDonationPricing,
+} from "./resolve-registration-donation";
+
+describe("resolve-registration-donation", () => {
+  it("lit le don depuis le dossier Firestore", () => {
+    expect(readVoluntaryDonationCents({ voluntaryDonationCents: 5000 })).toBe(5000);
+    expect(readVoluntaryDonationCents({})).toBe(0);
+    expect(readVoluntaryDonationCents({ voluntaryDonationCents: -1 })).toBe(0);
+  });
+
+  it("rejette un don invalide", () => {
+    const quote = calculateQuote({
+      birthDate: "2014-06-01",
+      mainSectionId: "voisins",
+      wantsCompetitorExtras: false,
+      wantsOptionalJersey: false,
+      competitionIds: [],
+      familyRegistrationOrder: "none",
+      sex: "male",
+    });
+    expect(() =>
+      resolveRegistrationDonationPricing(quote, { voluntaryDonationCents: 50 })
+    ).toThrow("Montant de don invalide");
+    expect(isValidVoluntaryDonationCents(50)).toBe(false);
+  });
+});

--- a/src/lib/club-registration/resolve-registration-donation.ts
+++ b/src/lib/club-registration/resolve-registration-donation.ts
@@ -1,0 +1,25 @@
+import type { PriceQuote } from "@/lib/pricing/types";
+import {
+  isValidVoluntaryDonationCents,
+  resolveDonationPricing,
+  type DonationPricingBreakdown,
+} from "@/lib/pricing/donation-discount";
+
+export function readVoluntaryDonationCents(data: Record<string, unknown>): number {
+  const value = data.voluntaryDonationCents;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return 0;
+  }
+  return value;
+}
+
+export function resolveRegistrationDonationPricing(
+  quote: PriceQuote,
+  data: Record<string, unknown>
+): DonationPricingBreakdown {
+  const voluntaryDonationCents = readVoluntaryDonationCents(data);
+  if (!isValidVoluntaryDonationCents(voluntaryDonationCents)) {
+    throw new Error("Montant de don invalide (0 ou minimum 1 €).");
+  }
+  return resolveDonationPricing(quote, voluntaryDonationCents);
+}

--- a/src/lib/club-registration/resolve-registration-payment-status.test.ts
+++ b/src/lib/club-registration/resolve-registration-payment-status.test.ts
@@ -1,0 +1,25 @@
+import { resolveRegistrationPaymentStatus } from "./resolve-registration-payment-status";
+
+describe("resolveRegistrationPaymentStatus", () => {
+  it("considère payé si paidAt est renseigné malgré paymentStatus legacy pending", () => {
+    expect(
+      resolveRegistrationPaymentStatus({
+        paymentStatus: "pending",
+        paidAt: "2026-06-27T08:31:30.000Z",
+      })
+    ).toBe("paid");
+  });
+
+  it("mappe pending vers waiting_payment sans paidAt", () => {
+    expect(resolveRegistrationPaymentStatus({ paymentStatus: "pending" })).toBe(
+      "waiting_payment"
+    );
+  });
+
+  it("lit les statuts canoniques", () => {
+    expect(
+      resolveRegistrationPaymentStatus({ paymentStatus: "waiting_payment" })
+    ).toBe("waiting_payment");
+    expect(resolveRegistrationPaymentStatus({ paymentStatus: "paid" })).toBe("paid");
+  });
+});

--- a/src/lib/club-registration/resolve-registration-payment-status.ts
+++ b/src/lib/club-registration/resolve-registration-payment-status.ts
@@ -1,0 +1,37 @@
+import {
+  PAYMENT_STATUS_IDS,
+  type PaymentStatusId,
+} from "@/lib/club-registration/payment-constants";
+
+type PaymentStatusRecord = Record<string, unknown>;
+
+/**
+ * Statut de paiement affiché / filtré, en tenant compte des champs legacy Firestore
+ * (`pending`, `complete`) et des indicateurs de règlement effectif (`paidAt`, `status`).
+ */
+export function resolveRegistrationPaymentStatus(
+  record: PaymentStatusRecord
+): PaymentStatusId | null {
+  if (record.status === "paid" || record.paidAt != null) {
+    return "paid";
+  }
+
+  const raw = record.paymentStatus;
+  if (typeof raw !== "string" || !raw) {
+    return null;
+  }
+
+  if (raw === "complete" || raw === "paid") {
+    return "paid";
+  }
+
+  if (raw === "pending") {
+    return "waiting_payment";
+  }
+
+  if ((PAYMENT_STATUS_IDS as readonly string[]).includes(raw)) {
+    return raw as PaymentStatusId;
+  }
+
+  return null;
+}

--- a/src/lib/club-registration/self-service-checkout.test.ts
+++ b/src/lib/club-registration/self-service-checkout.test.ts
@@ -1,0 +1,152 @@
+import {
+  canSelfServiceCheckout,
+  isAwaitingNonCardPayment,
+  resolveSelfServicePayableCents,
+} from "./self-service-checkout";
+
+describe("self-service-checkout", () => {
+  it("autorise le paiement en ligne pour carte et paiement demandé", () => {
+    expect(
+      canSelfServiceCheckout({
+        status: "payment_requested",
+        paymentAmountCents: 22_400,
+        payment: {
+          paymentMethod: "card",
+          amountToPayCents: 22_400,
+          totalAmountCents: 22_400,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 22_400,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("refuse si déjà payé ou hors carte", () => {
+    expect(
+      canSelfServiceCheckout({
+        status: "paid",
+        paymentAmountCents: 22_400,
+        payment: { paymentMethod: "card" },
+      })
+    ).toBe(false);
+
+    expect(
+      canSelfServiceCheckout({
+        status: "payment_requested",
+        paymentStatus: "pending",
+        paidAt: "2026-06-27T08:31:30.000Z",
+        paymentAmountCents: 22_400,
+        payment: {
+          paymentMethod: "card",
+          amountToPayCents: 22_400,
+          totalAmountCents: 22_400,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 22_400,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(false);
+
+    expect(
+      canSelfServiceCheckout({
+        status: "payment_requested",
+        paymentAmountCents: 22_400,
+        payment: {
+          paymentMethod: "cheque",
+          amountToPayCents: 22_400,
+          totalAmountCents: 22_400,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 22_400,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(false);
+
+    expect(
+      canSelfServiceCheckout({
+        status: "in_review",
+        paymentAmountCents: 22_400,
+        payment: { paymentMethod: "card" },
+      })
+    ).toBe(false);
+  });
+
+  it("résout le montant depuis payment ou paymentAmountCents", () => {
+    expect(
+      resolveSelfServicePayableCents({
+        paymentAmountCents: 15_000,
+        payment: {
+          paymentMethod: "card",
+          amountToPayCents: 22_400,
+          totalAmountCents: 22_400,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 22_400,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(22_400);
+    expect(resolveSelfServicePayableCents({ paymentAmountCents: 15_000 })).toBe(15_000);
+  });
+
+  it("détecte l'attente hors carte", () => {
+    expect(
+      isAwaitingNonCardPayment({
+        status: "payment_requested",
+        paymentAmountCents: 10_000,
+        payment: {
+          paymentMethod: "cheque",
+          amountToPayCents: 10_000,
+          totalAmountCents: 10_000,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 10_000,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(true);
+    expect(
+      isAwaitingNonCardPayment({
+        status: "payment_requested",
+        paymentAmountCents: 10_000,
+        payment: {
+          paymentMethod: "card",
+          amountToPayCents: 10_000,
+          totalAmountCents: 10_000,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 10_000,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lib/club-registration/self-service-checkout.ts
+++ b/src/lib/club-registration/self-service-checkout.ts
@@ -1,0 +1,48 @@
+import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
+import type { PaymentMethodId } from "@/lib/club-registration/payment-constants";
+
+export type SelfServiceCheckoutRecord = Record<string, unknown> & {
+  status?: string;
+  paymentStatus?: string;
+  paymentAmountCents?: number;
+};
+
+export function resolveRegistrationPaymentMethod(
+  data: SelfServiceCheckoutRecord
+): PaymentMethodId | null {
+  const payment = normalizeRegistrationPayment(data);
+  return payment?.paymentMethod ?? null;
+}
+
+export function resolveSelfServicePayableCents(data: SelfServiceCheckoutRecord): number {
+  const payment = normalizeRegistrationPayment(data);
+  if (payment && payment.amountToPayCents > 0) {
+    return payment.amountToPayCents;
+  }
+  if (typeof data.paymentAmountCents === "number" && data.paymentAmountCents > 0) {
+    return data.paymentAmountCents;
+  }
+  return 0;
+}
+
+export function canSelfServiceCheckout(data: SelfServiceCheckoutRecord): boolean {
+  if (data.status !== "payment_requested") {
+    return false;
+  }
+  if (isRegistrationPaidRecord(data)) {
+    return false;
+  }
+  if (resolveRegistrationPaymentMethod(data) !== "card") {
+    return false;
+  }
+  return resolveSelfServicePayableCents(data) > 0;
+}
+
+export function isAwaitingNonCardPayment(data: SelfServiceCheckoutRecord): boolean {
+  if (data.status !== "payment_requested" || isRegistrationPaidRecord(data)) {
+    return false;
+  }
+  const method = resolveRegistrationPaymentMethod(data);
+  return method != null && method !== "card" && resolveSelfServicePayableCents(data) > 0;
+}

--- a/src/lib/club-registration/spreadsheet/column-labels.ts
+++ b/src/lib/club-registration/spreadsheet/column-labels.ts
@@ -72,6 +72,8 @@ export const SPREADSHEET_COLUMN_LABELS: Record<SpreadsheetColumnId, string> = {
   remainingPaymentMethod: "Solde à régler par",
   paymentNote: "Note paiement",
   specialPaymentNote: "Note paiement spéciale",
+  voluntaryDonationCents: "Don libre (centimes)",
+  donationDiscountCents: "Remise don (centimes)",
   submittedAt: "Soumis le",
   updatedAt: "Mis à jour le",
 };

--- a/src/lib/club-registration/spreadsheet/format-cell-value.ts
+++ b/src/lib/club-registration/spreadsheet/format-cell-value.ts
@@ -11,9 +11,9 @@ import {
   PAYMENT_STATUS_LABELS,
   REMAINING_PAYMENT_METHOD_LABELS,
   type PaymentMethodId,
-  type PaymentStatusId,
   type RemainingPaymentMethodId,
 } from "@/lib/club-registration/payment-constants";
+import { resolveRegistrationPaymentStatus } from "@/lib/club-registration/resolve-registration-payment-status";
 import {
   REGISTRATION_STATUS_LABELS,
   type RegistrationStatus,
@@ -250,10 +250,10 @@ export function formatSpreadsheetCellValue(
       return typeof value === "string"
         ? (REGISTRATION_STATUS_LABELS[value as RegistrationStatus] ?? value)
         : "";
-    case "paymentStatus":
-      return typeof value === "string"
-        ? (PAYMENT_STATUS_LABELS[value as PaymentStatusId] ?? value)
-        : "";
+    case "paymentStatus": {
+      const resolved = resolveRegistrationPaymentStatus(row);
+      return resolved ? PAYMENT_STATUS_LABELS[resolved] : "";
+    }
     case "paymentMethod":
       return typeof value === "string"
         ? (PAYMENT_METHOD_LABELS[value as PaymentMethodId] ?? value)
@@ -264,6 +264,8 @@ export function formatSpreadsheetCellValue(
         : "";
     case "paymentAmountCents":
     case "holidayVoucherAmountCents":
+    case "voluntaryDonationCents":
+    case "donationDiscountCents":
       return formatCents(value);
     case "submittedAt":
     case "updatedAt":

--- a/src/lib/club-registration/spreadsheet/quick-filters.ts
+++ b/src/lib/club-registration/spreadsheet/quick-filters.ts
@@ -12,9 +12,9 @@ import {
 } from "@/lib/club-registration/registration-status";
 import {
   PAYMENT_STATUS_LABELS,
-  PAYMENT_STATUS_IDS,
   type PaymentStatusId,
 } from "@/lib/club-registration/payment-constants";
+import { resolveRegistrationPaymentStatus } from "@/lib/club-registration/resolve-registration-payment-status";
 
 export type SpreadsheetQuickFilters = {
   registrationStatuses: RegistrationStatus[];
@@ -113,11 +113,7 @@ export function getRowRegistrationStatus(
 }
 
 export function getRowPaymentStatus(row: RegistrationClientRecord): PaymentStatusId | null {
-  const status = row.paymentStatus;
-  return typeof status === "string" &&
-    (PAYMENT_STATUS_IDS as readonly string[]).includes(status)
-    ? (status as PaymentStatusId)
-    : null;
+  return resolveRegistrationPaymentStatus(row);
 }
 
 export function getRowMedicalCertificateStatus(

--- a/src/lib/club-registration/stripe-checkout-discounts.test.ts
+++ b/src/lib/club-registration/stripe-checkout-discounts.test.ts
@@ -1,0 +1,65 @@
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import {
+  assertStripePayableAfterDiscounts,
+  buildMergedCheckoutDiscountCouponName,
+  computeSecretariatAidDiscountCents,
+  sumPaymentAidDiscountCents,
+} from "./stripe-checkout-discounts";
+
+describe("stripe-checkout-discounts", () => {
+  it("calcule la remise aides secrétariat", () => {
+    expect(computeSecretariatAidDiscountCents(27_500, 22_500)).toBe(5_000);
+    expect(computeSecretariatAidDiscountCents(20_000, 20_000)).toBe(0);
+  });
+
+  it("valide le net après remise don (déjà dans la facture) et aides", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 37_400,
+        donationDiscountCents: 5_000,
+        aidDiscountCents: 2_000,
+        amountToPayCents: 35_400,
+      })
+    ).not.toThrow();
+  });
+
+  it("valide le net sans aide secrétariat", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 27_500,
+        donationDiscountCents: 2_500,
+        aidDiscountCents: 0,
+        amountToPayCents: 27_500,
+      })
+    ).not.toThrow();
+  });
+
+  it("rejette une incohérence montant / remises", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 37_400,
+        donationDiscountCents: 5_000,
+        aidDiscountCents: 2_000,
+        amountToPayCents: 30_400,
+      })
+    ).toThrow("Incohérence montant Stripe");
+  });
+
+  it("fusionne remise don et aides en un libellé coupon", () => {
+    expect(
+      buildMergedCheckoutDiscountCouponName({
+        donationDiscountCents: 5_000,
+        donationDiscountCouponName: "Remise don libre",
+        aids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 2_000 }],
+      })
+    ).toBe("Remise don libre + Pass Sport");
+  });
+
+  it("somme les aides", () => {
+    const aids: PaymentAid[] = [
+      { type: "pass_sport", label: "Pass Sport", amountCents: 5_000 },
+      { type: "labaz", label: "Labaz", amountCents: 0 },
+    ];
+    expect(sumPaymentAidDiscountCents(aids)).toBe(5_000);
+  });
+});

--- a/src/lib/club-registration/stripe-checkout-discounts.ts
+++ b/src/lib/club-registration/stripe-checkout-discounts.ts
@@ -1,0 +1,105 @@
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import { createAmountOffCheckoutCoupon } from "@/lib/club-registration/stripe";
+
+const STRIPE_COUPON_NAME_MAX = 40;
+
+function truncateCouponName(label: string): string {
+  const trimmed = label.trim();
+  if (trimmed.length <= STRIPE_COUPON_NAME_MAX) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, STRIPE_COUPON_NAME_MAX - 1)}…`;
+}
+
+/** Libellé du coupon unique (Checkout Stripe : 1 seul coupon autorisé par session). */
+export function buildMergedCheckoutDiscountCouponName(params: {
+  donationDiscountCents: number;
+  donationDiscountCouponName: string;
+  aids: PaymentAid[];
+}): string {
+  const activeAids = params.aids.filter((aid) => aid.amountCents > 0);
+  const hasDonation = params.donationDiscountCents > 0;
+
+  if (hasDonation && activeAids.length === 0) {
+    return params.donationDiscountCouponName;
+  }
+  if (!hasDonation && activeAids.length === 1) {
+    return activeAids[0]!.label;
+  }
+  if (!hasDonation && activeAids.length > 1) {
+    return "Remises aides secrétariat";
+  }
+  if (hasDonation && activeAids.length === 1) {
+    return `${params.donationDiscountCouponName} + ${activeAids[0]!.label}`;
+  }
+  return "Remises adhésion";
+}
+
+/** Montant total des coupons « aides secrétariat » à appliquer sur la facture. */
+export function computeSecretariatAidDiscountCents(
+  invoiceTotalCents: number,
+  amountToPayCents: number
+): number {
+  return Math.max(0, invoiceTotalCents - amountToPayCents);
+}
+
+export function sumPaymentAidDiscountCents(aids: PaymentAid[]): number {
+  return aids.reduce((sum, aid) => sum + Math.max(0, aid.amountCents), 0);
+}
+
+/**
+ * Vérifie que le reste à payer correspond au net Stripe attendu.
+ *
+ * `invoiceTotalCents` = catalogue + don − remise don (déjà net de la remise don).
+ * Seules les aides secrétariat réduisent encore le montant encaissé ; la remise don
+ * est un coupon Stripe distinct mais déjà reflétée dans `invoiceTotalCents`.
+ */
+export function assertStripePayableAfterDiscounts(params: {
+  invoiceTotalCents: number;
+  donationDiscountCents: number;
+  aidDiscountCents: number;
+  amountToPayCents: number;
+}): void {
+  void params.donationDiscountCents;
+  const expectedPayable = params.invoiceTotalCents - params.aidDiscountCents;
+  if (expectedPayable !== params.amountToPayCents) {
+    throw new Error(
+      `Incohérence montant Stripe : facture ${params.invoiceTotalCents} cts, aides ${params.aidDiscountCents} cts, attendu ${params.amountToPayCents} cts, calculé ${expectedPayable} cts`
+    );
+  }
+}
+
+/**
+ * Crée le coupon Stripe de remise (un seul : limite API Checkout).
+ * Remise don + aides secrétariat sont fusionnées ; le détail figure sur la facture
+ * (champs personnalisés).
+ */
+export async function createCheckoutDiscountCouponIds(params: {
+  registrationId: string;
+  donationDiscountCents: number;
+  donationDiscountCouponName: string;
+  aids: PaymentAid[];
+}): Promise<string[]> {
+  const aidTotal = sumPaymentAidDiscountCents(params.aids);
+  const donationDiscount = Math.max(0, params.donationDiscountCents);
+  const totalOff = donationDiscount + aidTotal;
+
+  if (totalOff <= 0) {
+    return [];
+  }
+
+  const couponId = await createAmountOffCheckoutCoupon({
+    registrationId: params.registrationId,
+    amountOffCents: totalOff,
+    name: truncateCouponName(
+      buildMergedCheckoutDiscountCouponName({
+        donationDiscountCents: donationDiscount,
+        donationDiscountCouponName: params.donationDiscountCouponName,
+        aids: params.aids,
+      })
+    ),
+    kind: "merged_checkout_discount",
+  });
+
+  return [couponId];
+}

--- a/src/lib/club-registration/stripe-invoice.test.ts
+++ b/src/lib/club-registration/stripe-invoice.test.ts
@@ -9,6 +9,13 @@ function mockStripeFetch() {
   global.fetch = jest.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
 
+    if (url.includes("/v1/customers?")) {
+      return {
+        ok: true,
+        json: async () => ({ data: [] }),
+      } as Response;
+    }
+
     if (url.endsWith("/v1/customers")) {
       return {
         ok: true,
@@ -59,27 +66,49 @@ describe("createPaidOutOfBandInvoice", () => {
     delete process.env.STRIPE_SECRET_KEY;
   });
 
-  it("crée, finalise et marque payée une facture Stripe hors ligne", async () => {
+  it("crée, finalise et marque payée une facture multi-lignes", async () => {
     const result = await createPaidOutOfBandInvoice({
       registrationId: "reg_1",
       customerEmail: "adherent@example.com",
-      amountCents: 12000,
-      description: "Adhésion SQY Ping — Ada Lovelace",
+      customerName: "Ada Lovelace",
+      invoiceDescription: "Adhésion SQY Ping — Ada Lovelace",
+      lineItems: [
+        { name: "Adhésion club", amountCents: 10_000 },
+        { name: "Licence", amountCents: 2_000 },
+      ],
     });
 
     expect(result).toEqual({ invoiceId: "in_paid" });
-    expect(global.fetch).toHaveBeenCalledTimes(5);
+    expect(global.fetch).toHaveBeenCalledTimes(7);
   });
 
-  it("refuse un montant nul ou négatif", async () => {
+  it("applique plusieurs coupons de remise", async () => {
+    const result = await createPaidOutOfBandInvoice({
+      registrationId: "reg_1",
+      customerEmail: "adherent@example.com",
+      customerName: "Ada Lovelace",
+      invoiceDescription: "Adhésion SQY Ping — Ada Lovelace",
+      lineItems: [
+        { name: "Adhésion club", amountCents: 10_000 },
+        { name: "Don libre au club", amountCents: 4_000 },
+      ],
+      discountCouponIds: ["coupon_don", "coupon_pass_sport"],
+    });
+
+    expect(result).toEqual({ invoiceId: "in_paid" });
+    expect(global.fetch).toHaveBeenCalledTimes(7);
+  });
+
+  it("refuse une facture sans lignes", async () => {
     await expect(
       createPaidOutOfBandInvoice({
         registrationId: "reg_1",
         customerEmail: "adherent@example.com",
-        amountCents: 0,
-        description: "Adhésion SQY Ping — Ada Lovelace",
+        customerName: "Ada Lovelace",
+        invoiceDescription: "Adhésion SQY Ping — Ada Lovelace",
+        lineItems: [],
       })
-    ).rejects.toThrow("Montant de facture invalide");
+    ).rejects.toThrow("Aucune ligne de facture");
   });
 });
 

--- a/src/lib/club-registration/stripe.ts
+++ b/src/lib/club-registration/stripe.ts
@@ -29,6 +29,40 @@ export function getAppBaseUrl(req: Request): string {
   return resolveAppOrigin(req);
 }
 
+export async function createAmountOffCheckoutCoupon(params: {
+  registrationId: string;
+  amountOffCents: number;
+  name: string;
+  kind?: string;
+}): Promise<string> {
+  if (params.amountOffCents <= 0) {
+    throw new Error("Montant de remise invalide");
+  }
+
+  const body = new URLSearchParams();
+  body.set("duration", "once");
+  body.set("amount_off", String(params.amountOffCents));
+  body.set("currency", "eur");
+  body.set("name", params.name);
+  body.set("metadata[registrationId]", params.registrationId);
+  body.set("metadata[kind]", params.kind ?? "checkout_discount");
+
+  const coupon = await postStripeForm<{ id: string }>("/v1/coupons", body);
+  return coupon.id;
+}
+
+/** Coupon de remise liée au don libre (25 %, plaf. 73 €). */
+export async function createDonationDiscountCoupon(params: {
+  registrationId: string;
+  amountOffCents: number;
+  name: string;
+}): Promise<string> {
+  return createAmountOffCheckoutCoupon({
+    ...params,
+    kind: "donation_discount",
+  });
+}
+
 export async function createMembershipCheckoutSession(params: {
   registrationId: string;
   lineItems: StripeCheckoutLineItem[];
@@ -43,6 +77,10 @@ export async function createMembershipCheckoutSession(params: {
   cancelUrl: string;
   /** Champs informatifs sur la facture (ex. détail des remises). */
   invoiceCustomFields?: StripeInvoiceCustomField[];
+  /** Coupons Stripe (remise don, aides secrétariat…) appliqués à la session Checkout. */
+  discountCouponIds?: string[];
+  donationCents?: number;
+  donationDiscountCents?: number;
 }): Promise<StripeCheckoutSession> {
   if (params.lineItems.length === 0) {
     throw new Error("Au moins une ligne de paiement est requise.");
@@ -63,9 +101,20 @@ export async function createMembershipCheckoutSession(params: {
   body.set("metadata[registrationId]", params.registrationId);
   body.set("metadata[catalogVersion]", params.catalogVersion);
   body.set("metadata[quoteHash]", params.quoteHash);
+  if (params.donationCents != null && params.donationCents > 0) {
+    body.set("metadata[donationCents]", String(params.donationCents));
+  }
+  if (params.donationDiscountCents != null && params.donationDiscountCents > 0) {
+    body.set("metadata[donationDiscountCents]", String(params.donationDiscountCents));
+  }
   body.set("payment_intent_data[metadata][registrationId]", params.registrationId);
   body.set("payment_intent_data[metadata][catalogVersion]", params.catalogVersion);
   body.set("payment_intent_data[metadata][quoteHash]", params.quoteHash);
+  const expiresAt = Math.floor(Date.now() / 1000) + 24 * 60 * 60;
+  body.set("expires_at", String(expiresAt));
+  (params.discountCouponIds ?? []).forEach((couponId, index) => {
+    body.set(`discounts[${index}][coupon]`, couponId);
+  });
   body.set("invoice_creation[enabled]", "true");
   body.set("invoice_creation[invoice_data][description]", params.invoiceDescription);
 
@@ -257,38 +306,51 @@ export async function retrieveStripeInvoiceLinks(
   };
 }
 
-/**
- * Crée une facture Stripe "payée hors ligne" pour les encaissements manuels.
- * Permet d'avoir un format de facture homogène (Checkout + hors Checkout).
- */
-export async function createPaidOutOfBandInvoice(params: {
+export type PaidOutOfBandInvoiceParams = {
   registrationId: string;
   customerEmail: string;
-  amountCents: number;
-  description: string;
-}): Promise<{ invoiceId: string }> {
-  if (params.amountCents <= 0) {
-    throw new Error("Montant de facture invalide");
+  customerName: string;
+  invoiceDescription: string;
+  lineItems: StripeCheckoutLineItem[];
+  /** Coupons à appliquer (remise don, aides…), dans l'ordre d'affichage souhaité. */
+  discountCouponIds?: string[];
+};
+
+/**
+ * Crée une facture Stripe "payée hors ligne" pour les encaissements manuels.
+ * Même ventilation multi-lignes (+ coupon remise don) que le Checkout.
+ */
+export async function createPaidOutOfBandInvoice(
+  params: PaidOutOfBandInvoiceParams
+): Promise<{ invoiceId: string }> {
+  if (params.lineItems.length === 0) {
+    throw new Error("Aucune ligne de facture");
   }
 
-  const customerBody = new URLSearchParams();
-  customerBody.set("email", params.customerEmail);
-  customerBody.set("metadata[registrationId]", params.registrationId);
-  const customer = await postStripeForm<{ id: string }>("/v1/customers", customerBody);
+  const customerId = await findOrCreateStripeCheckoutCustomer({
+    registrationId: params.registrationId,
+    customerEmail: params.customerEmail,
+    customerName: params.customerName,
+  });
 
-  const invoiceItemBody = new URLSearchParams();
-  invoiceItemBody.set("customer", customer.id);
-  invoiceItemBody.set("currency", "eur");
-  invoiceItemBody.set("amount", String(params.amountCents));
-  invoiceItemBody.set("description", `Adhésion SQY Ping — dossier ${params.registrationId}`);
-  await postStripeForm<{ id: string }>("/v1/invoiceitems", invoiceItemBody);
+  for (const item of params.lineItems) {
+    const invoiceItemBody = new URLSearchParams();
+    invoiceItemBody.set("customer", customerId);
+    invoiceItemBody.set("currency", "eur");
+    invoiceItemBody.set("amount", String(item.amountCents));
+    invoiceItemBody.set("description", item.description ?? item.name);
+    await postStripeForm<{ id: string }>("/v1/invoiceitems", invoiceItemBody);
+  }
 
   const invoiceBody = new URLSearchParams();
-  invoiceBody.set("customer", customer.id);
-  invoiceBody.set("description", params.description);
+  invoiceBody.set("customer", customerId);
+  invoiceBody.set("description", params.invoiceDescription);
   invoiceBody.set("collection_method", "send_invoice");
   invoiceBody.set("auto_advance", "false");
   invoiceBody.set("metadata[registrationId]", params.registrationId);
+  (params.discountCouponIds ?? []).forEach((couponId, index) => {
+    invoiceBody.set(`discounts[${index}][coupon]`, couponId);
+  });
   const draftInvoice = await postStripeForm<StripeInvoice>("/v1/invoices", invoiceBody);
 
   const finalizedInvoice = await postStripeForm<StripeInvoice>(

--- a/src/lib/club-registration/validate-admin-aids.ts
+++ b/src/lib/club-registration/validate-admin-aids.ts
@@ -14,6 +14,8 @@ type DraftSlice = Pick<
   RegistrationDraft,
   | "birthDate"
   | "mainSectionId"
+  | "slotIds"
+  | "additionalSectionIds"
   | "wantsCompetitorExtras"
   | "wantsOptionalJersey"
   | "competitionIds"
@@ -34,6 +36,8 @@ function quoteTotalCents(
     buildPricingContext({
       birthDate: draft.birthDate,
       mainSectionId: draft.mainSectionId,
+      slotIds: draft.slotIds ?? [],
+      additionalSectionIds: draft.additionalSectionIds ?? [],
       wantsCompetitorExtras: draft.wantsCompetitorExtras,
       wantsOptionalJersey: draft.wantsOptionalJersey,
       competitionIds: draft.competitionIds,

--- a/src/lib/email/donation-breakdown-email.ts
+++ b/src/lib/email/donation-breakdown-email.ts
@@ -1,0 +1,76 @@
+import { SQYPING_COLORS } from "@/lib/email/brand";
+import { escapeHtml } from "@/lib/email/escape-html";
+import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
+import { formatEurosForEmail } from "@/lib/email/format-euros";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+
+export function formatSecretariatAidsBreakdownText(aids: PaymentAid[]): string {
+  return aids
+    .filter((aid) => aid.amountCents > 0)
+    .map((aid) => `  - ${aid.label} : −${formatEurosForEmail(aid.amountCents)}`)
+    .join("\n");
+}
+
+export function formatSecretariatAidsBreakdownHtml(aids: PaymentAid[]): string {
+  return aids
+    .filter((aid) => aid.amountCents > 0)
+    .map(
+      (aid) => `
+    <tr>
+      <td style="padding: 10px 12px; font-size: 15px; color: ${SQYPING_COLORS.text.primary}; border-bottom: 1px solid ${SQYPING_COLORS.surface.divider};">
+        ${escapeHtml(aid.label)}
+      </td>
+      <td align="right" style="padding: 10px 12px; font-size: 15px; font-weight: 600; color: ${SQYPING_COLORS.text.primary}; border-bottom: 1px solid ${SQYPING_COLORS.surface.divider}; white-space: nowrap;">
+        −${escapeHtml(formatEurosForEmail(aid.amountCents))}
+      </td>
+    </tr>
+  `
+    )
+    .join("");
+}
+
+export function formatDonationBreakdownText(
+  donation: DonationPricingBreakdown
+): string {
+  if (donation.voluntaryDonationCents <= 0) {
+    return "";
+  }
+  return [
+    `  - Don libre au club : ${formatEurosForEmail(donation.voluntaryDonationCents)}`,
+    `  - Remise don 25 % (plaf. 73 €) : −${formatEurosForEmail(donation.donationDiscountCents)}`,
+  ].join("\n");
+}
+
+export function formatDonationBreakdownHtml(
+  donation: DonationPricingBreakdown
+): string {
+  if (donation.voluntaryDonationCents <= 0) {
+    return "";
+  }
+
+  return `
+    <tr>
+      <td style="padding: 10px 12px; font-size: 15px; color: ${SQYPING_COLORS.text.primary}; border-bottom: 1px solid ${SQYPING_COLORS.surface.divider};">
+        Don libre au club
+      </td>
+      <td align="right" style="padding: 10px 12px; font-size: 15px; font-weight: 600; color: ${SQYPING_COLORS.text.primary}; border-bottom: 1px solid ${SQYPING_COLORS.surface.divider}; white-space: nowrap;">
+        ${escapeHtml(formatEurosForEmail(donation.voluntaryDonationCents))}
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 10px 12px; font-size: 15px; color: ${SQYPING_COLORS.text.primary}; border-bottom: 1px solid ${SQYPING_COLORS.surface.divider};">
+        Remise don 25 % (plaf. 73 €)
+      </td>
+      <td align="right" style="padding: 10px 12px; font-size: 15px; font-weight: 600; color: ${SQYPING_COLORS.text.primary}; border-bottom: 1px solid ${SQYPING_COLORS.surface.divider}; white-space: nowrap;">
+        −${escapeHtml(formatEurosForEmail(donation.donationDiscountCents))}
+      </td>
+    </tr>
+  `;
+}
+
+export function resolveEmailPayableTotalCents(
+  quoteTotalCents: number,
+  donation?: DonationPricingBreakdown | null
+): number {
+  return donation?.invoiceTotalCents ?? quoteTotalCents;
+}

--- a/src/lib/email/email-templates.test.ts
+++ b/src/lib/email/email-templates.test.ts
@@ -2,7 +2,7 @@ import { SQYPING_COLORS, SQYPING_SECRETARIAT_EMAIL } from "@/lib/email/brand";
 import { buildVerificationEmail } from "@/lib/email/auth-emails";
 import { buildPasswordResetEmail } from "@/lib/email/auth-emails";
 import { buildSqyPingEmailLayout } from "@/lib/email/layout";
-import { buildPaymentRequestEmail } from "@/lib/email/payment-email";
+import { buildPaymentRequestEmail, buildPaymentRequestEmailSubject } from "@/lib/email/payment-email";
 import { adaptEmailHtmlForFilePreview } from "@/lib/email/preview";
 import { buildPaymentConfirmedEmail } from "@/lib/email/payment-confirmed-email";
 import { buildPaymentInstructionsEmail } from "@/lib/email/payment-instructions-email";
@@ -253,11 +253,11 @@ describe("buildPaymentRequestEmail", () => {
   };
 
   it("affiche un tableau détaillé quand un devis est fourni", () => {
-    const checkoutUrl = "https://checkout.stripe.com/pay/cs_test";
+    const mesInscriptionsUrl = `${APP_ORIGIN}/club/mes-inscriptions?registration=reg-test-1`;
     const { html, text } = buildPaymentRequestEmail({
+      registrationId: "reg-test-1",
       adherentName: "Marie Dupont",
       amountCents: 15000,
-      checkoutUrl,
       appOrigin: APP_ORIGIN,
       quote,
     });
@@ -265,26 +265,54 @@ describe("buildPaymentRequestEmail", () => {
     expect(html).toContain("Marie Dupont");
     expect(html).toContain("Cotisation loisir");
     expect(html).toContain("150,00");
-    expect(html).toContain(checkoutUrl);
-    expect(html).toContain("Payer");
+    expect(html).toContain(mesInscriptionsUrl);
+    expect(html).toContain("Finaliser mon adhésion");
+    expect(html).not.toContain("checkout.stripe.com");
     expect(html).toContain(BNPL_COPY_TEST_MARKER);
     expect(html).toContain(SQYPING_SECRETARIAT_EMAIL);
     expect(text).toContain("Cotisation loisir");
     expect(text).toContain(BNPL_COPY_TEST_MARKER);
     expect(text).toContain(SQYPING_SECRETARIAT_EMAIL);
-    expect(text).toContain(checkoutUrl);
+    expect(text).toContain(mesInscriptionsUrl);
+    expect(text).toContain("Mes dossiers");
+    expect(text).toContain("24 heures");
   });
 
-  it("fonctionne sans devis détaillé (mode legacy)", () => {
-    const { html } = buildPaymentRequestEmail({
-      adherentName: "Paul Martin",
-      amountCents: 8000,
-      checkoutUrl: "https://checkout.stripe.com/pay/cs_legacy",
+  it("adapte l'objet et l'intro pour un renvoi", () => {
+    const mesInscriptionsUrl = `${APP_ORIGIN}/club/mes-inscriptions?registration=reg-test-1`;
+    const { html, text } = buildPaymentRequestEmail({
+      registrationId: "reg-test-1",
+      adherentName: "Marie Dupont",
+      amountCents: 15000,
       appOrigin: APP_ORIGIN,
-      quote: null,
+      variant: "resend",
     });
 
-    expect(html).toContain("80,00");
-    expect(html).not.toContain("Détail de votre adhésion");
+    expect(buildPaymentRequestEmailSubject("Marie Dupont", "resend")).toContain("Rappel");
+    expect(html).toContain("attend encore votre règlement");
+    expect(html).not.toContain("validé administrativement");
+    expect(html).toContain(mesInscriptionsUrl);
+    expect(text).toContain("attend encore votre règlement");
+  });
+
+  it("affiche le net après aides secrétariat dans le total", () => {
+    const { html } = buildPaymentRequestEmail({
+      registrationId: "reg-test-1",
+      adherentName: "Test User",
+      amountCents: 35_400,
+      appOrigin: APP_ORIGIN,
+      quote,
+      donationPricing: {
+        voluntaryDonationCents: 20_000,
+        donationDiscountCents: 5_000,
+        membershipNetCents: 16_000,
+        invoiceTotalCents: 37_400,
+      },
+      secretariatAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 2_000 }],
+    });
+
+    expect(html).toContain("Pass Sport");
+    expect(html).toContain("354,00");
+    expect(html).not.toMatch(/Total à régler[\s\S]*374,00/);
   });
 });

--- a/src/lib/email/format-euros.ts
+++ b/src/lib/email/format-euros.ts
@@ -1,0 +1,7 @@
+/** Formate un montant en centimes pour les e-mails (EUR fr-FR). */
+export function formatEurosForEmail(amountCents: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+  }).format(amountCents / 100);
+}

--- a/src/lib/email/layout.ts
+++ b/src/lib/email/layout.ts
@@ -36,6 +36,8 @@ export type BuildSqyPingEmailLayoutOptions = {
   /** Encart d'information ou d'avertissement. */
   noticeHtml?: string;
   noticeVariant?: EmailNoticeVariant;
+  /** Contenu affiché après le bouton et le lien de secours (mentions légales, rappels…). */
+  afterActionHtml?: string;
 };
 
 function noticeStyles(variant: EmailNoticeVariant): {
@@ -115,6 +117,7 @@ export function buildSqyPingEmailLayout(
     fallbackLink,
     noticeHtml,
     noticeVariant = "info",
+    afterActionHtml,
   } = options;
 
   const safeTitle = escapeHtml(title);
@@ -127,6 +130,7 @@ export function buildSqyPingEmailLayout(
   const actionBlock = primaryAction ? renderPrimaryAction(primaryAction) : "";
   const fallbackBlock = fallbackLink ? renderFallbackLink(fallbackLink) : "";
   const noticeBlock = noticeHtml ? renderNotice(noticeHtml, noticeVariant) : "";
+  const afterActionBlock = afterActionHtml ?? "";
 
   return `<!DOCTYPE html>
 <html lang="fr">
@@ -161,9 +165,10 @@ export function buildSqyPingEmailLayout(
                 ${safeTitle}
               </h1>
               ${bodyHtml}
+              ${noticeBlock}
               ${actionBlock}
               ${fallbackBlock}
-              ${noticeBlock}
+              ${afterActionBlock}
             </td>
           </tr>
           <tr>

--- a/src/lib/email/payment-email.ts
+++ b/src/lib/email/payment-email.ts
@@ -11,26 +11,71 @@ import {
 import {
   BNPL_PAYMENT_REQUEST_NOTICE,
   BNPL_PAYMENT_REQUEST_PARAGRAPH,
-  BNPL_PAYMENT_REQUEST_TEXT_LINE,
+  CHECKOUT_LINK_VALIDITY_FROM_MES_DOSSIERS_NOTICE,
+  PAYMENT_EMAIL_CTA_LABEL,
+  PAYMENT_EMAIL_HUB_INSTRUCTION_HTML,
+  PAYMENT_EMAIL_HUB_INSTRUCTION_TEXT,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
+import { buildMesInscriptionsUrl } from "@/lib/club-registration/mes-inscriptions-url";
 import type { PriceQuote } from "@/lib/pricing/types";
+import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
+import {
+  formatDonationBreakdownHtml,
+  formatDonationBreakdownText,
+  formatSecretariatAidsBreakdownHtml,
+  formatSecretariatAidsBreakdownText,
+  resolveEmailPayableTotalCents,
+} from "@/lib/email/donation-breakdown-email";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
 
-export function formatEurosForEmail(amountCents: number): string {
-  return new Intl.NumberFormat("fr-FR", {
-    style: "currency",
-    currency: "EUR",
-  }).format(amountCents / 100);
+import { formatEurosForEmail } from "@/lib/email/format-euros";
+
+export { formatEurosForEmail };
+
+export type QuoteBreakdownEmailOptions = {
+  /** Montant réellement à régler (après aides secrétariat). */
+  amountToPayCents?: number;
+  secretariatAids?: PaymentAid[];
+};
+
+function resolveBreakdownPayableCents(
+  quote: PriceQuote,
+  donation: DonationPricingBreakdown | null | undefined,
+  options?: QuoteBreakdownEmailOptions
+): number {
+  if (options?.amountToPayCents != null) {
+    return options.amountToPayCents;
+  }
+  return resolveEmailPayableTotalCents(quote.totalCents, donation);
 }
 
-export function formatQuoteBreakdownText(quote: PriceQuote): string {
+export function formatQuoteBreakdownText(
+  quote: PriceQuote,
+  donation?: DonationPricingBreakdown | null,
+  options?: QuoteBreakdownEmailOptions
+): string {
   const lines = quote.lines
     .filter((line) => line.kind !== "info" && line.amountCents !== 0)
     .map((line) => `  - ${line.label} : ${formatEurosForEmail(line.amountCents)}`);
+  const donationLines = donation ? formatDonationBreakdownText(donation) : "";
+  const aidLines = options?.secretariatAids?.length
+    ? formatSecretariatAidsBreakdownText(options.secretariatAids)
+    : "";
+  const payable = resolveBreakdownPayableCents(quote, donation, options);
 
-  return [...lines, `  Total : ${formatEurosForEmail(quote.totalCents)}`].join("\n");
+  return [
+    ...lines,
+    ...(donationLines ? [donationLines] : []),
+    ...(aidLines ? [aidLines] : []),
+    `  Total : ${formatEurosForEmail(payable)}`,
+  ].join("\n");
 }
 
-export function formatQuoteBreakdownHtmlForEmail(quote: PriceQuote): string {
+export function formatQuoteBreakdownHtmlForEmail(
+  quote: PriceQuote,
+  donation?: DonationPricingBreakdown | null,
+  options?: QuoteBreakdownEmailOptions
+): string {
   const rows = quote.lines
     .filter((line) => line.kind !== "info" && line.amountCents !== 0)
     .map(
@@ -46,54 +91,104 @@ export function formatQuoteBreakdownHtmlForEmail(quote: PriceQuote): string {
       `
     )
     .join("");
+  const donationRows = donation ? formatDonationBreakdownHtml(donation) : "";
+  const aidRows = options?.secretariatAids?.length
+    ? formatSecretariatAidsBreakdownHtml(options.secretariatAids)
+    : "";
+  const payable = resolveBreakdownPayableCents(quote, donation, options);
 
   return `
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 8px 0; border: 1px solid ${SQYPING_COLORS.surface.divider}; border-radius: 12px; overflow: hidden;">
       ${rows}
+      ${donationRows}
+      ${aidRows}
       <tr style="background-color: rgba(40, 48, 109, 0.04);">
         <td style="padding: 12px; font-size: 15px; font-weight: 700; color: ${SQYPING_COLORS.primary.main};">
           Total à régler
         </td>
         <td align="right" style="padding: 12px; font-size: 16px; font-weight: 700; color: ${SQYPING_COLORS.primary.main}; white-space: nowrap;">
-          ${escapeHtml(formatEurosForEmail(quote.totalCents))}
+          ${escapeHtml(formatEurosForEmail(payable))}
         </td>
       </tr>
     </table>
   `;
 }
 
+export type PaymentRequestEmailVariant = "initial" | "resend";
+
 export type PaymentRequestEmailContent = {
+  registrationId: string;
   adherentName: string;
   amountCents: number;
-  checkoutUrl: string;
   appOrigin: string;
   quote?: PriceQuote | null;
+  donationPricing?: DonationPricingBreakdown | null;
+  secretariatAids?: PaymentAid[];
+  variant?: PaymentRequestEmailVariant;
 };
+
+export function buildPaymentRequestEmailSubject(
+  adherentName: string,
+  variant: PaymentRequestEmailVariant = "initial"
+): string {
+  if (variant === "resend") {
+    return `Rappel — paiement de votre adhésion SQY Ping - ${adherentName}`;
+  }
+  return `Paiement de votre adhésion SQY Ping - ${adherentName}`;
+}
 
 export function buildPaymentRequestEmail(
   options: PaymentRequestEmailContent
 ): { html: string; text: string } {
-  const { adherentName, amountCents, checkoutUrl, appOrigin, quote } = options;
+  const {
+    registrationId,
+    adherentName,
+    amountCents,
+    appOrigin,
+    quote,
+    donationPricing,
+    secretariatAids,
+    variant = "initial",
+  } = options;
   const safeName = escapeHtml(adherentName);
   const formattedAmount = formatEurosForEmail(amountCents);
   const hasDetailedQuote = Boolean(quote && quote.lines.length > 0);
+  const mesInscriptionsUrl = buildMesInscriptionsUrl(appOrigin, registrationId);
+  const breakdownOptions: QuoteBreakdownEmailOptions = {
+    amountToPayCents: amountCents,
+    ...(secretariatAids?.length ? { secretariatAids } : {}),
+  };
 
   const breakdownBlock = hasDetailedQuote
-    ? `${emailSectionTitle("Détail de votre adhésion")}${formatQuoteBreakdownHtmlForEmail(quote!)}`
+    ? `${emailSectionTitle("Détail de votre adhésion")}${formatQuoteBreakdownHtmlForEmail(quote!, donationPricing, breakdownOptions)}`
     : emailParagraph(
         `Montant à régler : <strong style="color: ${SQYPING_COLORS.primary.main};">${escapeHtml(formattedAmount)}</strong>`
       );
 
+  const introHtml =
+    variant === "resend"
+      ? emailParagraph(
+          `Rappel&nbsp;: votre adhésion <strong>SQY Ping</strong> attend encore votre règlement.`
+        )
+      : emailParagraph(
+          `Bonne nouvelle&nbsp;: votre dossier d'adhésion <strong>SQY Ping</strong> a été relu et <strong>validé administrativement</strong> par le secrétariat.`
+        );
+
+  const introText =
+    variant === "resend"
+      ? "Rappel : votre adhésion SQY Ping attend encore votre règlement."
+      : "Votre dossier d'adhésion SQY Ping a été relu et validé administrativement.";
+
   const bodyHtml = [
     emailParagraph(`Bonjour${adherentName ? ` <strong>${safeName}</strong>` : ""},`),
-    emailParagraph(
-      `Bonne nouvelle&nbsp;: votre dossier d'adhésion <strong>SQY Ping</strong> a été relu et <strong>validé administrativement</strong> par le secrétariat.`
-    ),
-    emailParagraph(
-      "Vous pouvez maintenant procéder au règlement en ligne via notre plateforme de paiement sécurisée Stripe."
-    ),
+    introHtml,
+    emailParagraph(PAYMENT_EMAIL_HUB_INSTRUCTION_HTML),
     emailParagraph(BNPL_PAYMENT_REQUEST_PARAGRAPH),
     breakdownBlock,
+  ].join("");
+
+  const afterActionHtml = [
+    emailMutedParagraph(CHECKOUT_LINK_VALIDITY_FROM_MES_DOSSIERS_NOTICE),
     emailMutedParagraph(
       "Après paiement, une facture détaillée vous sera transmise automatiquement par Stripe à la même adresse e-mail."
     ),
@@ -103,39 +198,49 @@ export function buildPaymentRequestEmail(
   ].join("");
 
   const html = buildSqyPingEmailLayout({
-    title: "Paiement de votre adhésion",
-    preheader: `Votre adhésion SQY Ping est validée — montant : ${formattedAmount}.`,
+    title: variant === "resend" ? "Rappel — paiement de votre adhésion" : "Paiement de votre adhésion",
+    preheader:
+      variant === "resend"
+        ? `Finalisez votre adhésion SQY Ping — montant : ${formattedAmount}.`
+        : `Votre adhésion SQY Ping est validée — montant : ${formattedAmount}.`,
     bodyHtml,
     appOrigin,
     primaryAction: {
-      label: "Payer en ligne",
-      url: checkoutUrl,
+      label: PAYMENT_EMAIL_CTA_LABEL,
+      url: mesInscriptionsUrl,
     },
-    fallbackLink: checkoutUrl,
+    fallbackLink: mesInscriptionsUrl,
     noticeHtml: `
       <p style="margin: 0; font-size: 14px; line-height: 1.6;">
-        <strong>Paiement sécurisé</strong> — vous serez redirigé(e) vers Stripe. ${escapeHtml(BNPL_PAYMENT_REQUEST_NOTICE)} Aucune donnée bancaire n'est collectée par ${escapeHtml(SQYPING_EMAIL_APP_NAME)}.
+        <strong>Paiement sécurisé</strong> — depuis Mes dossiers, vous serez redirigé(e) vers Stripe. ${escapeHtml(BNPL_PAYMENT_REQUEST_NOTICE)} Aucune donnée bancaire n'est collectée par ${escapeHtml(SQYPING_EMAIL_APP_NAME)}.
       </p>
     `,
     noticeVariant: "info",
+    afterActionHtml,
   });
 
   const textLines = [
     `Bonjour${adherentName ? ` ${adherentName}` : ""},`,
     "",
-    "Votre dossier d'adhésion SQY Ping a été relu et validé administrativement.",
+    introText,
+    "",
+    PAYMENT_EMAIL_HUB_INSTRUCTION_TEXT,
+    "",
+    BNPL_PAYMENT_REQUEST_PARAGRAPH,
     "",
   ];
 
   if (hasDetailedQuote) {
-    textLines.push("Détail :", formatQuoteBreakdownText(quote!), "");
+    textLines.push("Détail :", formatQuoteBreakdownText(quote!, donationPricing, breakdownOptions), "");
   } else {
     textLines.push(`Montant à régler : ${formattedAmount}.`, "");
   }
 
   textLines.push(
-    BNPL_PAYMENT_REQUEST_TEXT_LINE,
-    checkoutUrl,
+    `${PAYMENT_EMAIL_CTA_LABEL} :`,
+    mesInscriptionsUrl,
+    "",
+    CHECKOUT_LINK_VALIDITY_FROM_MES_DOSSIERS_NOTICE,
     "",
     "Une facture détaillée sera disponible après paiement.",
     "",

--- a/src/lib/email/payment-instructions-email.ts
+++ b/src/lib/email/payment-instructions-email.ts
@@ -5,7 +5,7 @@ import {
   type PaymentMethodId,
   type RemainingPaymentMethodId,
 } from "@/lib/club-registration/payment-constants";
-import type { ExpectedPayment } from "@/lib/club-registration/payment/types";
+import type { ExpectedPayment, PaymentAid } from "@/lib/club-registration/payment/types";
 import { SQYPING_COLORS, SQYPING_EMAIL_APP_NAME, SQYPING_SECRETARIAT_EMAIL } from "@/lib/email/brand";
 import { escapeHtml } from "@/lib/email/escape-html";
 import {
@@ -21,12 +21,14 @@ import {
   formatEurosForEmail,
   formatQuoteBreakdownHtmlForEmail,
   formatQuoteBreakdownText,
+  type QuoteBreakdownEmailOptions,
 } from "@/lib/email/payment-email";
 import {
   BNPL_INSTRUCTIONS_CARD_HTML,
   BNPL_INSTRUCTIONS_CARD_TEXT,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import type { PriceQuote } from "@/lib/pricing/types";
+import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
 
 export type PaymentInstructionsEmailContent = {
   adherentName: string;
@@ -41,6 +43,8 @@ export type PaymentInstructionsEmailContent = {
   specialPaymentNote?: string;
   paymentNote?: string;
   quote?: PriceQuote | null;
+  donationPricing?: DonationPricingBreakdown | null;
+  secretariatAids?: PaymentAid[];
 };
 
 function formatExpectedPaymentsHtml(expectedPayments: ExpectedPayment[]): string {
@@ -207,15 +211,21 @@ export function buildPaymentInstructionsEmail(
     appOrigin,
     paymentNote,
     quote,
+    donationPricing,
+    secretariatAids,
   } = options;
 
   const safeName = escapeHtml(adherentName);
   const formattedAmount = formatEurosForEmail(amountCents);
   const hasDetailedQuote = Boolean(quote && quote.lines.length > 0);
+  const breakdownOptions: QuoteBreakdownEmailOptions = {
+    amountToPayCents: amountCents,
+    ...(secretariatAids?.length ? { secretariatAids } : {}),
+  };
   const mesInscriptionsUrl = `${appOrigin.replace(/\/$/, "")}/club/mes-inscriptions?registration=${encodeURIComponent(registrationId)}`;
 
   const breakdownBlock = hasDetailedQuote
-    ? `${emailSectionTitle("Détail de votre adhésion")}${formatQuoteBreakdownHtmlForEmail(quote!)}`
+    ? `${emailSectionTitle("Détail de votre adhésion")}${formatQuoteBreakdownHtmlForEmail(quote!, donationPricing, breakdownOptions)}`
     : emailParagraph(
         `Montant à régler : <strong style="color: ${SQYPING_COLORS.primary.main};">${escapeHtml(formattedAmount)}</strong>`
       );
@@ -262,7 +272,7 @@ export function buildPaymentInstructionsEmail(
   ];
 
   if (hasDetailedQuote) {
-    textLines.push("Détail :", formatQuoteBreakdownText(quote!), "");
+    textLines.push("Détail :", formatQuoteBreakdownText(quote!, donationPricing, breakdownOptions), "");
   } else {
     textLines.push(`Montant à régler : ${formattedAmount}.`, "");
   }

--- a/src/lib/pricing/build-context.ts
+++ b/src/lib/pricing/build-context.ts
@@ -5,6 +5,8 @@ type RegistrationPricingInput = Pick<
   ClubRegistrationPayload,
   | "birthDate"
   | "mainSectionId"
+  | "slotIds"
+  | "additionalSectionIds"
   | "wantsCompetitorExtras"
   | "wantsOptionalJersey"
   | "competitionIds"
@@ -31,6 +33,13 @@ export function buildPricingContext(
     familyRegistrationOrder: input.familyRegistrationOrder,
     sex: input.sex,
   };
+
+  if (input.slotIds.length > 0) {
+    ctx.slotIds = [...input.slotIds];
+  }
+  if (input.additionalSectionIds.length > 0) {
+    ctx.additionalSectionIds = [...input.additionalSectionIds];
+  }
 
   if (input.pricingDate) {
     ctx.pricingDate = input.pricingDate;

--- a/src/lib/pricing/donation-discount.test.ts
+++ b/src/lib/pricing/donation-discount.test.ts
@@ -1,0 +1,60 @@
+import { calculateQuote } from "./calculate-quote";
+import type { PricingContext } from "./types";
+import {
+  computeDonationDiscountCents,
+  computeInvoiceTotalCents,
+  DONATION_DISCOUNT_MAX_CENTS,
+  getMembershipNetCents,
+  isValidVoluntaryDonationCents,
+  resolveDonationPricing,
+  VOLUNTARY_DONATION_MIN_CENTS,
+} from "./donation-discount";
+
+function ctx(patch: Partial<PricingContext> & Pick<PricingContext, "birthDate">): PricingContext {
+  return {
+    mainSectionId: "voisins",
+    wantsCompetitorExtras: false,
+    wantsOptionalJersey: false,
+    competitionIds: [],
+    familyRegistrationOrder: "none",
+    sex: "male",
+    pricingDate: "2025-09-01",
+    ...patch,
+  };
+}
+
+describe("donation-discount", () => {
+  it("valide 0 ou ≥ 1 €", () => {
+    expect(isValidVoluntaryDonationCents(0)).toBe(true);
+    expect(isValidVoluntaryDonationCents(100)).toBe(true);
+    expect(isValidVoluntaryDonationCents(50)).toBe(false);
+    expect(isValidVoluntaryDonationCents(99)).toBe(false);
+    expect(VOLUNTARY_DONATION_MIN_CENTS).toBe(100);
+  });
+
+  it("calcule 25 % du don avec plafond 73 €", () => {
+    expect(computeDonationDiscountCents(4_000, 16_000)).toBe(1_000);
+    expect(computeDonationDiscountCents(40_000, 16_000)).toBe(DONATION_DISCOUNT_MAX_CENTS);
+    expect(computeDonationDiscountCents(40_000, 5_000)).toBe(5_000);
+  });
+
+  it("résout le total facture catalogue + don − remise", () => {
+    const quote = calculateQuote(ctx({ birthDate: "2014-06-01" }));
+    const membershipNet = getMembershipNetCents(quote);
+    expect(membershipNet).toBeGreaterThan(0);
+
+    const breakdown = resolveDonationPricing(quote, 10_000);
+    expect(breakdown.donationDiscountCents).toBe(2_500);
+    expect(breakdown.invoiceTotalCents).toBe(
+      computeInvoiceTotalCents(quote.totalCents, 10_000, membershipNet)
+    );
+    expect(breakdown.invoiceTotalCents).toBe(quote.totalCents + 10_000 - 2_500);
+  });
+
+  it("sans don, le total facture égale le devis", () => {
+    const quote = calculateQuote(ctx({ birthDate: "2005-01-01" }));
+    const breakdown = resolveDonationPricing(quote, 0);
+    expect(breakdown.donationDiscountCents).toBe(0);
+    expect(breakdown.invoiceTotalCents).toBe(quote.totalCents);
+  });
+});

--- a/src/lib/pricing/donation-discount.ts
+++ b/src/lib/pricing/donation-discount.ts
@@ -1,0 +1,83 @@
+import type { PriceQuote } from "./types";
+
+/** Montant minimum du don libre (1 €) lorsqu'un don est choisi. */
+export const VOLUNTARY_DONATION_MIN_CENTS = 100;
+
+/** Plafond de la remise liée au don (73 €). */
+export const DONATION_DISCOUNT_MAX_CENTS = 7_300;
+
+/** Taux de remise sur l'adhésion : 25 % du don. */
+export const DONATION_DISCOUNT_RATE = 0.25;
+
+export function isValidVoluntaryDonationCents(cents: number): boolean {
+  return Number.isInteger(cents) && (cents === 0 || cents >= VOLUNTARY_DONATION_MIN_CENTS);
+}
+
+/** Adhésion club nette après remises catalogue (centimes). */
+export function getMembershipNetCents(quote: PriceQuote): number {
+  const membership = quote.lines.find((line) => line.kind === "membership");
+  if (!membership) {
+    return 0;
+  }
+
+  const catalogDiscountCents = quote.lines
+    .filter(
+      (line) =>
+        line.kind === "discount_family" ||
+        line.kind === "discount_female_first" ||
+        line.kind === "discount_aid"
+    )
+    .reduce((sum, line) => sum + line.amountCents, 0);
+
+  return Math.max(0, membership.amountCents + catalogDiscountCents);
+}
+
+export function computeDonationDiscountCents(
+  donationCents: number,
+  membershipNetCents: number
+): number {
+  if (donationCents <= 0 || membershipNetCents <= 0) {
+    return 0;
+  }
+
+  const rawDiscount = Math.floor(donationCents * DONATION_DISCOUNT_RATE);
+  return Math.min(rawDiscount, DONATION_DISCOUNT_MAX_CENTS, membershipNetCents);
+}
+
+export function computeInvoiceTotalCents(
+  quoteTotalCents: number,
+  donationCents: number,
+  membershipNetCents: number
+): number {
+  const discount = computeDonationDiscountCents(donationCents, membershipNetCents);
+  return Math.max(0, quoteTotalCents + donationCents - discount);
+}
+
+export type DonationPricingBreakdown = {
+  voluntaryDonationCents: number;
+  donationDiscountCents: number;
+  membershipNetCents: number;
+  invoiceTotalCents: number;
+};
+
+export function resolveDonationPricing(
+  quote: PriceQuote,
+  voluntaryDonationCents: number
+): DonationPricingBreakdown {
+  const membershipNetCents = getMembershipNetCents(quote);
+  const donationDiscountCents = computeDonationDiscountCents(
+    voluntaryDonationCents,
+    membershipNetCents
+  );
+
+  return {
+    voluntaryDonationCents,
+    donationDiscountCents,
+    membershipNetCents,
+    invoiceTotalCents: computeInvoiceTotalCents(
+      quote.totalCents,
+      voluntaryDonationCents,
+      membershipNetCents
+    ),
+  };
+}

--- a/src/lib/pricing/from-registration-record.ts
+++ b/src/lib/pricing/from-registration-record.ts
@@ -3,6 +3,8 @@ import type { FamilyRegistrationOrder, PricingContext } from "./types";
 type RegistrationPricingRecord = {
   birthDate?: string;
   mainSectionId?: string;
+  slotIds?: string[];
+  additionalSectionIds?: string[];
   wantsCompetitorExtras?: boolean;
   wantsOptionalJersey?: boolean;
   competitionIds?: string[];
@@ -65,6 +67,19 @@ export function buildPricingContextFromRecord(
 
   if (Array.isArray(record.reductionTypes) && record.reductionTypes.length > 0) {
     ctx.reductionTypes = record.reductionTypes.filter(
+      (id): id is string => typeof id === "string"
+    );
+  }
+
+  if (Array.isArray(record.slotIds) && record.slotIds.length > 0) {
+    ctx.slotIds = record.slotIds.filter((id): id is string => typeof id === "string");
+  }
+
+  if (
+    Array.isArray(record.additionalSectionIds) &&
+    record.additionalSectionIds.length > 0
+  ) {
+    ctx.additionalSectionIds = record.additionalSectionIds.filter(
       (id): id is string => typeof id === "string"
     );
   }

--- a/src/lib/pricing/index.ts
+++ b/src/lib/pricing/index.ts
@@ -21,7 +21,8 @@ export {
   buildStripeInvoiceCustomFields,
   formatDiscountBreakdown,
   sumStripeCheckoutLineItems,
-  type StripeCheckoutLineItem,
+  computeStripeCheckoutPayableCents,
+  type DonationStripeContext,
   type StripeInvoiceCustomField,
 } from "./stripe-checkout-lines";
 export {
@@ -30,6 +31,17 @@ export {
   resolveSportAdapteAgeBand,
 } from "./resolve-age-band";
 export { resolveBaseRates } from "./resolve-base-rates";
+export {
+  DONATION_DISCOUNT_MAX_CENTS,
+  DONATION_DISCOUNT_RATE,
+  VOLUNTARY_DONATION_MIN_CENTS,
+  computeDonationDiscountCents,
+  computeInvoiceTotalCents,
+  getMembershipNetCents,
+  isValidVoluntaryDonationCents,
+  resolveDonationPricing,
+  type DonationPricingBreakdown,
+} from "./donation-discount";
 export {
   PRICING_CATALOG_VERSION,
   type FamilyRegistrationOrder,

--- a/src/lib/pricing/stripe-checkout-lines.test.ts
+++ b/src/lib/pricing/stripe-checkout-lines.test.ts
@@ -62,4 +62,13 @@ describe("buildStripeCheckoutLineItems", () => {
     expect(items.some((i) => i.name === "Championnat de Paris")).toBe(true);
     expect(sumStripeCheckoutLineItems(items)).toBe(quote.totalCents);
   });
+
+  it("ajoute une ligne don et valide le total après remise", () => {
+    const quote = calculateQuote(ctx({ birthDate: "2014-06-01" }));
+    const donation = { voluntaryDonationCents: 10_000, donationDiscountCents: 2_500 };
+    const items = buildStripeCheckoutLineItems(quote, undefined, donation);
+    expect(items.some((i) => i.name === "Don libre au club")).toBe(true);
+    expect(sumStripeCheckoutLineItems(items)).toBe(quote.totalCents + 10_000);
+    expect(() => assertStripeLinesMatchQuote(quote, items, donation)).not.toThrow();
+  });
 });

--- a/src/lib/pricing/stripe-checkout-lines.ts
+++ b/src/lib/pricing/stripe-checkout-lines.ts
@@ -1,7 +1,9 @@
 import type { StripePresentationConfig } from "@/lib/club-registration-config/types";
 import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import type { DonationPricingBreakdown } from "./donation-discount";
 import type { PriceLine, PriceQuote } from "./types";
 import { formatCentsAsEuros, stripeCheckoutLines } from "./format";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
 
 export type StripeCheckoutLineItem = {
   /** Libellé affiché sur la facture Stripe (ligne produit). */
@@ -14,6 +16,11 @@ export type StripeInvoiceCustomField = {
   name: string;
   value: string;
 };
+
+export type DonationStripeContext = Pick<
+  DonationPricingBreakdown,
+  "voluntaryDonationCents" | "donationDiscountCents"
+>;
 
 const STRIPE_CUSTOM_FIELD_VALUE_MAX = 500;
 
@@ -81,21 +88,46 @@ function buildMembershipStripeLine(
  */
 export function buildStripeInvoiceCustomFields(
   quote: PriceQuote,
-  stripePresentation?: StripePresentationConfig
+  stripePresentation?: StripePresentationConfig,
+  donation?: DonationStripeContext,
+  secretariatAids?: PaymentAid[]
 ): StripeInvoiceCustomField[] {
   const stripe =
     stripePresentation ?? getDefaultRegistrationConfig().stripePresentation;
-  const discountText = formatDiscountBreakdown(quote);
-  if (!discountText) {
-    return [];
-  }
+  const fields: StripeInvoiceCustomField[] = [];
 
-  return [
-    {
+  const discountText = formatDiscountBreakdown(quote);
+  if (discountText) {
+    fields.push({
       name: stripe.discountCustomFieldName,
       value: truncateForStripe(discountText, STRIPE_CUSTOM_FIELD_VALUE_MAX),
-    },
-  ];
+    });
+  }
+
+  if (donation && donation.voluntaryDonationCents > 0) {
+    fields.push({
+      name: "Don et remise adhésion",
+      value: truncateForStripe(
+        `Don : ${formatCentsAsEuros(donation.voluntaryDonationCents)} ; remise 25 % (plaf. 73 €) : −${formatCentsAsEuros(donation.donationDiscountCents)}`,
+        STRIPE_CUSTOM_FIELD_VALUE_MAX
+      ),
+    });
+  }
+
+  const activeAids = (secretariatAids ?? []).filter((aid) => aid.amountCents > 0);
+  if (activeAids.length > 0) {
+    fields.push({
+      name: "Aides secrétariat",
+      value: truncateForStripe(
+        activeAids
+          .map((aid) => `${aid.label} : −${formatCentsAsEuros(aid.amountCents)}`)
+          .join(" ; "),
+        STRIPE_CUSTOM_FIELD_VALUE_MAX
+      ),
+    });
+  }
+
+  return fields;
 }
 
 /**
@@ -105,7 +137,8 @@ export function buildStripeInvoiceCustomFields(
  */
 export function buildStripeCheckoutLineItems(
   quote: PriceQuote,
-  stripePresentation?: StripePresentationConfig
+  stripePresentation?: StripePresentationConfig,
+  donation?: DonationStripeContext
 ): StripeCheckoutLineItem[] {
   const stripe =
     stripePresentation ?? getDefaultRegistrationConfig().stripePresentation;
@@ -142,6 +175,14 @@ export function buildStripeCheckoutLineItems(
     }
   }
 
+  if (donation && donation.voluntaryDonationCents > 0) {
+    items.push({
+      name: stripe.donationLabel,
+      amountCents: donation.voluntaryDonationCents,
+      description: "Don libre au profit du club",
+    });
+  }
+
   return items;
 }
 
@@ -149,13 +190,36 @@ export function sumStripeCheckoutLineItems(items: StripeCheckoutLineItem[]): num
   return items.reduce((sum, item) => sum + item.amountCents, 0);
 }
 
-/** Vérifie la cohérence entre le devis et les lignes envoyées à Stripe. */
+/** Montant encaissé après coupon de remise don (si applicable). */
+export function computeStripeCheckoutPayableCents(
+  quote: PriceQuote,
+  items: StripeCheckoutLineItem[],
+  donation?: DonationStripeContext
+): number {
+  const lineSum = sumStripeCheckoutLineItems(items);
+  const discount = donation?.donationDiscountCents ?? 0;
+  const expectedFromQuote =
+    quote.totalCents + (donation?.voluntaryDonationCents ?? 0) - discount;
+  if (lineSum - discount !== expectedFromQuote) {
+    throw new Error(
+      `Incohérence lignes Stripe : somme ${lineSum} cts, remise ${discount} cts, attendu ${expectedFromQuote} cts`
+    );
+  }
+  return lineSum - discount;
+}
+
+/** Vérifie la cohérence entre le devis, le don et les lignes envoyées à Stripe. */
 export function assertStripeLinesMatchQuote(
   quote: PriceQuote,
-  items: StripeCheckoutLineItem[]
+  items: StripeCheckoutLineItem[],
+  donation?: DonationStripeContext
 ): void {
-  const expected = quote.totalCents;
-  const actual = sumStripeCheckoutLineItems(items);
+  const expected = donation
+    ? quote.totalCents +
+      donation.voluntaryDonationCents -
+      donation.donationDiscountCents
+    : quote.totalCents;
+  const actual = computeStripeCheckoutPayableCents(quote, items, donation);
   if (actual !== expected) {
     throw new Error(
       `Incohérence devis / Stripe : attendu ${expected} cts, obtenu ${actual} cts`

--- a/src/lib/pricing/types.ts
+++ b/src/lib/pricing/types.ts
@@ -34,6 +34,10 @@ export type PricingContext = {
   pricingDate?: string;
   birthDate: string;
   mainSectionId: string;
+  /** Créneaux sélectionnés (éligibilité dispositifs tarifaires). */
+  slotIds?: string[];
+  /** Sections complémentaires (hors section principale). */
+  additionalSectionIds?: string[];
   wantsCompetitorExtras: boolean;
   wantsOptionalJersey: boolean;
   competitionIds: string[];
@@ -52,4 +56,7 @@ export type PriceQuote = {
   totalCents: number;
   warnings: string[];
   requiresAdminReview: boolean;
+  /** Dispositif tarifaire appliqué (ex. CHAMP'YON), le cas échéant. */
+  appliedPricingDeviceId?: string;
+  appliedPricingDeviceLabel?: string;
 };


### PR DESCRIPTION
## Summary

Livraison verticale club-registration regroupant quatre chantiers produit :

- **Paiement Stripe / expiration 24 h** — hub « Mes dossiers » : l'e-mail de demande redirige vers Mes dossiers ; l'adhérent génère un lien Stripe à la demande via « Payer en ligne » (`POST /api/club/registration/[id]/checkout`). Sessions avec `expires_at` explicite (+24 h). Secrétariat : libellés renvoi clarifiés, action rapide liste.
- **Dispositif CHAMP'YON** — dispositifs tarifaires paramétrables (`pricingDevices`) : 1 section Trappes/La Verrière + 1 créneau loisir sans compétition → grille 105 € / 115 €. Éditeur config onglet dédié + réparation catalogue legacy.
- **Don libre** — don optionnel (min. 1 €), remise 25 % plafonnée 73 €, ventilation facture Stripe multi-lignes + coupon unique (don + aides secrétariat). ADR-0005.
- **Statut paiement** — résolution cohérente `paymentStatus` / `paidAt` (bug Guerveno), garde API 409 sur renvoi si déjà payé, script de réparation Firestore (`scripts/repair-registration-payment-status.ts`).

## Test plan

- [ ] Wizard : inscription Trappes 1 créneau loisir → devis CHAMP'YON (105 € ou 115 € selon âge)
- [ ] Wizard : don libre 20 € → remise 5 € visible au récap et sur devis secrétariat
- [ ] Secrétariat : valider et demander paiement → e-mail avec CTA Mes dossiers (pas de lien Stripe direct)
- [ ] Adhérent : Mes dossiers → « Payer en ligne » → Checkout Stripe 24 h, paiement test 4242…
- [ ] Secrétariat : renvoyer le lien sur dossier déjà payé → 409 / bouton masqué
- [ ] Tableau adhésions : dossier payé affiche « Payé » même si legacy `paymentStatus: pending`
- [ ] Config admin : onglet dispositifs tarifaires, publication config CHAMP'YON
- [ ] `npm run check` CI

## Notes ops

- Le script `repair-registration-payment-status.ts` a déjà été exécuté en `--apply` sur la prod (1 dossier Guerveno). Pas de re-run nécessaire après déploiement sauf nouveau cas détecté.
- Après merge staging : publier la config inscription depuis `/club/parametrage-inscription` si besoin d'activer CHAMP'YON en dev.


Made with [Cursor](https://cursor.com)