### PR TITLE
feat(club-registration): montant fixe des aides et saisie euros au blur

### DIFF
--- a/src/components/club-registration-config/AidRulesEditor.tsx
+++ b/src/components/club-registration-config/AidRulesEditor.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { InputAdornment, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { MenuItem, Stack, TextField, Typography } from "@mui/material";
 import type {
   AidRule,
   AidRuleFormPresentation,
   RegistrationConfigV1,
 } from "@/lib/club-registration-config/types";
 import { moveArrayItem } from "@/lib/club-registration-config/sort-order";
-import { getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
-import { generateConfigItemId, centsToEuroInput, euroInputToCents } from "./config-editor-utils";
+import { getAidRuleFixedAmountCents, getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
+import { EuroAmountField } from "./EuroAmountField";
+import { generateConfigItemId, centsToEuroInput } from "./config-editor-utils";
 import {
   ConfigEditorAddButton,
   ConfigEditorCollapsibleItem,
@@ -37,9 +38,14 @@ function defaultAidForm(): AidRuleFormPresentation {
 function aidSummaryMeta(rule: AidRule, form: AidRuleFormPresentation): string | undefined {
   const parts: string[] = [];
   if (form.style === "toggle") parts.push("Interrupteur avec code de référence");
-  const maxCents = getAidRuleMaxAmountCents(rule);
-  if (maxCents !== undefined) {
-    parts.push(`Plafond ${centsToEuroInput(maxCents)} €`);
+  const fixedCents = getAidRuleFixedAmountCents(rule);
+  if (fixedCents !== undefined) {
+    parts.push(`Montant fixe ${centsToEuroInput(fixedCents)} €`);
+  } else {
+    const maxCents = getAidRuleMaxAmountCents(rule);
+    if (maxCents !== undefined) {
+      parts.push(`Plafond ${centsToEuroInput(maxCents)} €`);
+    }
   }
   return parts.length > 0 ? parts.join(" · ") : undefined;
 }
@@ -123,27 +129,35 @@ export function AidRulesEditor({ config, onChange }: Props) {
               minRows={2}
               helperText="Affiché aux familles à côté de l'aide (conditions, montant indicatif, etc.)."
             />
-            <TextField
+            <EuroAmountField
               label="Montant maximum (facultatif)"
-              size="small"
-              type="number"
-              value={
-                rule.maxAmountCents !== undefined ? centsToEuroInput(rule.maxAmountCents) : ""
-              }
-              onChange={(e) => {
-                const raw = e.target.value;
-                if (!raw.trim()) {
+              valueCents={rule.maxAmountCents}
+              onChangeCents={(cents) => {
+                if (cents <= 0) {
                   updateRule(index, { maxAmountCents: undefined });
                   return;
                 }
-                updateRule(index, { maxAmountCents: euroInputToCents(raw) });
+                updateRule(index, { maxAmountCents: cents, fixedAmountCents: undefined });
               }}
+              allowEmpty
+              disabled={rule.fixedAmountCents !== undefined}
               fullWidth
-              inputProps={{ min: 0, step: 0.01 }}
-              InputProps={{
-                endAdornment: <InputAdornment position="end">€</InputAdornment>,
-              }}
               helperText="Plafond du montant saisi par la famille. Laisser vide pour aucune limite."
+            />
+            <EuroAmountField
+              label="Montant fixe (facultatif)"
+              valueCents={rule.fixedAmountCents}
+              onChangeCents={(cents) => {
+                if (cents <= 0) {
+                  updateRule(index, { fixedAmountCents: undefined });
+                  return;
+                }
+                updateRule(index, { fixedAmountCents: cents, maxAmountCents: undefined });
+              }}
+              allowEmpty
+              disabled={rule.maxAmountCents !== undefined}
+              fullWidth
+              helperText="Montant imposé et non modifiable par la famille. Incompatible avec un plafond."
             />
             <Typography variant="caption" color="text.secondary" display="block">
               Identifiant technique : <strong>{rule.id}</strong>

--- a/src/components/club-registration-config/EuroAmountField.tsx
+++ b/src/components/club-registration-config/EuroAmountField.tsx
@@ -2,14 +2,18 @@
 
 import { InputAdornment, TextField } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import { centsToEuroInput, euroInputToCents } from "./config-editor-utils";
+import { useEuroMonetaryTextInput } from "@/lib/club-registration/payment/use-euro-monetary-text-input";
 
 type Props = {
   label: string;
-  valueCents: number;
+  valueCents?: number | undefined;
   onChangeCents: (cents: number) => void;
   size?: "small" | "medium";
   fullWidth?: boolean;
+  disabled?: boolean;
+  /** Montant facultatif : vide tant qu'aucune valeur n'est enregistrée. */
+  allowEmpty?: boolean;
+  helperText?: string;
   sx?: SxProps<Theme>;
 };
 
@@ -19,17 +23,31 @@ export function EuroAmountField({
   onChangeCents,
   size = "small",
   fullWidth = false,
+  disabled = false,
+  allowEmpty = false,
+  helperText,
   sx,
 }: Props) {
+  const { text, handleFocus, handleChange, handleBlur } = useEuroMonetaryTextInput({
+    amountCents: valueCents,
+    allowEmpty,
+    selectAllOnFocus: true,
+  });
+
   return (
     <TextField
       label={label}
       size={size}
-      type="number"
       fullWidth={fullWidth}
-      value={centsToEuroInput(valueCents)}
-      onChange={(e) => onChangeCents(euroInputToCents(e.target.value))}
-      inputProps={{ min: 0, step: 0.01 }}
+      disabled={disabled}
+      value={text}
+      onChange={(e) => handleChange(e.target.value)}
+      onFocus={handleFocus}
+      onBlur={() => handleBlur(onChangeCents)}
+      inputProps={{ inputMode: "decimal", autoComplete: "off" }}
+      InputLabelProps={{ shrink: true }}
+      placeholder="0,00"
+      {...(helperText !== undefined ? { helperText } : {})}
       InputProps={{
         endAdornment: <InputAdornment position="end">€</InputAdornment>,
       }}

--- a/src/components/club-registration/AidEuroAmountField.tsx
+++ b/src/components/club-registration/AidEuroAmountField.tsx
@@ -12,6 +12,7 @@ type Props = {
   sx?: SxProps<Theme>;
   dataField: string;
   helperText?: string;
+  disabled?: boolean;
 };
 
 /** Montant en euros pour une aide (délègue à {@link EuroMonetaryInputField}). */
@@ -20,6 +21,7 @@ export function AidEuroAmountField({
   amountCents,
   onCommitCents,
   required = false,
+  disabled = false,
   size = "small",
   sx,
   dataField,
@@ -31,6 +33,7 @@ export function AidEuroAmountField({
       amountCents={amountCents}
       onCommitCents={onCommitCents}
       required={required}
+      disabled={disabled}
       size={size}
       dataField={dataField}
       selectAllOnFocus={true}

--- a/src/components/club-registration/AidReductionFields.tsx
+++ b/src/components/club-registration/AidReductionFields.tsx
@@ -12,6 +12,8 @@ import {
   Typography,
 } from "@mui/material";
 import {
+  findAidRuleById,
+  getAidRuleFixedAmountCents,
   getAidRuleHelperText,
   getAidRuleMaxAmountCents,
   getCheckboxAidRules,
@@ -53,9 +55,42 @@ const AID_AMOUNT_FIELD_SX = {
   maxWidth: 220,
 } as const;
 
-function aidAmountHelperText(ruleMaxCents: number | undefined): string | undefined {
+function aidMaxAmountHelperText(ruleMaxCents: number | undefined): string | undefined {
   if (ruleMaxCents === undefined) return undefined;
   return `Montant maximum : ${formatCentsAsEuros(ruleMaxCents)}`;
+}
+
+/** Aligné sur le helperText MUI d’un TextField outlined (14px). */
+const TEXT_FIELD_HELPER_INSET_SX = { px: 1.75, mt: 1 } as const;
+
+function defaultAidAmountCents(config: RegistrationConfigV1, aidId: string): number {
+  const rule = findAidRuleById(config, aidId);
+  return rule ? (getAidRuleFixedAmountCents(rule) ?? 0) : 0;
+}
+
+function FixedAidAmountLine({
+  ruleId,
+  fixedAmountCents,
+  alignWithTextFieldHelper = false,
+}: {
+  ruleId: string;
+  fixedAmountCents: number;
+  alignWithTextFieldHelper?: boolean;
+}) {
+  return (
+    <Typography
+      variant="subtitle2"
+      fontWeight={600}
+      color="text.primary"
+      data-field={`paymentAid.${ruleId}`}
+      {...(alignWithTextFieldHelper ? { sx: TEXT_FIELD_HELPER_INSET_SX } : {})}
+    >
+      Montant&nbsp;:{" "}
+      <Box component="span" sx={{ fontWeight: 700 }}>
+        {formatCentsAsEuros(fixedAmountCents)}
+      </Box>
+    </Typography>
+  );
 }
 
 export function AidReductionFields({ config, draft, onChange }: Props) {
@@ -76,7 +111,8 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
           {
             type: id,
             label: labelsByType[id] ?? id,
-            amountCents: findPaymentAid(paymentAids, id)?.amountCents ?? 0,
+            amountCents:
+              findPaymentAid(paymentAids, id)?.amountCents ?? defaultAidAmountCents(config, id),
             ...(reference ? { reference } : {}),
           },
           { retainZero: true }
@@ -114,7 +150,7 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
         {
           type: id,
           label: labelsByType[id] ?? id,
-          amountCents: 0,
+          amountCents: defaultAidAmountCents(config, id),
         },
         { retainZero: true }
       ),
@@ -163,8 +199,27 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
     });
   };
 
+  const renderEditableAidAmount = (
+    rule: { id: string; label: string },
+    aid: ReturnType<typeof findPaymentAid>,
+    maxAmountCents: number | undefined
+  ) => {
+    const maxHelperText = aidMaxAmountHelperText(maxAmountCents);
+    return (
+      <AidEuroAmountField
+        label={`Montant (${rule.label})`}
+        amountCents={aid?.amountCents ?? 0}
+        onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
+        required
+        sx={AID_AMOUNT_FIELD_SX}
+        dataField={`paymentAid.${rule.id}`}
+        {...(maxHelperText ? { helperText: maxHelperText } : {})}
+      />
+    );
+  };
+
   return (
-    <>
+    <Stack spacing={2}>
       <Typography variant="body2" color="text.secondary">
         Cochez les aides dont vous bénéficiez et indiquez le montant pour chacune.
         Ces montants seront déduits du reste à payer à l&apos;étape suivante.
@@ -175,7 +230,8 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
         const selected = draft.reductionTypes.includes(rule.id);
         const aid = findPaymentAid(paymentAids, rule.id);
         const accompaniment = getAidRuleHelperText(rule);
-        const amountHelperText = aidAmountHelperText(getAidRuleMaxAmountCents(rule));
+        const fixedAmountCents = getAidRuleFixedAmountCents(rule);
+        const maxAmountCents = getAidRuleMaxAmountCents(rule);
         return (
           <Stack key={rule.id} spacing={1}>
             <FormControlLabel
@@ -193,27 +249,30 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
               </Typography>
             ) : null}
             <Collapse in={selected} timeout={{ enter: 300, exit: 200 }}>
-              <Stack spacing={1.5} alignItems="flex-start">
-                <TextField
-                  label={rule.form.referenceCode.label}
-                  value={getReductionReferenceCode(draft.reductionReferenceCodes, rule.id)}
-                  onChange={(e) => updateReferenceCode(rule.id, e.target.value)}
-                  fullWidth
-                  inputProps={{
-                    "data-field": reductionReferenceCodeFieldKey(rule.id),
-                    maxLength: rule.form.referenceCode.maxLength ?? 80,
-                  }}
-                  helperText={rule.form.referenceCode.helperText}
-                />
-                <AidEuroAmountField
-                  label={`Montant (${rule.label})`}
-                  amountCents={aid?.amountCents ?? 0}
-                  onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
-                  required
-                  sx={AID_AMOUNT_FIELD_SX}
-                  dataField={`paymentAid.${rule.id}`}
-                  {...(amountHelperText ? { helperText: amountHelperText } : {})}
-                />
+              <Stack spacing={1} alignItems="flex-start" sx={{ width: "100%", pt: 0.5 }}>
+                <Box sx={{ width: "100%" }}>
+                  <TextField
+                    label={rule.form.referenceCode.label}
+                    value={getReductionReferenceCode(draft.reductionReferenceCodes, rule.id)}
+                    onChange={(e) => updateReferenceCode(rule.id, e.target.value)}
+                    fullWidth
+                    inputProps={{
+                      "data-field": reductionReferenceCodeFieldKey(rule.id),
+                      maxLength: rule.form.referenceCode.maxLength ?? 80,
+                    }}
+                    helperText={rule.form.referenceCode.helperText}
+                  />
+                  {fixedAmountCents !== undefined ? (
+                    <FixedAidAmountLine
+                      ruleId={rule.id}
+                      fixedAmountCents={fixedAmountCents}
+                      alignWithTextFieldHelper
+                    />
+                  ) : null}
+                </Box>
+                {fixedAmountCents === undefined
+                  ? renderEditableAidAmount(rule, aid, maxAmountCents)
+                  : null}
               </Stack>
             </Collapse>
           </Stack>
@@ -230,7 +289,8 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
               const selected = draft.reductionTypes.includes(rule.id);
               const aid = findPaymentAid(paymentAids, rule.id);
               const accompaniment = getAidRuleHelperText(rule);
-              const amountHelperText = aidAmountHelperText(getAidRuleMaxAmountCents(rule));
+              const fixedAmountCents = getAidRuleFixedAmountCents(rule);
+              const maxAmountCents = getAidRuleMaxAmountCents(rule);
               return (
                 <Stack key={rule.id} spacing={1} sx={{ mb: selected ? 1.5 : 0 }}>
                   <FormControlLabel
@@ -253,15 +313,14 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
                   ) : null}
                   {selected ? (
                     <Box sx={{ pl: 4 }}>
-                      <AidEuroAmountField
-                        label={`Montant (${rule.label})`}
-                        amountCents={aid?.amountCents ?? 0}
-                        onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
-                        required
-                        sx={AID_AMOUNT_FIELD_SX}
-                        dataField={`paymentAid.${rule.id}`}
-                        {...(amountHelperText ? { helperText: amountHelperText } : {})}
-                      />
+                      {fixedAmountCents !== undefined ? (
+                        <FixedAidAmountLine
+                          ruleId={rule.id}
+                          fixedAmountCents={fixedAmountCents}
+                        />
+                      ) : (
+                        renderEditableAidAmount(rule, aid, maxAmountCents)
+                      )}
                     </Box>
                   ) : null}
                 </Stack>
@@ -270,6 +329,6 @@ export function AidReductionFields({ config, draft, onChange }: Props) {
           </FormGroup>
         </Stack>
       ) : null}
-    </>
+    </Stack>
   );
 }

--- a/src/components/club-registration/EuroMonetaryInputField.tsx
+++ b/src/components/club-registration/EuroMonetaryInputField.tsx
@@ -1,20 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { InputAdornment, TextField } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import {
-  centsToEurosInput,
-  eurosInputToCents,
-  sanitizeEurosMonetaryInput,
-} from "@/lib/club-registration/payment/payment-draft-helpers";
+import { useEuroMonetaryTextInput } from "@/lib/club-registration/payment/use-euro-monetary-text-input";
 
 type Props = {
   label: string;
   amountCents: number;
   onCommitCents: (cents: number) => void;
-  /** Mise à jour optionnelle pendant la frappe (aperçu, sans valider le formulaire). */
-  onDraftCents?: (cents: number) => void;
+  /** Texte brut pendant la frappe (aperçu sans formater ni valider le formulaire). */
+  onDraftText?: (text: string) => void;
   /** Si défini, le montant est relevé à ce minimum au blur (ex. don 1 €). */
   minCentsOnBlur?: number;
   required?: boolean;
@@ -33,13 +29,13 @@ type Props = {
 
 /**
  * Saisie euros (virgule) : texte local pendant la frappe, conversion en centimes au blur.
- * Évite les effacements impossibles dus au formatage « 1,00 » à chaque touche.
+ * Évite le formatage « 5,00 » à chaque touche qui empêche de saisir « 50 ».
  */
 export function EuroMonetaryInputField({
   label,
   amountCents,
   onCommitCents,
-  onDraftCents,
+  onDraftText,
   minCentsOnBlur,
   required = false,
   disabled = false,
@@ -53,24 +49,12 @@ export function EuroMonetaryInputField({
   selectAllOnFocus = true,
   endAdornment,
 }: Props) {
-  const [text, setText] = useState(() => centsToEurosInput(amountCents));
-  const focusedRef = useRef(false);
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    if (!focusedRef.current) {
-      setText(centsToEurosInput(amountCents));
-    }
-  }, [amountCents]);
-
-  const commitFromText = (raw: string) => {
-    let cents = eurosInputToCents(raw);
-    if (minCentsOnBlur != null && cents > 0 && cents < minCentsOnBlur) {
-      cents = minCentsOnBlur;
-    }
-    onCommitCents(cents);
-    setText(cents > 0 ? centsToEurosInput(cents) : "");
-  };
+  const { text, handleFocus, handleChange, handleBlur } = useEuroMonetaryTextInput({
+    amountCents,
+    allowEmpty: true,
+    selectAllOnFocus,
+    ...(onDraftText ? { onTextChange: onDraftText } : {}),
+  });
 
   return (
     <TextField
@@ -81,23 +65,10 @@ export function EuroMonetaryInputField({
       required={required}
       fullWidth={fullWidth}
       size={size}
-      onChange={(e) => {
-        const next = sanitizeEurosMonetaryInput(e.target.value);
-        setText(next);
-        onDraftCents?.(eurosInputToCents(next));
-      }}
-      onFocus={(e) => {
-        focusedRef.current = true;
-        if (selectAllOnFocus) {
-          e.target.select();
-        }
-      }}
-      onBlur={() => {
-        focusedRef.current = false;
-        commitFromText(text);
-      }}
+      onChange={(e) => handleChange(e.target.value)}
+      onFocus={handleFocus}
+      onBlur={() => handleBlur(onCommitCents, minCentsOnBlur)}
       InputLabelProps={{ shrink: true }}
-      inputRef={inputRef}
       inputProps={{
         ...(dataField ? { "data-field": dataField } : {}),
         inputMode: "decimal",

--- a/src/components/club-registration/VoluntaryDonationFields.tsx
+++ b/src/components/club-registration/VoluntaryDonationFields.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Box,
   Checkbox,
@@ -15,6 +15,7 @@ import {
   getMembershipNetCents,
 } from "@/lib/pricing";
 import type { PriceQuote } from "@/lib/pricing/types";
+import { eurosInputToCents } from "@/lib/club-registration/payment/payment-draft-helpers";
 import { EuroMonetaryInputField } from "./EuroMonetaryInputField";
 
 type Props = {
@@ -33,13 +34,13 @@ export function VoluntaryDonationFields({
   idPrefix = "donation",
 }: Props) {
   const wantsDonation = voluntaryDonationCents > 0;
-  const [draftDonationCents, setDraftDonationCents] = useState(voluntaryDonationCents);
+  const [draftText, setDraftText] = useState("");
 
-  useEffect(() => {
-    setDraftDonationCents(voluntaryDonationCents);
-  }, [voluntaryDonationCents]);
-
-  const previewCents = wantsDonation ? draftDonationCents || voluntaryDonationCents : 0;
+  const previewCents = (() => {
+    if (!wantsDonation) return 0;
+    if (draftText.trim()) return eurosInputToCents(draftText);
+    return voluntaryDonationCents;
+  })();
 
   const preview = (() => {
     if (!quote || !wantsDonation || previewCents <= 0) {
@@ -54,18 +55,18 @@ export function VoluntaryDonationFields({
   })();
 
   const toggleDonation = (checked: boolean) => {
+    setDraftText("");
     if (!checked) {
-      setDraftDonationCents(0);
       onChange(0);
       return;
     }
-    setDraftDonationCents(VOLUNTARY_DONATION_MIN_CENTS);
     onChange(VOLUNTARY_DONATION_MIN_CENTS);
   };
 
   const commitDonation = (cents: number) => {
-    const next = cents > 0 ? Math.max(cents, VOLUNTARY_DONATION_MIN_CENTS) : VOLUNTARY_DONATION_MIN_CENTS;
-    setDraftDonationCents(next);
+    setDraftText("");
+    const next =
+      cents > 0 ? Math.max(cents, VOLUNTARY_DONATION_MIN_CENTS) : VOLUNTARY_DONATION_MIN_CENTS;
     onChange(next);
   };
 
@@ -94,7 +95,7 @@ export function VoluntaryDonationFields({
           label="Montant du don"
           amountCents={voluntaryDonationCents}
           onCommitCents={commitDonation}
-          onDraftCents={setDraftDonationCents}
+          onDraftText={setDraftText}
           minCentsOnBlur={VOLUNTARY_DONATION_MIN_CENTS}
           fullWidth
           disabled={disabled}

--- a/src/lib/club-registration-config/aid-rules.test.ts
+++ b/src/lib/club-registration-config/aid-rules.test.ts
@@ -1,6 +1,7 @@
 import { getDefaultRegistrationConfig } from "./default-config";
 import {
   DEFAULT_PASS_SPORT_FORM,
+  getAidRuleFixedAmountCents,
   getAidRuleHelperText,
   getAidRuleMaxAmountCents,
   getCheckboxAidRules,
@@ -30,7 +31,7 @@ describe("aid-rules helpers", () => {
     ).toEqual(DEFAULT_PASS_SPORT_FORM);
   });
 
-  it("normalise helperText et plafond de montant", () => {
+  it("normalise helperText, plafond et montant fixe", () => {
     const rule = {
       id: "pass_sport",
       label: "Pass Sport",
@@ -42,5 +43,10 @@ describe("aid-rules helpers", () => {
     expect(getAidRuleMaxAmountCents(rule)).toBe(5_000);
     expect(getAidRuleMaxAmountCents({ ...rule, maxAmountCents: 0 })).toBeUndefined();
     expect(getAidRuleHelperText({ ...rule, helperText: "   " })).toBeUndefined();
+
+    const fixedRule = { ...rule, maxAmountCents: undefined, fixedAmountCents: 5_000 };
+    expect(getAidRuleFixedAmountCents(fixedRule)).toBe(5_000);
+    expect(getAidRuleFixedAmountCents({ ...fixedRule, fixedAmountCents: 0 })).toBeUndefined();
+    expect(getAidRuleMaxAmountCents(fixedRule)).toBeUndefined();
   });
 });

--- a/src/lib/club-registration-config/aid-rules.ts
+++ b/src/lib/club-registration-config/aid-rules.ts
@@ -51,9 +51,16 @@ export function getAidRuleHelperText(rule: AidRule): string | undefined {
 }
 
 export function getAidRuleMaxAmountCents(rule: AidRule): number | undefined {
+  if (getAidRuleFixedAmountCents(rule) !== undefined) return undefined;
   const max = rule.maxAmountCents;
   if (max === undefined || max <= 0) return undefined;
   return max;
+}
+
+export function getAidRuleFixedAmountCents(rule: AidRule): number | undefined {
+  const fixed = rule.fixedAmountCents;
+  if (fixed === undefined || fixed <= 0) return undefined;
+  return fixed;
 }
 
 export function findAidRuleById(

--- a/src/lib/club-registration-config/schema.ts
+++ b/src/lib/club-registration-config/schema.ts
@@ -133,19 +133,39 @@ const aidRuleFormPresentationSchema = z.discriminatedUnion("style", [
   }),
 ]);
 
-const aidRuleSchema = z.object({
-  id: z.string().trim().min(1).max(80),
-  label: z.string().trim().min(1).max(200),
-  effect: aidRuleEffectSchema,
-  form: aidRuleFormPresentationSchema.optional(),
-  helperText: optionalTrimmedLabelSchema(500),
-  maxAmountCents: z
-    .number()
-    .int()
-    .min(0)
-    .optional()
-    .transform((value) => (value !== undefined && value > 0 ? value : undefined)),
-});
+const aidRuleSchema = z
+  .object({
+    id: z.string().trim().min(1).max(80),
+    label: z.string().trim().min(1).max(200),
+    effect: aidRuleEffectSchema,
+    form: aidRuleFormPresentationSchema.optional(),
+    helperText: optionalTrimmedLabelSchema(500),
+    maxAmountCents: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .transform((value) => (value !== undefined && value > 0 ? value : undefined)),
+    fixedAmountCents: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .transform((value) => (value !== undefined && value > 0 ? value : undefined)),
+  })
+  .superRefine((rule, ctx) => {
+    if (
+      rule.maxAmountCents !== undefined &&
+      rule.fixedAmountCents !== undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Une aide ne peut pas avoir à la fois un montant maximum et un montant fixe.",
+        path: ["fixedAmountCents"],
+      });
+    }
+  });
 
 const stripePresentationSchema = z.object({
   membershipLabel: z.string().trim().min(1).max(200),

--- a/src/lib/club-registration-config/types.ts
+++ b/src/lib/club-registration-config/types.ts
@@ -138,6 +138,8 @@ export type AidRule = {
   helperText?: string | undefined;
   /** Plafond facultatif du montant saisi par la famille (centimes). */
   maxAmountCents?: number | undefined;
+  /** Montant exact imposé (centimes) — le champ est prérempli et non modifiable. */
+  fixedAmountCents?: number | undefined;
 };
 
 export type StripePresentationConfig = {

--- a/src/lib/club-registration/payment/use-euro-monetary-text-input.test.ts
+++ b/src/lib/club-registration/payment/use-euro-monetary-text-input.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, act } from "@testing-library/react";
+import type { FocusEvent } from "react";
+import { useEuroMonetaryTextInput } from "./use-euro-monetary-text-input";
+
+describe("useEuroMonetaryTextInput", () => {
+  it("conserve la saisie entière en cours sans formater (ex. 5 puis 50)", () => {
+    const { result } = renderHook(() =>
+      useEuroMonetaryTextInput({ amountCents: 0, allowEmpty: true })
+    );
+
+    act(() => {
+      result.current.handleChange("5");
+    });
+    expect(result.current.text).toBe("5");
+
+    act(() => {
+      result.current.handleChange("50");
+    });
+    expect(result.current.text).toBe("50");
+  });
+
+  it("formate en centimes uniquement au blur", () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useEuroMonetaryTextInput({ amountCents: 0, allowEmpty: true })
+    );
+
+    act(() => {
+      result.current.handleChange("50");
+    });
+
+    act(() => {
+      result.current.handleBlur(onCommit);
+    });
+
+    expect(onCommit).toHaveBeenCalledWith(5_000);
+    expect(result.current.text).toBe("50,00");
+  });
+
+  it("n'écrase pas la saisie en cours quand amountCents change côté parent", () => {
+    const { result, rerender } = renderHook(
+      ({ amountCents }: { amountCents: number }) =>
+        useEuroMonetaryTextInput({ amountCents, allowEmpty: true }),
+      { initialProps: { amountCents: 0 } }
+    );
+
+    act(() => {
+      result.current.handleFocus({
+        target: { select: jest.fn() },
+      } as unknown as FocusEvent<HTMLInputElement>);
+      result.current.handleChange("5");
+    });
+
+    rerender({ amountCents: 500 });
+
+    expect(result.current.text).toBe("5");
+  });
+});

--- a/src/lib/club-registration/payment/use-euro-monetary-text-input.ts
+++ b/src/lib/club-registration/payment/use-euro-monetary-text-input.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type FocusEvent } from "react";
+import {
+  centsToEurosInput,
+  eurosInputToCents,
+  sanitizeEurosMonetaryInput,
+} from "./payment-draft-helpers";
+
+type Options = {
+  amountCents: number | undefined;
+  /** Si vrai, 0 € ou vide s'affiche comme champ vide (montants facultatifs). */
+  allowEmpty?: boolean;
+  selectAllOnFocus?: boolean;
+  onTextChange?: (text: string) => void;
+};
+
+function centsToDisplayText(amountCents: number | undefined, allowEmpty: boolean): string {
+  if (amountCents === undefined || (allowEmpty && amountCents <= 0)) {
+    return "";
+  }
+  return centsToEurosInput(amountCents);
+}
+
+export function useEuroMonetaryTextInput({
+  amountCents,
+  allowEmpty = false,
+  selectAllOnFocus = true,
+  onTextChange,
+}: Options) {
+  const [text, setText] = useState(() => centsToDisplayText(amountCents, allowEmpty));
+  const isEditingRef = useRef(false);
+
+  useEffect(() => {
+    if (!isEditingRef.current) {
+      setText(centsToDisplayText(amountCents, allowEmpty));
+    }
+  }, [amountCents, allowEmpty]);
+
+  const handleFocus = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      isEditingRef.current = true;
+      if (selectAllOnFocus) {
+        event.target.select();
+      }
+    },
+    [selectAllOnFocus]
+  );
+
+  const handleChange = useCallback(
+    (raw: string) => {
+      const next = sanitizeEurosMonetaryInput(raw);
+      setText(next);
+      onTextChange?.(next);
+    },
+    [onTextChange]
+  );
+
+  const commitText = useCallback(
+    (onCommitCents: (cents: number) => void, minCentsOnBlur?: number) => {
+      isEditingRef.current = false;
+      let cents = eurosInputToCents(text);
+      if (minCentsOnBlur != null && cents > 0 && cents < minCentsOnBlur) {
+        cents = minCentsOnBlur;
+      }
+      onCommitCents(cents);
+      setText(centsToDisplayText(cents > 0 ? cents : allowEmpty ? undefined : 0, allowEmpty));
+    },
+    [allowEmpty, text]
+  );
+
+  const handleBlur = useCallback(
+    (onCommitCents: (cents: number) => void, minCentsOnBlur?: number) => {
+      commitText(onCommitCents, minCentsOnBlur);
+    },
+    [commitText]
+  );
+
+  return {
+    text,
+    handleFocus,
+    handleChange,
+    handleBlur,
+    commitText,
+    parseDraftCents: () => eurosInputToCents(text),
+  };
+}

--- a/src/lib/club-registration/validate-admin-aids.test.ts
+++ b/src/lib/club-registration/validate-admin-aids.test.ts
@@ -57,4 +57,25 @@ describe("validateAdminAids", () => {
     expect(issue?.message).toMatch(/50,00/);
     expect(issue?.focusSelector).toBe('[data-field="paymentAid.pass_sport"]');
   });
+
+  it("exige le montant fixe configuré pour l'aide", () => {
+    const fixedConfig = {
+      ...config,
+      aidRules: config.aidRules.map((rule) =>
+        rule.id === "pass_sport"
+          ? { ...rule, fixedAmountCents: 5_000, maxAmountCents: undefined }
+          : rule
+      ),
+    };
+    const issue = validateAdminAids(
+      {
+        ...baseDraft,
+        reductionTypes: ["pass_sport"],
+        paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 4_999 }],
+      },
+      fixedConfig
+    );
+    expect(issue?.message).toMatch(/50,00/);
+    expect(issue?.focusSelector).toBe('[data-field="paymentAid.pass_sport"]');
+  });
 });

--- a/src/lib/club-registration/validate-admin-aids.ts
+++ b/src/lib/club-registration/validate-admin-aids.ts
@@ -1,5 +1,5 @@
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
-import { findAidRuleById, getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
+import { findAidRuleById, getAidRuleFixedAmountCents, getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
 import { buildPricingContext, calculateQuote, formatCentsAsEuros } from "@/lib/pricing";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
 import { findPaymentAid, normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
@@ -69,6 +69,15 @@ export function validateAdminAids(
     }
 
     const rule = findAidRuleById(config, reductionId);
+    const fixedAmountCents = rule ? getAidRuleFixedAmountCents(rule) : undefined;
+    if (fixedAmountCents !== undefined && entry.amountCents !== fixedAmountCents) {
+      const label = rule?.label ?? reductionId;
+      return {
+        message: `Le montant pour « ${label} » doit être de ${formatCentsAsEuros(fixedAmountCents)}.`,
+        focusSelector: `[data-field="paymentAid.${reductionId}"]`,
+      };
+    }
+
     const maxAmountCents = rule ? getAidRuleMaxAmountCents(rule) : undefined;
     if (maxAmountCents !== undefined && entry.amountCents > maxAmountCents) {
       const label = rule?.label ?? reductionId;


### PR DESCRIPTION
## Summary
- Ajout du paramétrage d’un montant fixe par aide (incompatible avec le plafond max).
- Affichage famille : ligne « Montant : X € » mise en avant sous le champ code, sans champ grisé redondant.
- Correction de la saisie monétaire (formatage au blur uniquement) sur le parcours adhésion et l’éditeur de config via `useEuroMonetaryTextInput`.

## Test plan
- [ ] Configurer une aide avec montant fixe (ex. Pass Sport 50 €) et vérifier l’affichage au parcours adhésion.
- [ ] Saisir un montant libre : taper `5` puis `0` doit donner `50` sans formatage prématuré.
- [ ] Valider qu’une aide avec plafond max refuse un montant trop élevé.
- [ ] Vérifier l’aperçu du don libre pendant la saisie.

Made with [Cursor](https://cursor.com)