### PR TITLE
🛡️ Sentinel: standardize security for admin set-role API

### DIFF
--- a/src/app/api/admin/users/set-role/route.ts
+++ b/src/app/api/admin/users/set-role/route.ts
@@ -1,8 +1,4 @@
-export const runtime = "nodejs";
-
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import {
   initializeFirebaseAdmin,
@@ -11,7 +7,6 @@ import {
 } from "@/lib/firebase-admin";
 import {
   COACH_REQUEST_STATUS,
-  hasAnyRole,
   resolveCoachRequestStatus,
   resolveRole,
   USER_ROLES,
@@ -19,6 +14,10 @@ import {
 import type { CoachRequestStatus, UserRole } from "@/types";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import { withAuth } from "@/lib/auth/api-utils";
+import type { DecodedIdToken } from "firebase-admin/auth";
+
+export const runtime = "nodejs";
 
 interface SetRolePayload {
   userId?: string;
@@ -28,7 +27,6 @@ interface SetRolePayload {
   playerId?: string | null;
 }
 
-const ADMIN_ONLY_ROLES: readonly UserRole[] = [USER_ROLES.ADMIN];
 const MANAGED_ROLES: readonly UserRole[] = [
   USER_ROLES.ADMIN,
   USER_ROLES.SECRETARY,
@@ -51,160 +49,133 @@ const resolveCoachStatusForRole = (
   return COACH_REQUEST_STATUS.NONE;
 };
 
-export async function POST(req: NextRequest) {
-  try {
-    // Valider l'origine de la requête pour prévenir les attaques CSRF
-    if (!validateOrigin(req)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Invalid origin",
-          message: "Requête non autorisée",
-        },
-        { status: 403 }
+export const POST = withAuth(
+  async (req: Request, context: unknown) => {
+    const { decoded } = context as { decoded: DecodedIdToken };
+
+    try {
+      // Valider l'origine de la requête pour prévenir les attaques CSRF
+      if (!validateOrigin(req)) {
+        return jsonNoStore(
+          {
+            success: false,
+            error: "Invalid origin",
+            message: "Requête non autorisée",
+          },
+          { status: 403 }
+        );
+      }
+
+      const body = (await req.json()) as SetRolePayload;
+
+      const { userId, role, coachRequestStatus, coachRequestMessage, playerId } =
+        body ?? {};
+
+      if (!userId || typeof userId !== "string") {
+        return jsonNoStore(
+          {
+            success: false,
+            error: "Paramètre 'userId' invalide",
+          },
+          { status: 400 }
+        );
+      }
+
+      const resolvedRole = resolveRole(role ?? null);
+
+      if (!MANAGED_ROLES.includes(resolvedRole)) {
+        return jsonNoStore(
+          {
+            success: false,
+            error: "Rôle invalide",
+          },
+          { status: 400 }
+        );
+      }
+
+      const resolvedCoachStatus = resolveCoachStatusForRole(
+        coachRequestStatus,
+        resolvedRole
       );
-    }
 
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { success: false, error: "Session cookie requis" },
-        { status: 401 }
-      );
-    }
+      await initializeFirebaseAdmin();
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const requesterRole = resolveRole(decoded.role as string | undefined);
+      const userRecord = await adminAuth.getUser(userId);
+      const existingClaims = userRecord.customClaims ?? {};
 
-    if (!hasAnyRole(requesterRole, ADMIN_ONLY_ROLES)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Accès refusé",
-          message: "Seuls les administrateurs peuvent modifier les rôles",
-        },
-        { status: 403 }
-      );
-    }
-
-    const body = (await req.json()) as SetRolePayload;
-
-    const { userId, role, coachRequestStatus, coachRequestMessage, playerId } =
-      body ?? {};
-
-    if (!userId || typeof userId !== "string") {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Paramètre 'userId' invalide",
-        },
-        { status: 400 }
-      );
-    }
-
-    const resolvedRole = resolveRole(role ?? null);
-
-    if (!MANAGED_ROLES.includes(resolvedRole)) {
-      return jsonNoStore(
-        {
-          success: false,
-          error: "Rôle invalide",
-          details: `Le rôle '${role}' n'est pas supporté`,
-        },
-        { status: 400 }
-      );
-    }
-
-    const resolvedCoachStatus = resolveCoachStatusForRole(
-      coachRequestStatus,
-      resolvedRole
-    );
-
-    await initializeFirebaseAdmin();
-
-    const userRecord = await adminAuth.getUser(userId);
-    const existingClaims = userRecord.customClaims ?? {};
-
-    await adminAuth.setCustomUserClaims(userId, {
-      ...existingClaims,
-      role: resolvedRole,
-      coachRequestStatus: resolvedCoachStatus,
-    });
-
-    await adminAuth.revokeRefreshTokens(userId);
-
-    const db = getFirestoreAdmin();
-    const now = FieldValue.serverTimestamp();
-    const userDocRef = db.collection("users").doc(userId);
-
-    await userDocRef.set(
-      {
+      await adminAuth.setCustomUserClaims(userId, {
+        ...existingClaims,
         role: resolvedRole,
         coachRequestStatus: resolvedCoachStatus,
-        coachRequestMessage:
-          coachRequestMessage !== undefined
-            ? coachRequestMessage
-            : FieldValue.delete(),
-        coachRequestHandledBy: decoded.uid,
-        coachRequestHandledAt: now,
-        coachRequestUpdatedAt: now,
-        playerId: playerId !== undefined ? playerId : FieldValue.delete(),
-        updatedAt: now,
-      },
-      { merge: true }
-    );
+      });
 
-    // Log d'audit pour la modification de rôle
-    logAuditAction(AUDIT_ACTIONS.USER_ROLE_CHANGED, decoded.uid, {
-      resource: "user",
-      resourceId: userId,
-      details: {
-        oldRole: userRecord.customClaims?.role,
-        newRole: resolvedRole,
-        coachRequestStatus: resolvedCoachStatus,
-      },
-      success: true,
-    });
+      await adminAuth.revokeRefreshTokens(userId);
 
-    return jsonNoStore(
-      {
-        success: true,
-        data: {
-          userId,
+      const db = getFirestoreAdmin();
+      const now = FieldValue.serverTimestamp();
+      const userDocRef = db.collection("users").doc(userId);
+
+      await userDocRef.set(
+        {
           role: resolvedRole,
           coachRequestStatus: resolvedCoachStatus,
+          coachRequestMessage:
+            coachRequestMessage !== undefined
+              ? coachRequestMessage
+              : FieldValue.delete(),
+          coachRequestHandledBy: decoded.uid,
+          coachRequestHandledAt: now,
+          coachRequestUpdatedAt: now,
+          playerId: playerId !== undefined ? playerId : FieldValue.delete(),
+          updatedAt: now,
         },
-      },
-      { status: 200 }
-    );
-  } catch (error) {
-    console.error("[app/api/admin/users/set-role] error", error);
-    
-    // Log d'audit pour l'échec
-    try {
-      const cookieStore = await cookies();
-      const sessionCookie = cookieStore.get("__session")?.value;
-      if (sessionCookie) {
-        const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+        { merge: true }
+      );
+
+      // Log d'audit pour la modification de rôle
+      logAuditAction(AUDIT_ACTIONS.USER_ROLE_CHANGED, decoded.uid, {
+        resource: "user",
+        resourceId: userId,
+        details: {
+          oldRole: userRecord.customClaims?.role,
+          newRole: resolvedRole,
+          coachRequestStatus: resolvedCoachStatus,
+        },
+        success: true,
+      });
+
+      return jsonNoStore(
+        {
+          success: true,
+          data: {
+            userId,
+            role: resolvedRole,
+            coachRequestStatus: resolvedCoachStatus,
+          },
+        },
+        { status: 200 }
+      );
+    } catch (error) {
+      console.error("[app/api/admin/users/set-role] error", error);
+
+      // Log d'audit pour l'échec
+      try {
         logAuditAction(AUDIT_ACTIONS.USER_ROLE_CHANGED, decoded.uid, {
           resource: "user",
           success: false,
-          details: { error: error instanceof Error ? error.message : "Unknown error" },
         });
+      } catch {
+        // Ignorer les erreurs de logging d'audit
       }
-    } catch {
-      // Ignorer les erreurs de logging d'audit
+
+      return jsonNoStore(
+        {
+          success: false,
+          error: "Erreur lors de la mise à jour du rôle",
+        },
+        { status: 500 }
+      );
     }
-
-    return jsonNoStore(
-      {
-        success: false,
-        error: "Erreur lors de la mise à jour du rôle",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 }
-    );
-  }
-}
-
+  },
+  [USER_ROLES.ADMIN]
+);


### PR DESCRIPTION
This PR hardens the administrative API route for setting user roles.

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The endpoint was using manual authentication logic and leaking internal error details in its responses.
🎯 **Impact**: Inconsistent security enforcement and information disclosure that could assist an attacker.
🔧 **Fix**: 
- Replaced manual session verification with the `withAuth` higher-order function.
- Enforced the `ADMIN` role and the `email_verified` claim.
- Removed `details: error.message` from error responses to prevent leaking system internals.
- Maintained audit logging and CSRF protection (`validateOrigin`).
✅ **Verification**: 
- Successfully executed `npm run check` (linting, type-checking, Jest tests, and production build).
- Manual code review confirmed the fix adheres to the project's security standards.

---
*PR created automatically by Jules for task [1680582965395544262](https://jules.google.com/task/1680582965395544262) started by @omichalo*