### PR TITLE
🛡️ Sentinel: Admin Role Hardening & API Sanitization

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,11 @@ service cloud.firestore {
     function isAuthenticated() {
       return request.auth != null;
     }
+
+    // Vérifie si l'email de l'utilisateur est vérifié
+    function isVerified() {
+      return request.auth != null && request.auth.token.email_verified == true;
+    }
     
     // Récupère le rôle de l'utilisateur depuis les custom claims
     function authRole() {
@@ -19,21 +24,21 @@ service cloud.firestore {
     
     // Vérifie si l'utilisateur est admin
     function isAdmin() {
-      return authRole() == "admin";
+      return isVerified() && authRole() == "admin";
     }
     
     // Vérifie si l'utilisateur est coach ou admin
     function isCoach() {
-      return isAdmin() || authRole() == "coach";
+      return isAdmin() || (isVerified() && authRole() == "coach");
     }
 
     // Secrétariat (gestion des dossiers d'inscription côté client limitée ; API Admin SDK en prod)
     function isSecretary() {
-      return authRole() == "secretary";
+      return isVerified() && authRole() == "secretary";
     }
 
     function isClubRegistrationManager() {
-      return isAdmin() || isSecretary();
+      return isVerified() && (isAdmin() || isSecretary());
     }
 
     // Liste client : uniquement ses propres dossiers (requête filtrée + plafond).

--- a/src/app/api/admin/sync-status/route.ts
+++ b/src/app/api/admin/sync-status/route.ts
@@ -1,89 +1,70 @@
 export const runtime = "nodejs";
 
 import { jsonNoStore } from "@/lib/http/cache-headers";
-import { cookies } from "next/headers";
-import { initializeFirebaseAdmin, getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { USER_ROLES } from "@/lib/auth/roles";
+import { withAuth } from "@/lib/auth/api-utils";
 
-export async function GET() {
-  try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore(
-        { error: "Session cookie requis" },
-        { status: 401 }
+export const GET = withAuth(
+  async () => {
+    try {
+      console.log(
+        "🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe..."
       );
-    }
 
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
+      const db = getFirestoreAdmin();
 
-    if (!hasAnyRole(role, [USER_ROLES.ADMIN])) {
+      const [metadataDoc, playersSnapshot, teamsSnapshot] = await Promise.all([
+        db.collection("metadata").doc("lastSync").get(),
+        db.collection("players").get(),
+        db.collection("teams").get(),
+      ]);
+
+      const metadata = metadataDoc.exists ? metadataDoc.data() : {};
+      const playersCount = playersSnapshot.size;
+      const teamsCount = teamsSnapshot.size;
+      const teamMatchesCount = metadata?.teamMatchesCount || 0;
+
+      console.log(
+        `✅ Statut récupéré: ${playersCount} joueurs, ${teamsCount} équipes, ${teamMatchesCount} matchs par équipe`
+      );
+
+      return jsonNoStore(
+        {
+          success: true,
+          data: {
+            players: {
+              lastSync: metadata?.players?.toDate?.()?.toISOString() || null,
+              count: playersCount,
+              duration: metadata?.playersDuration || null,
+            },
+            teams: {
+              lastSync: metadata?.teams?.toDate?.()?.toISOString() || null,
+              count: teamsCount,
+              duration: metadata?.teamsDuration || null,
+            },
+            teamMatches: {
+              lastSync: metadata?.teamMatches?.toDate?.()?.toISOString() || null,
+              count: teamMatchesCount,
+              duration: metadata?.teamMatchesDuration || null,
+            },
+          },
+        },
+        { status: 200 }
+      );
+    } catch (error) {
+      console.error(
+        "❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:",
+        error
+      );
       return jsonNoStore(
         {
           success: false,
-          error: "Accès refusé",
-          message: "Cette ressource est réservée aux administrateurs",
+          error: "Erreur lors de la récupération du statut de synchronisation",
         },
-        { status: 403 }
+        { status: 500 }
       );
     }
-
-    console.log("🔄 [app/api/admin/sync-status] Récupération du statut de synchronisation directe...");
-
-    await initializeFirebaseAdmin();
-    const db = getFirestoreAdmin();
-
-    const [metadataDoc, playersSnapshot, teamsSnapshot] = await Promise.all([
-      db.collection("metadata").doc("lastSync").get(),
-      db.collection("players").get(),
-      db.collection("teams").get(),
-    ]);
-
-    const metadata = metadataDoc.exists ? metadataDoc.data() : {};
-    const playersCount = playersSnapshot.size;
-    const teamsCount = teamsSnapshot.size;
-    const teamMatchesCount = metadata?.teamMatchesCount || 0;
-
-    console.log(
-      `✅ Statut récupéré: ${playersCount} joueurs, ${teamsCount} équipes, ${teamMatchesCount} matchs par équipe`
-    );
-
-    return jsonNoStore(
-      {
-        success: true,
-        data: {
-          players: {
-            lastSync: metadata?.players?.toDate?.()?.toISOString() || null,
-            count: playersCount,
-            duration: metadata?.playersDuration || null,
-          },
-          teams: {
-            lastSync: metadata?.teams?.toDate?.()?.toISOString() || null,
-            count: teamsCount,
-            duration: metadata?.teamsDuration || null,
-          },
-          teamMatches: {
-            lastSync: metadata?.teamMatches?.toDate?.()?.toISOString() || null,
-            count: teamMatchesCount,
-            duration: metadata?.teamMatchesDuration || null,
-          },
-        },
-      },
-      { status: 200 }
-    );
-  } catch (error) {
-    console.error("❌ [app/api/admin/sync-status] Erreur lors de la récupération du statut:", error);
-    return jsonNoStore(
-      {
-        success: false,
-        error: "Erreur lors de la récupération du statut de synchronisation",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 }
-    );
-  }
-}
-
-
+  },
+  [USER_ROLES.ADMIN]
+);


### PR DESCRIPTION
This PR implements a security enhancement to the application's authorization layer and administrative APIs.

### 🚨 Severity: HIGH

### 💡 Vulnerability:
1. **Administrative Bypass:** Previously, the `firestore.rules` checked for custom role claims (`admin`, `coach`, etc.) but did not verify the `email_verified` status. This meant a user whose email was not verified but had been granted a role (e.g., through a previous session or misconfiguration) could still perform privileged database operations.
2. **Information Leakage:** The `/api/admin/sync-status` endpoint was leaking internal server-side error messages (stack traces or raw error strings) via the `details` field in its error response.
3. **Inconsistent Auth:** The endpoint used manual session verification instead of the project's standard `withAuth` HOC.

### 🎯 Impact:
- Unverified accounts could potentially bypass intended account state requirements to manage club data.
- Attackers could gain insights into server internals from verbose error messages.

### 🔧 Fix:
- Added a centralized `isVerified()` helper in `firestore.rules` and integrated it into all administrative role checks.
- Refactored `/api/admin/sync-status` to use `withAuth`, which automatically enforces the `email_verified` claim and standardizes the auth flow.
- Removed the `details` field from the API's catch block to ensure only generic error messages are returned to the client.

### ✅ Verification:
- Ran `npm run check` which passed linting, type-checking, and all 564 Vitest tests.
- Verified `firestore.rules` logic manually via `read_file`.
- Confirmed the API refactor satisfies the project's security standards documented in `src/lib/auth/api-utils.ts`.

---
*PR created automatically by Jules for task [12390835646585481275](https://jules.google.com/task/12390835646585481275) started by @omichalo*