### PR TITLE
feat(club-registration): engagement disponibilité compétitions paramétrable

### DIFF
--- a/src/components/club-registration-config/CompetitionsEditor.tsx
+++ b/src/components/club-registration-config/CompetitionsEditor.tsx
@@ -206,6 +206,20 @@ export function CompetitionsEditor({ config, onChange }: Props) {
                 sx={configEditorSwitchLabelSx}
                 control={
                   <Switch
+                    checked={comp.requiresAvailabilityCommitment === true}
+                    onChange={(e) =>
+                      updateCompetition(comp.id, {
+                        requiresAvailabilityCommitment: e.target.checked,
+                      })
+                    }
+                  />
+                }
+                label="Afficher l'engagement de disponibilité (amendes forfaits)"
+              />
+              <FormControlLabel
+                sx={configEditorSwitchLabelSx}
+                control={
+                  <Switch
                     checked={comp.enabled}
                     onChange={(e) => updateCompetition(comp.id, { enabled: e.target.checked })}
                   />

--- a/src/components/club-registration-config/StripePresentationEditor.tsx
+++ b/src/components/club-registration-config/StripePresentationEditor.tsx
@@ -145,6 +145,18 @@ export function StripePresentationEditor({ config, onChange }: Props) {
             onChange={(e) => updateUiCopy({ optionalJerseyOptInLabel: e.target.value })}
             fullWidth
           />
+          <TextField
+            label="Engagement de disponibilité — compétitions (formulaire)"
+            size="small"
+            value={config.uiCopy.competitionAvailabilityCommitmentNotice ?? ""}
+            onChange={(e) =>
+              updateUiCopy({ competitionAvailabilityCommitmentNotice: e.target.value })
+            }
+            multiline
+            minRows={4}
+            fullWidth
+            helperText="Affiché lors d'une inscription à une compétition avec engagement de disponibilité."
+          />
         </Stack>
       </ConfigEditorCard>
 

--- a/src/components/club-registration-config/config-editor-summary-meta.ts
+++ b/src/components/club-registration-config/config-editor-summary-meta.ts
@@ -29,11 +29,13 @@ export function competitionSummaryMeta(comp: {
   enabled: boolean;
   formGroup: "youth" | "other";
   priceCents: number;
+  requiresAvailabilityCommitment?: boolean | undefined;
 }): string {
   const parts = [
     comp.formGroup === "youth" ? "Jeunes" : "Autres",
     `${centsToEuroInput(comp.priceCents)} €`,
   ];
+  if (comp.requiresAvailabilityCommitment) parts.push("Engagement disponibilité");
   if (!comp.enabled) parts.push("Masquée");
   return parts.join(" · ");
 }

--- a/src/components/club-registration/CompetitionAvailabilityCommitmentAlert.tsx
+++ b/src/components/club-registration/CompetitionAvailabilityCommitmentAlert.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Alert, AlertTitle, Typography } from "@mui/material";
+import type { RegistrationCompetition, RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import { getCompetitionAvailabilityCommitmentNotice } from "@/lib/club-registration-config/competition-availability-commitment";
+
+type Props = {
+  config: RegistrationConfigV1;
+  competitions: RegistrationCompetition[];
+};
+
+/** Rappel d'engagement de disponibilité lors d'une inscription à une compétition paramétrée. */
+export function CompetitionAvailabilityCommitmentAlert({ config, competitions }: Props) {
+  if (competitions.length === 0) return null;
+
+  const notice = getCompetitionAvailabilityCommitmentNotice(config);
+  const labels = competitions.map((c) => c.formLabel);
+  const inscriptionLabel =
+    labels.length === 1
+      ? `Inscription concernée : ${labels[0]}`
+      : `Inscriptions concernées : ${labels.join(", ")}`;
+
+  return (
+    <Alert
+      severity="warning"
+      variant="filled"
+      role="note"
+      sx={{
+        borderRadius: 2,
+        boxShadow: (theme) => theme.shadows[3],
+        "& .MuiAlert-message": { width: "100%" },
+        "& .MuiAlert-icon": { alignItems: "flex-start", pt: 0.75 },
+      }}
+    >
+      <AlertTitle sx={{ fontWeight: 800, fontSize: "1.05rem", mb: 0.75 }}>
+        Engagement lié à votre inscription en compétition
+      </AlertTitle>
+      <Typography variant="body1" component="p" sx={{ fontWeight: 500, lineHeight: 1.6 }}>
+        {notice}
+      </Typography>
+      <Typography
+        variant="body2"
+        component="p"
+        sx={{ mt: 1.25, fontWeight: 700, opacity: 0.95 }}
+      >
+        {inscriptionLabel}
+      </Typography>
+    </Alert>
+  );
+}

--- a/src/components/club-registration/PracticeStep.tsx
+++ b/src/components/club-registration/PracticeStep.tsx
@@ -26,6 +26,8 @@ import {
   PracticeCompetitorJerseyField,
   PracticeOptionalJerseySection,
 } from "./PracticeJerseySection";
+import { CompetitionAvailabilityCommitmentAlert } from "./CompetitionAvailabilityCommitmentAlert";
+import { getCompetitionsRequiringAvailabilityCommitment } from "@/lib/club-registration-config/competition-availability-commitment";
 
 type Props = {
   draft: RegistrationDraft;
@@ -77,6 +79,10 @@ export function PracticeStep({ draft, onChange }: Props) {
     (c) => c.enabled && c.formGroup === "other"
   );
   const youthBundle = config.competitionBundles[0];
+  const commitmentCompetitions = getCompetitionsRequiringAvailabilityCommitment(
+    config,
+    draft.competitionIds
+  );
 
   const [expandedSiteIds, setExpandedSiteIds] = useState<Set<string>>(() =>
     siteIdsMatchingMainSection(draft.mainSectionId, getEnabledSites(config))
@@ -329,6 +335,13 @@ export function PracticeStep({ draft, onChange }: Props) {
                 />
               ))}
             </FormGroup>
+          </Box>
+
+          <Box sx={{ mt: 1 }}>
+            <CompetitionAvailabilityCommitmentAlert
+              config={config}
+              competitions={commitmentCompetitions}
+            />
           </Box>
         </Stack>
       )}

--- a/src/lib/club-registration-config/competition-availability-commitment.test.ts
+++ b/src/lib/club-registration-config/competition-availability-commitment.test.ts
@@ -1,0 +1,50 @@
+import { getDefaultRegistrationConfig } from "./default-config";
+import {
+  getCompetitionAvailabilityCommitmentNotice,
+  getCompetitionsRequiringAvailabilityCommitment,
+} from "./competition-availability-commitment";
+
+describe("competition availability commitment", () => {
+  it("retourne les compétitions sélectionnées marquées engagement disponibilité", () => {
+    const config = getDefaultRegistrationConfig();
+    const withFlag = config.competitions.find((c) => c.requiresAvailabilityCommitment);
+    expect(withFlag).toBeDefined();
+    if (!withFlag) return;
+
+    const result = getCompetitionsRequiringAvailabilityCommitment(config, [
+      withFlag.id,
+      "unknown",
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(withFlag.id);
+  });
+
+  it("ignore les compétitions sans engagement de disponibilité", () => {
+    const config = getDefaultRegistrationConfig();
+    const withoutFlag = config.competitions.find(
+      (c) => !c.requiresAvailabilityCommitment
+    );
+    if (!withoutFlag) {
+      config.competitions.push({
+        id: "leisure_only",
+        formLabel: "Loisir",
+        stripeLabel: "Loisir",
+        priceCents: 0,
+        formGroup: "other",
+        enabled: true,
+        requiresAvailabilityCommitment: false,
+      });
+    }
+    const targetId = withoutFlag?.id ?? "leisure_only";
+    expect(
+      getCompetitionsRequiringAvailabilityCommitment(config, [targetId])
+    ).toHaveLength(0);
+  });
+
+  it("expose le texte d'engagement depuis uiCopy ou la valeur par défaut", () => {
+    const config = getDefaultRegistrationConfig();
+    expect(getCompetitionAvailabilityCommitmentNotice(config)).toContain(
+      "règlement intérieur du club"
+    );
+  });
+});

--- a/src/lib/club-registration-config/competition-availability-commitment.ts
+++ b/src/lib/club-registration-config/competition-availability-commitment.ts
@@ -1,0 +1,27 @@
+import type { RegistrationCompetition, RegistrationConfigV1 } from "./types";
+
+/** Texte par défaut — aligné sur le règlement intérieur du club (section Compétition). */
+export const DEFAULT_COMPETITION_AVAILABILITY_COMMITMENT_NOTICE =
+  "En vous inscrivant à une compétition, vous vous engagez à être disponible pour l'ensemble de ses épreuves et à prévenir votre entraîneur en cas d'absence. Conformément au règlement intérieur du club, les amendes liées à une absence non justifiée par un certificat médical seront à votre charge et devront être réglées avant la compétition suivante. En cas d'amendes impayées, le club se réserve le droit de ne pas vous réinscrire aux compétitions suivantes.";
+
+export function getCompetitionsRequiringAvailabilityCommitment(
+  config: RegistrationConfigV1,
+  competitionIds: readonly string[]
+): RegistrationCompetition[] {
+  const selected = new Set(competitionIds);
+  return config.competitions.filter(
+    (competition) =>
+      competition.enabled &&
+      competition.requiresAvailabilityCommitment === true &&
+      selected.has(competition.id)
+  );
+}
+
+export function getCompetitionAvailabilityCommitmentNotice(
+  config: RegistrationConfigV1
+): string {
+  return (
+    config.uiCopy.competitionAvailabilityCommitmentNotice ??
+    DEFAULT_COMPETITION_AVAILABILITY_COMMITMENT_NOTICE
+  );
+}

--- a/src/lib/club-registration-config/default-config.ts
+++ b/src/lib/club-registration-config/default-config.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_JERSEY_SIZE_HELPER,
   DEFAULT_OPTIONAL_JERSEY_OPT_IN_LABEL,
 } from "./repair-jersey";
+import { DEFAULT_COMPETITION_AVAILABILITY_COMMITMENT_NOTICE } from "./competition-availability-commitment";
 import { buildDefaultPricingDevices } from "./pricing-devices";
 
 function sectionPricingProfile(id: string): RegistrationSection["pricingProfile"] {
@@ -267,6 +268,7 @@ export function buildDefaultRegistrationConfig(): RegistrationConfigV1 {
       priceCents: COMPETITION_PRICE_CENTS[comp.id] ?? 0,
       formGroup: youthIds.has(comp.id) ? "youth" : "other",
       enabled: true,
+      requiresAvailabilityCommitment: true,
     })),
     competitionBundles: buildCompetitionBundles(),
     ageBandProfiles: {
@@ -373,6 +375,8 @@ export function buildDefaultRegistrationConfig(): RegistrationConfigV1 {
       competitorJerseyHelper: DEFAULT_COMPETITOR_JERSEY_HELPER,
       jerseySizeHelper: DEFAULT_JERSEY_SIZE_HELPER,
       optionalJerseyOptInLabel: DEFAULT_OPTIONAL_JERSEY_OPT_IN_LABEL,
+      competitionAvailabilityCommitmentNotice:
+        DEFAULT_COMPETITION_AVAILABILITY_COMMITMENT_NOTICE,
     },
     pricingDevices: buildDefaultPricingDevices(),
   };

--- a/src/lib/club-registration-config/repair-jersey.ts
+++ b/src/lib/club-registration-config/repair-jersey.ts
@@ -1,5 +1,7 @@
 import type { JerseyCatalogConfig, RegistrationConfigV1 } from "./types";
 
+import { DEFAULT_COMPETITION_AVAILABILITY_COMMITMENT_NOTICE } from "./competition-availability-commitment";
+
 export const DEFAULT_JERSEY_CATALOG: JerseyCatalogConfig = {
   optionalPriceCents: 3_500,
   optionalStripeLabel: "Maillot de compétition",
@@ -31,6 +33,9 @@ export function repairJerseyConfig(config: RegistrationConfigV1): RegistrationCo
       jerseySizeHelper: config.uiCopy.jerseySizeHelper ?? DEFAULT_JERSEY_SIZE_HELPER,
       optionalJerseyOptInLabel:
         config.uiCopy.optionalJerseyOptInLabel ?? DEFAULT_OPTIONAL_JERSEY_OPT_IN_LABEL,
+      competitionAvailabilityCommitmentNotice:
+        config.uiCopy.competitionAvailabilityCommitmentNotice ??
+        DEFAULT_COMPETITION_AVAILABILITY_COMMITMENT_NOTICE,
     },
   };
 }

--- a/src/lib/club-registration-config/schema.ts
+++ b/src/lib/club-registration-config/schema.ts
@@ -64,6 +64,7 @@ const registrationCompetitionSchema = z.object({
   priceCents: z.number().int().min(0),
   formGroup: z.enum(["youth", "other"]),
   enabled: z.boolean(),
+  requiresAvailabilityCommitment: z.boolean().optional(),
 });
 
 const competitionBundleSchema = z.object({
@@ -236,6 +237,7 @@ const registrationUiCopySchema = z.object({
   competitorJerseyHelper: z.string().trim().min(1).max(500).optional(),
   jerseySizeHelper: z.string().trim().min(1).max(500).optional(),
   optionalJerseyOptInLabel: z.string().trim().min(1).max(500).optional(),
+  competitionAvailabilityCommitmentNotice: z.string().trim().min(1).max(2000).optional(),
 });
 
 export const registrationConfigV1Schema = z

--- a/src/lib/club-registration-config/types.ts
+++ b/src/lib/club-registration-config/types.ts
@@ -60,6 +60,8 @@ export type RegistrationCompetition = {
   priceCents: number;
   formGroup: "youth" | "other";
   enabled: boolean;
+  /** Affiche l'engagement de disponibilité (amendes forfaits) lorsque l'option est cochée. */
+  requiresAvailabilityCommitment?: boolean | undefined;
 };
 
 export type CompetitionBundle = {
@@ -218,6 +220,8 @@ export type RegistrationUiCopy = {
   jerseySizeHelper: string;
   /** Libellé de la case à cocher maillot hors section compétiteur. */
   optionalJerseyOptInLabel: string;
+  /** Rappel affiché lors de la sélection d'une compétition avec engagement de disponibilité. */
+  competitionAvailabilityCommitmentNotice?: string | undefined;
 };
 
 export type RegistrationConfigV1 = {


### PR DESCRIPTION
## Summary
- Ajoute un rappel d'engagement de disponibilité lors de l'inscription à des compétitions configurables (amendes forfaits, règlement intérieur du club).
- Bandeau warning visible dans l'étape pratique compétiteur, texte éditable dans la config admin.
- Option par compétition dans l'éditeur de catalogue (`requiresAvailabilityCommitment`).

## Test plan
- [ ] Cocher une compétition avec engagement activé → bandeau orange visible avec le libellé mis à jour
- [ ] Décocher toutes les compétitions concernées → bandeau masqué
- [ ] Admin : basculer l'option par compétition et éditer le texte dans Stripe/présentation
- [ ] `npm run check` et tests unitaires `competition-availability-commitment.test.ts`


Made with [Cursor](https://cursor.com)