### PR TITLE
🛡️ Sentinel: Fix information leakage and harden sync-status API

### DIFF
--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,38 +1,16 @@
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
+
 export const runtime = "nodejs";
 
-import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
-
-export async function GET() {
+const getHandler = async () => {
   try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
+    console.log(
+      "🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe..."
+    );
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
-        },
-        { status: 403 }
-      );
-    }
-
-    console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
-
-    await initializeFirebaseAdmin();
     const db = getFirestoreAdmin();
 
     const [metadataDoc, playersSnapshot, teamsSnapshot] = await Promise.all([
@@ -74,16 +52,18 @@ export async function GET() {
       { status: 200 }
     );
   } catch (error) {
-    console.error("❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:", error);
+    console.error(
+      "❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:",
+      error
+    );
     return jsonNoStore(
       {
         success: false,
         error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
   }
-}
+};
 
-
+export const GET = withAuth(getHandler, [USER_ROLES.ADMIN]);


### PR DESCRIPTION
I identified a security issue where administrative API routes were leaking internal server details (like error messages) to the client. I refactored the `/api/admin/sync-status` route to use the project's standard `withAuth` higher-order component, which enforces authentication, role-based access control, and provides sanitized error responses. I also established the `.jules/sentinel.md` security journal to document this vulnerability pattern for future prevention.

---
*PR created automatically by Jules for task [14478538745939686890](https://jules.google.com/task/14478538745939686890) started by @omichalo*