### PR TITLE
fix(club-registration): cibler les e-mails de paiement selon le soumettant

### DIFF
--- a/src/app/api/club/registration/[id]/checkout/route.ts
+++ b/src/app/api/club/registration/[id]/checkout/route.ts
@@ -16,7 +16,7 @@ import {
   resolveRegistrationConfigForRecord,
 } from "@/lib/club-registration-config/pricing-resolve";
 import { resolveRegistrationDonationPricing } from "@/lib/club-registration/resolve-registration-donation";
-import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve-registration-contact-email";
+import { resolveRegistrationPaymentRecipientEmails } from "@/lib/club-registration/resolve-registration-contact-email";
 import {
   createStripeCheckoutForRegistration,
   persistSelfServiceStripeCheckout,
@@ -89,7 +89,8 @@ export async function POST(
       );
     }
 
-    const paymentEmail = resolveRegistrationContactEmail(data);
+    const paymentEmails = resolveRegistrationPaymentRecipientEmails(data);
+    const paymentEmail = paymentEmails[0] ?? null;
     if (!paymentEmail) {
       return jsonNoStore(
         { error: "Aucune adresse e-mail exploitable pour le paiement." },

--- a/src/app/api/club/registration/[id]/request-payment/route.ts
+++ b/src/app/api/club/registration/[id]/request-payment/route.ts
@@ -21,7 +21,9 @@ import {
   resolveRegistrationConfigForRecord,
 } from "@/lib/club-registration-config/pricing-resolve";
 import { resolveRegistrationDonationPricing } from "@/lib/club-registration/resolve-registration-donation";
-import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve-registration-contact-email";
+import {
+  resolveRegistrationPaymentRecipientEmails,
+} from "@/lib/club-registration/resolve-registration-contact-email";
 import {
   persistPaymentRequestedAndNotify,
   processManualPaymentFollowUp,
@@ -94,7 +96,8 @@ export async function POST(
       );
     }
 
-    const paymentEmail = resolveRegistrationContactEmail(data);
+    const paymentEmails = resolveRegistrationPaymentRecipientEmails(data);
+    const paymentEmail = paymentEmails[0] ?? null;
     if (!paymentEmail) {
       return jsonNoStore(
         { error: "Aucune adresse e-mail exploitable pour envoyer la demande de paiement." },
@@ -178,7 +181,7 @@ export async function POST(
         donationPricing,
         amountToPayCents,
         paymentMethod,
-        paymentEmail,
+        paymentEmails,
         adherentName,
         baseUrl,
         requestedByUid: decoded.uid,
@@ -217,7 +220,7 @@ export async function POST(
       quote,
       donationPricing,
       amountToPayCents,
-      paymentEmail,
+      paymentEmails,
       adherentName,
       baseUrl,
       requestedByUid: decoded.uid,

--- a/src/app/api/club/registration/route.ts
+++ b/src/app/api/club/registration/route.ts
@@ -13,21 +13,13 @@ import { buildRegistrationPayloadSchema } from "@/lib/club-registration/schema";
 import { isMinorAt } from "@/lib/club-registration/age";
 import {
   initialMedicalCertificateStatus,
-  isMedicalCertificateStatus,
-  normalizeMedicalCertificateStatus,
 } from "@/lib/club-registration/medical-certificate";
 import { checkRateLimit } from "@/lib/auth/rate-limit";
-import { buildManagerRegistrationPricingPatch } from "@/lib/club-registration/build-manager-registration-pricing-patch";
+import { handleManagerRegistrationPatch } from "@/lib/club-registration/patch-manager-registration";
 import {
   ensureRegistrationConfigSeeded,
   getActiveRegistrationConfig,
 } from "@/lib/club-registration-config/store";
-import { isValidVoluntaryDonationCents } from "@/lib/pricing/donation-discount";
-import {
-  APPLICANT_NOTES_MAX_LENGTH,
-  isApplicantNotesTooLong,
-  normalizeApplicantNotes,
-} from "@/lib/club-registration/applicant-notes";
 import { createRegistrationWithIdempotency } from "@/lib/club-registration/create-registration-with-idempotency";
 import {
   findRegistrationLicenseConflicts,
@@ -43,17 +35,10 @@ import { getSqyPingLogoAttachment } from "@/lib/email/logo-attachment";
 import { sendMail } from "@/lib/mailer";
 import { getAppBaseUrl } from "@/lib/club-registration/stripe";
 import {
-  MANAGER_EDITABLE_FIELDS,
-} from "@/lib/club-registration/registration-api-fields";
-import { ffttLicenseLookupSchema } from "@/lib/club-registration/schema-base";
-import {
   formatPersonDisplayName,
-  normalizeRegistrationLastNamePatch,
 } from "@/lib/shared/person-name-format";
 
 const COLLECTION = "clubRegistrations";
-const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
-const FFTT_LICENSE_RE = /^[0-9]{5,12}$/;
 
 function stripUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -110,203 +95,7 @@ export async function GET(req: Request) {
 
 /** PATCH /api/club/registration?id={registrationId} — correction d'un dossier par admin/secrétaire. */
 export async function PATCH(req: Request) {
-  try {
-    if (!validateOrigin(req)) {
-      return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
-    }
-
-    const url = new URL(req.url);
-    const id = url.searchParams.get("id");
-    if (!id) {
-      return jsonNoStore({ error: "Paramètre 'id' requis" }, { status: 400 });
-    }
-
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("__session")?.value;
-    if (!sessionCookie) {
-      return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
-    }
-
-    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, MANAGER_ROLES)) {
-      return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
-    }
-
-    const body = ((await req.json()) ?? {}) as Record<string, unknown>;
-    const updates: Record<string, unknown> = {};
-    for (const field of MANAGER_EDITABLE_FIELDS) {
-      if (body[field] !== undefined) {
-        updates[field] = body[field];
-      }
-    }
-
-    if (Object.keys(updates).length === 0) {
-      return jsonNoStore({ error: "Aucun champ modifiable fourni" }, { status: 400 });
-    }
-
-    Object.assign(updates, normalizeRegistrationLastNamePatch(updates));
-
-    const db = getFirestoreAdmin();
-
-    if (updates.applicantNotes !== undefined) {
-      if (typeof updates.applicantNotes !== "string") {
-        return jsonNoStore({ error: "Précisions de l'inscrit invalides" }, { status: 400 });
-      }
-      if (isApplicantNotesTooLong(updates.applicantNotes)) {
-        return jsonNoStore(
-          {
-            error: `Les précisions de l'inscrit ne peuvent pas dépasser ${APPLICANT_NOTES_MAX_LENGTH} caractères`,
-          },
-          { status: 400 }
-        );
-      }
-      const normalized = normalizeApplicantNotes(updates.applicantNotes);
-      if (normalized) {
-        updates.applicantNotes = normalized;
-      } else {
-        updates.applicantNotes = FieldValue.delete();
-      }
-    }
-
-    if (
-      updates.voluntaryDonationCents !== undefined &&
-      (!Number.isInteger(updates.voluntaryDonationCents as number) ||
-        !isValidVoluntaryDonationCents(updates.voluntaryDonationCents as number))
-    ) {
-      return jsonNoStore(
-        { error: "Don libre invalide (0 € ou minimum 1 €)." },
-        { status: 400 }
-      );
-    }
-
-    if (
-      updates.paymentAmountCents !== undefined &&
-      (!Number.isInteger(updates.paymentAmountCents) ||
-        (updates.paymentAmountCents as number) < 0)
-    ) {
-      return jsonNoStore({ error: "Montant de paiement invalide" }, { status: 400 });
-    }
-
-    if (
-      updates.medicalCertificateStatus !== undefined &&
-      !isMedicalCertificateStatus(updates.medicalCertificateStatus)
-    ) {
-      return jsonNoStore(
-        { error: "Statut de certificat médical invalide" },
-        { status: 400 }
-      );
-    }
-
-    if (updates.ffttLicense !== undefined) {
-      if (updates.ffttLicense === null || updates.ffttLicense === "") {
-        updates.ffttLicense = FieldValue.delete();
-        if (updates.ffttLicenseLookup === undefined) {
-          updates.ffttLicenseLookup = FieldValue.delete();
-        }
-      } else if (
-        typeof updates.ffttLicense !== "string" ||
-        !FFTT_LICENSE_RE.test(updates.ffttLicense)
-      ) {
-        return jsonNoStore(
-          { error: "Numéro de licence invalide" },
-          { status: 400 }
-        );
-      } else {
-        const licenseConflicts = await findRegistrationLicenseConflicts(
-          db,
-          updates.ffttLicense,
-          id
-        );
-        if (licenseConflicts.blocking.length > 0) {
-          const message = formatBlockingLicenseConflictMessage(licenseConflicts.blocking);
-          return jsonNoStore(
-            {
-              error: message,
-              fieldErrors: { ffttLicense: [message] },
-            },
-            { status: 400 }
-          );
-        }
-      }
-    }
-
-    if (updates.ffttLicenseLookup !== undefined) {
-      if (updates.ffttLicenseLookup === null) {
-        updates.ffttLicenseLookup = FieldValue.delete();
-      } else {
-        const parsed = ffttLicenseLookupSchema.safeParse(updates.ffttLicenseLookup);
-        if (!parsed.success) {
-          return jsonNoStore(
-            { error: "Données de lookup FFTT invalides" },
-            { status: 400 }
-          );
-        }
-        updates.ffttLicenseLookup = parsed.data;
-      }
-    }
-
-    const docRef = db.collection(COLLECTION).doc(id);
-    const snap = await docRef.get();
-    if (!snap.exists) {
-      return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
-    }
-    const currentData = snap.data() ?? {};
-    const currentStatus = currentData.status;
-    const statusPatch =
-      currentStatus === "submitted" ? { status: "in_review" } : {};
-
-    if (
-      updates.medicalCertificateDeclaration !== undefined ||
-      updates.medicalCertificateStatus !== undefined
-    ) {
-      const nextDeclaration =
-        (updates.medicalCertificateDeclaration as string | undefined) ??
-        (currentData.medicalCertificateDeclaration as string | undefined);
-      const currentCertificateStatus = currentData.medicalCertificateStatus;
-      const requestedCertificateStatus =
-        updates.medicalCertificateStatus ?? currentCertificateStatus;
-      const nextCertificateStatus = normalizeMedicalCertificateStatus(
-        requestedCertificateStatus,
-        nextDeclaration
-      );
-      updates.medicalCertificateStatus = nextCertificateStatus;
-      if (nextCertificateStatus !== currentCertificateStatus) {
-        updates.medicalCertificateStatusUpdatedBy = decoded.uid;
-        updates.medicalCertificateStatusUpdatedAt = FieldValue.serverTimestamp();
-      }
-    }
-
-    const mergedForPricing = { ...currentData, ...updates };
-    const pricingPatch = await buildManagerRegistrationPricingPatch(
-      mergedForPricing,
-      currentData
-    );
-
-    await docRef.set(
-      {
-        ...updates,
-        ...pricingPatch,
-        ...statusPatch,
-        reviewedBy: decoded.uid,
-        reviewedAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true }
-    );
-
-    logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_UPDATED, decoded.uid, {
-      resource: "clubRegistration",
-      resourceId: id,
-      details: { fields: Object.keys(updates) },
-      success: true,
-    });
-
-    return jsonNoStore({ success: true }, { status: 200 });
-  } catch (error) {
-    console.error("[api/club/registration PATCH]", error);
-    return jsonNoStore({ error: "Impossible de mettre à jour le dossier" }, { status: 500 });
-  }
+  return handleManagerRegistrationPatch(req);
 }
 
 /**
@@ -415,6 +204,7 @@ export async function POST(req: Request) {
           config: activeConfig,
           submitterUid: decoded.uid,
           submitterAccountEmail: decoded.email ?? null,
+          submitterRole: role,
           isMinor: isMinorAt(sanitizedPayload.birthDate),
           medicalCertificateStatus: initialMedicalCertificateStatus(
             sanitizedPayload.medicalCertificateDeclaration

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
@@ -20,6 +20,7 @@ import { ReductionReferenceCodeAdminFields } from "../ReductionReferenceCodeAdmi
 import { RegistrationMultiSelectField } from "../RegistrationMultiSelectField";
 import type { RegistrationDraft } from "../registration-defaults";
 import { PaymentTrackingSection } from "../secretariat/PaymentTrackingSection";
+import { SecretariatAidAmountFields } from "../secretariat/SecretariatAidAmountFields";
 import { SecretariatPaymentNotesSection } from "../secretariat/SecretariatPaymentNotesSection";
 import { RegistrationMedicalDossierDetail } from "./RegistrationSupplementarySections";
 import { DetailSectionTitle } from "./DetailSectionTitle";
@@ -61,6 +62,7 @@ export function MembershipRequestDetailFormSecondary({
     amountDiffersFromQuote,
     fetchDetail,
     updateField,
+    updateReductionTypes,
     updateMedicalDeclaration,
     applyCalculatedAmount,
     persistQuote,
@@ -157,7 +159,7 @@ export function MembershipRequestDetailFormSecondary({
               value: reduction.id,
               label: reduction.label,
             }))}
-            onChange={(value) => updateField("reductionTypes", value)}
+            onChange={(value) => updateReductionTypes(value)}
           />
         </Grid>
         <ReductionReferenceCodeAdminFields
@@ -165,6 +167,13 @@ export function MembershipRequestDetailFormSecondary({
           reductionTypes={form.reductionTypes}
           reductionReferenceCodes={form.reductionReferenceCodes}
           onReferenceCodesChange={(codes) => updateField("reductionReferenceCodes", codes)}
+        />
+        <SecretariatAidAmountFields
+          config={config}
+          reductionTypes={form.reductionTypes}
+          reductionReferenceCodes={form.reductionReferenceCodes}
+          paymentAids={form.paymentAids}
+          onPaymentAidsChange={(paymentAids) => updateField("paymentAids", paymentAids)}
         />
         <Grid size={{ xs: 12, sm: 6 }}>
           <FormControlLabel

--- a/src/components/club-registration/membership-requests/membership-request-detail-shared.ts
+++ b/src/components/club-registration/membership-requests/membership-request-detail-shared.ts
@@ -2,6 +2,13 @@ import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types"
 import { getEnabledSites } from "@/lib/club-registration-config/helpers";
 import { formatRegistrationSiteLabel } from "@/lib/club-registration-config/site-display";
 import {
+  syncPaymentAidsWithReductionTypes,
+} from "@/lib/club-registration/payment/payment-draft-helpers";
+import {
+  stripUnselectedReductionReferenceCodes,
+} from "@/lib/club-registration/reduction-reference-codes";
+import { validateAdminAids } from "@/lib/club-registration/validate-admin-aids";
+import {
   MEDICAL_CERTIFICATE_STATUS_LABELS,
   MEDICAL_CERTIFICATE_STATUS_VALUES,
 } from "@/lib/club-registration/medical-certificate";
@@ -113,6 +120,50 @@ export function parseAmountCents(value: string): number | null {
   const amount = Number(normalized);
   if (!Number.isFinite(amount) || amount < 0) return null;
   return Math.round(amount * 100);
+}
+
+export function buildEditableReductionTypesUpdate(
+  form: EditableRegistration,
+  reductionTypes: string[],
+  config: RegistrationConfigV1
+): Pick<EditableRegistration, "reductionTypes" | "paymentAids" | "reductionReferenceCodes"> {
+  const labelsByType = Object.fromEntries(config.aidRules.map((rule) => [rule.id, rule.label]));
+  return {
+    reductionTypes,
+    paymentAids: syncPaymentAidsWithReductionTypes(
+      form.paymentAids,
+      reductionTypes,
+      labelsByType
+    ),
+    reductionReferenceCodes: stripUnselectedReductionReferenceCodes(
+      form.reductionReferenceCodes,
+      new Set(reductionTypes)
+    ),
+  };
+}
+
+export function validateEditableRegistrationAids(
+  form: EditableRegistration,
+  config: RegistrationConfigV1
+): string | null {
+  const issue = validateAdminAids(
+    {
+      birthDate: form.birthDate,
+      mainSectionId: form.mainSectionId,
+      slotIds: form.slotIds,
+      additionalSectionIds: form.additionalSectionIds,
+      wantsCompetitorExtras: form.wantsCompetitorExtras,
+      wantsOptionalJersey: form.wantsOptionalJersey,
+      competitionIds: form.competitionIds,
+      familyRegistrationOrder: form.familyRegistrationOrder as FamilyRegistrationOrder,
+      sex: form.sex,
+      firstFemaleRegistrationSqy: form.firstFemaleRegistrationSqy,
+      reductionTypes: form.reductionTypes,
+      paymentAids: form.paymentAids,
+    },
+    config
+  );
+  return issue?.message ?? null;
 }
 
 export function registrationStatusChipProps(status: string | undefined): {

--- a/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
+++ b/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
@@ -16,6 +16,8 @@ import {
   createEmptyRepresentative,
   formToPricingInput,
   parseAmountCents,
+  buildEditableReductionTypesUpdate,
+  validateEditableRegistrationAids,
 } from "./membership-request-detail-shared";
 import type {
   EditableRegistration,
@@ -133,6 +135,17 @@ export function useMembershipRequestDetail(
     setForm((current) => (current ? { ...current, [field]: value } : current));
   };
 
+  const updateReductionTypes = (reductionTypes: string[]) => {
+    setForm((current) =>
+      current
+        ? {
+            ...current,
+            ...buildEditableReductionTypesUpdate(current, reductionTypes, config),
+          }
+        : current
+    );
+  };
+
   const patchFfttFields = (patch: RegistrationFfttPatch) => {
     setForm((current) => (current ? { ...current, ...patch } : current));
   };
@@ -206,6 +219,12 @@ export function useMembershipRequestDetail(
       return false;
     }
 
+    const aidValidationError = validateEditableRegistrationAids(form, config);
+    if (aidValidationError) {
+      setError(aidValidationError);
+      return false;
+    }
+
     setSaving(true);
     setError(null);
     setSuccess(null);
@@ -263,6 +282,7 @@ export function useMembershipRequestDetail(
             applicantNotes: form.applicantNotes.trim() || undefined,
             reviewNotes: form.reviewNotes,
             voluntaryDonationCents: form.voluntaryDonationCents,
+            paymentAids: form.paymentAids,
             ...(amountCents !== null ? { paymentAmountCents: amountCents } : {}),
           }),
         }
@@ -417,6 +437,7 @@ export function useMembershipRequestDetail(
     amountDiffersFromQuote,
     fetchDetail,
     updateField,
+    updateReductionTypes,
     patchFfttFields,
     updateMedicalDeclaration,
     updateRepresentative,

--- a/src/components/club-registration/secretariat/SecretariatAidAmountFields.tsx
+++ b/src/components/club-registration/secretariat/SecretariatAidAmountFields.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+import {
+  findAidRuleById,
+  getAidRuleFixedAmountCents,
+  getAidRuleMaxAmountCents,
+} from "@/lib/club-registration-config/aid-rules";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import { formatCentsAsEuros } from "@/lib/pricing";
+import { AidEuroAmountField } from "../AidEuroAmountField";
+import {
+  findPaymentAid,
+  normalizePaymentAidList,
+  upsertPaymentAid,
+} from "@/lib/club-registration/payment/payment-draft-helpers";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import { getReductionReferenceCode } from "@/lib/club-registration/reduction-reference-codes";
+
+type Props = {
+  config: RegistrationConfigV1;
+  reductionTypes: string[];
+  reductionReferenceCodes: Record<string, string>;
+  paymentAids: PaymentAid[];
+  onPaymentAidsChange: (aids: PaymentAid[]) => void;
+};
+
+const AID_AMOUNT_FIELD_SX = {
+  width: "100%",
+  maxWidth: 220,
+} as const;
+
+function aidMaxAmountHelperText(ruleMaxCents: number | undefined): string | undefined {
+  if (ruleMaxCents === undefined) return undefined;
+  return `Montant maximum : ${formatCentsAsEuros(ruleMaxCents)}`;
+}
+
+export function SecretariatAidAmountFields({
+  config,
+  reductionTypes,
+  reductionReferenceCodes,
+  paymentAids,
+  onPaymentAidsChange,
+}: Props) {
+  const normalizedAids = normalizePaymentAidList(paymentAids);
+  const selectedRules = reductionTypes
+    .map((id) => findAidRuleById(config, id))
+    .filter((rule): rule is NonNullable<typeof rule> => rule !== undefined);
+
+  if (selectedRules.length === 0) {
+    return null;
+  }
+
+  const labelsByType = Object.fromEntries(config.aidRules.map((rule) => [rule.id, rule.label]));
+
+  const updateAidAmount = (aidId: string, amountCents: number) => {
+    const existing = findPaymentAid(normalizedAids, aidId);
+    const reference = getReductionReferenceCode(reductionReferenceCodes, aidId);
+    onPaymentAidsChange(
+      upsertPaymentAid(
+        normalizedAids,
+        {
+          type: aidId,
+          label: labelsByType[aidId] ?? aidId,
+          amountCents,
+          ...(reference ? { reference } : {}),
+          ...(existing?.note ? { note: existing.note } : {}),
+        },
+        { retainZero: true }
+      )
+    );
+  };
+
+  return (
+    <Box sx={{ gridColumn: "1 / -1" }}>
+      <Stack spacing={2}>
+        <Typography variant="subtitle2" fontWeight={600}>
+          Montants des aides
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Ajustez le montant déclaré pour chaque aide cochée. Ces montants sont déduits du reste
+          à payer estimé.
+        </Typography>
+        <Stack spacing={2}>
+          {selectedRules.map((rule) => {
+            const aid = findPaymentAid(normalizedAids, rule.id);
+            const fixedAmountCents = getAidRuleFixedAmountCents(rule);
+            const maxAmountCents = getAidRuleMaxAmountCents(rule);
+
+            if (fixedAmountCents !== undefined) {
+              return (
+                <Typography
+                  key={rule.id}
+                  variant="body2"
+                  data-field={`paymentAid.${rule.id}`}
+                >
+                  <strong>{rule.label}</strong> — montant fixe :{" "}
+                  {formatCentsAsEuros(fixedAmountCents)}
+                </Typography>
+              );
+            }
+
+            const maxHelperText = aidMaxAmountHelperText(maxAmountCents);
+            return (
+              <AidEuroAmountField
+                key={rule.id}
+                label={`Montant (${rule.label})`}
+                amountCents={aid?.amountCents ?? 0}
+                onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
+                required
+                sx={AID_AMOUNT_FIELD_SX}
+                dataField={`paymentAid.${rule.id}`}
+                {...(maxHelperText ? { helperText: maxHelperText } : {})}
+              />
+            );
+          })}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/lib/club-registration/build-manager-registration-aids-patch.test.ts
+++ b/src/lib/club-registration/build-manager-registration-aids-patch.test.ts
@@ -1,0 +1,54 @@
+import { buildManagerRegistrationAidsPatch } from "./build-manager-registration-aids-patch";
+import type { RegistrationPayment } from "./payment/types";
+
+describe("buildManagerRegistrationAidsPatch", () => {
+  const config = {
+    aidRules: [
+      { id: "pass_sport", label: "Pass Sport", effect: { type: "admin_review" as const } },
+    ],
+  } as const;
+
+  it("persiste paymentAids et recalcule payment.aids", () => {
+    const currentPayment: RegistrationPayment = {
+      totalAmountCents: 10_000,
+      assistanceTotalAmountCents: 2_000,
+      amountToPayCents: 8_000,
+      aids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 2_000 }],
+      paymentMethod: "card",
+      paymentInstallments: 1,
+      expectedPayments: [],
+      receivedPayments: [],
+      paidAmountCents: 0,
+      remainingAmountCents: 8_000,
+      paymentStatus: "pending_validation",
+    };
+
+    const patch = buildManagerRegistrationAidsPatch(
+      {
+        reductionTypes: ["pass_sport"],
+        reductionReferenceCodes: { pass_sport: "ABC1234567" },
+        paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 3_000 }],
+      },
+      { payment: currentPayment },
+      config as never,
+      [{ type: "pass_sport", label: "Pass Sport", amountCents: 3_000 }]
+    );
+
+    expect(patch.paymentAids).toEqual([
+      { type: "pass_sport", label: "Pass Sport", amountCents: 3_000 },
+    ]);
+    expect(patch.payment).toMatchObject({
+      assistanceTotalAmountCents: 3_000,
+      amountToPayCents: 7_000,
+      remainingAmountCents: 7_000,
+      aids: [
+        {
+          type: "pass_sport",
+          label: "Pass Sport",
+          amountCents: 3_000,
+          reference: "ABC1234567",
+        },
+      ],
+    });
+  });
+});

--- a/src/lib/club-registration/build-manager-registration-aids-patch.ts
+++ b/src/lib/club-registration/build-manager-registration-aids-patch.ts
@@ -1,0 +1,152 @@
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import { z } from "zod";
+import { mergePaymentAidsFromDraft } from "@/lib/club-registration/payment/build-payment-from-draft";
+import {
+  normalizeRegistrationPayment,
+  paymentToFirestoreUpdate,
+} from "@/lib/club-registration/payment/normalize-payment";
+import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
+import { recalculateRegistrationPayment } from "@/lib/club-registration/payment/payment-mutations";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import { paymentAidPayloadSchema } from "@/lib/club-registration/payment-payload-schema";
+import { validateAdminAids } from "@/lib/club-registration/validate-admin-aids";
+import { PRICING_CATALOG_VERSION, type FamilyRegistrationOrder, type PriceQuote } from "@/lib/pricing/types";
+
+const EMPTY_QUOTE: PriceQuote = {
+  catalogVersion: PRICING_CATALOG_VERSION,
+  segmentLabel: "",
+  lines: [],
+  subtotalCents: 0,
+  totalCents: 0,
+  warnings: [],
+  requiresAdminReview: false,
+};
+
+export function parseManagerPaymentAidsInput(
+  raw: unknown
+): { ok: true; data: PaymentAid[] } | { ok: false; error: string } {
+  const parsed = z.array(paymentAidPayloadSchema).safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: "Montants d'aides invalides" };
+  }
+  return { ok: true, data: normalizePaymentAidList(parsed.data) };
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function readFamilyRegistrationOrder(value: unknown): FamilyRegistrationOrder {
+  if (value === "second" || value === "third_or_more") return value;
+  return "none";
+}
+
+function readSex(value: unknown): "female" | "male" | "other" {
+  if (value === "female" || value === "male" || value === "other") return value;
+  return "other";
+}
+
+function buildAidValidationDraft(
+  mergedData: Record<string, unknown>,
+  paymentAids: PaymentAid[]
+) {
+  return {
+    birthDate: typeof mergedData.birthDate === "string" ? mergedData.birthDate : "",
+    mainSectionId:
+      typeof mergedData.mainSectionId === "string" ? mergedData.mainSectionId : "",
+    slotIds: readStringArray(mergedData.slotIds),
+    additionalSectionIds: readStringArray(mergedData.additionalSectionIds),
+    wantsCompetitorExtras: mergedData.wantsCompetitorExtras === true,
+    wantsOptionalJersey: mergedData.wantsOptionalJersey === true,
+    competitionIds: readStringArray(mergedData.competitionIds),
+    familyRegistrationOrder: readFamilyRegistrationOrder(mergedData.familyRegistrationOrder),
+    sex: readSex(mergedData.sex),
+    firstFemaleRegistrationSqy:
+      mergedData.firstFemaleRegistrationSqy === true ? true : undefined,
+    reductionTypes: readStringArray(mergedData.reductionTypes),
+    paymentAids,
+  };
+}
+
+export function resolveManagerPaymentAidsUpdate(
+  mergedData: Record<string, unknown>,
+  currentData: Record<string, unknown>,
+  rawPaymentAids: unknown,
+  config: RegistrationConfigV1
+): { ok: true; patch: Record<string, unknown> } | { ok: false; error: string } {
+  const parsedAids = parseManagerPaymentAidsInput(rawPaymentAids);
+  if (!parsedAids.ok) {
+    return parsedAids;
+  }
+
+  const aidIssue = validateAdminAids(buildAidValidationDraft(mergedData, parsedAids.data), config);
+  if (aidIssue) {
+    return { ok: false, error: aidIssue.message };
+  }
+
+  return {
+    ok: true,
+    patch: buildManagerRegistrationAidsPatch(
+      mergedData,
+      currentData,
+      config,
+      parsedAids.data
+    ),
+  };
+}
+
+function readReductionReferenceCodes(value: unknown): Record<string, string> {
+  if (typeof value !== "object" || value === null) return {};
+  const next: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string" && raw.trim()) {
+      next[key] = raw.trim();
+    }
+  }
+  return next;
+}
+
+/** Persiste `paymentAids` et recalcule `payment.aids` si un suivi paiement existe déjà. */
+export function buildManagerRegistrationAidsPatch(
+  mergedData: Record<string, unknown>,
+  currentData: Record<string, unknown>,
+  config: RegistrationConfigV1,
+  normalizedPaymentAids: PaymentAid[]
+): Record<string, unknown> {
+  const reductionTypes = readStringArray(mergedData.reductionTypes);
+  const reductionReferenceCodes = readReductionReferenceCodes(
+    mergedData.reductionReferenceCodes
+  );
+
+  const mergedAids = mergePaymentAidsFromDraft({
+    paymentAids: normalizedPaymentAids,
+    reductionTypes,
+    reductionReferenceCodes,
+    config,
+    quote: EMPTY_QUOTE,
+    paymentMethod: "card",
+    paymentInstallments: 1,
+    holidayVoucherAmountCents: null,
+    remainingPaymentMethod: "",
+    paymentNote: "",
+    specialPaymentNote: "",
+  }).map((aid) => {
+    const reference = reductionReferenceCodes[aid.type]?.trim();
+    return reference ? { ...aid, reference } : aid;
+  });
+
+  const patch: Record<string, unknown> = {
+    paymentAids: normalizedPaymentAids,
+  };
+
+  const payment = normalizeRegistrationPayment(currentData);
+  if (payment) {
+    const nextPayment = recalculateRegistrationPayment(
+      { ...payment, aids: mergedAids },
+      { preserveManualFollowUp: true }
+    );
+    Object.assign(patch, paymentToFirestoreUpdate(nextPayment));
+  }
+
+  return patch;
+}

--- a/src/lib/club-registration/patch-manager-registration.ts
+++ b/src/lib/club-registration/patch-manager-registration.ts
@@ -1,0 +1,243 @@
+import { FieldValue, type Firestore } from "firebase-admin/firestore";
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { adminAuth } from "@/lib/firebase-admin";
+import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
+import {
+  isMedicalCertificateStatus,
+  normalizeMedicalCertificateStatus,
+} from "@/lib/club-registration/medical-certificate";
+import { buildManagerRegistrationPricingPatch } from "@/lib/club-registration/build-manager-registration-pricing-patch";
+import { resolveManagerPaymentAidsUpdate } from "@/lib/club-registration/build-manager-registration-aids-patch";
+import {
+  ensureRegistrationConfigSeeded,
+  getActiveRegistrationConfig,
+} from "@/lib/club-registration-config/store";
+import { isValidVoluntaryDonationCents } from "@/lib/pricing/donation-discount";
+import {
+  APPLICANT_NOTES_MAX_LENGTH,
+  isApplicantNotesTooLong,
+  normalizeApplicantNotes,
+} from "@/lib/club-registration/applicant-notes";
+import {
+  findRegistrationLicenseConflicts,
+  formatBlockingLicenseConflictMessage,
+} from "@/lib/club-registration/find-registration-license-conflicts";
+import { MANAGER_EDITABLE_FIELDS } from "@/lib/club-registration/registration-api-fields";
+import { ffttLicenseLookupSchema } from "@/lib/club-registration/schema-base";
+import { normalizeRegistrationLastNamePatch } from "@/lib/shared/person-name-format";
+
+const COLLECTION = "clubRegistrations";
+const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
+const FFTT_LICENSE_RE = /^[0-9]{5,12}$/;
+
+export async function patchManagerRegistration(
+  req: Request,
+  registrationId: string,
+  sessionCookie: string,
+  db: Firestore
+) {
+  const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+  const role = resolveRole(decoded.role as string | undefined);
+  if (!hasAnyRole(role, MANAGER_ROLES)) {
+    return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
+  }
+
+  const body = ((await req.json()) ?? {}) as Record<string, unknown>;
+  const updates: Record<string, unknown> = {};
+  for (const field of MANAGER_EDITABLE_FIELDS) {
+    if (body[field] !== undefined) {
+      updates[field] = body[field];
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return jsonNoStore({ error: "Aucun champ modifiable fourni" }, { status: 400 });
+  }
+
+  Object.assign(updates, normalizeRegistrationLastNamePatch(updates));
+
+  if (updates.applicantNotes !== undefined) {
+    if (typeof updates.applicantNotes !== "string") {
+      return jsonNoStore({ error: "Précisions de l'inscrit invalides" }, { status: 400 });
+    }
+    if (isApplicantNotesTooLong(updates.applicantNotes)) {
+      return jsonNoStore(
+        {
+          error: `Les précisions de l'inscrit ne peuvent pas dépasser ${APPLICANT_NOTES_MAX_LENGTH} caractères`,
+        },
+        { status: 400 }
+      );
+    }
+    const normalized = normalizeApplicantNotes(updates.applicantNotes);
+    updates.applicantNotes = normalized ?? FieldValue.delete();
+  }
+
+  if (
+    updates.voluntaryDonationCents !== undefined &&
+    (!Number.isInteger(updates.voluntaryDonationCents as number) ||
+      !isValidVoluntaryDonationCents(updates.voluntaryDonationCents as number))
+  ) {
+    return jsonNoStore({ error: "Don libre invalide (0 € ou minimum 1 €)." }, { status: 400 });
+  }
+
+  if (
+    updates.paymentAmountCents !== undefined &&
+    (!Number.isInteger(updates.paymentAmountCents) ||
+      (updates.paymentAmountCents as number) < 0)
+  ) {
+    return jsonNoStore({ error: "Montant de paiement invalide" }, { status: 400 });
+  }
+
+  if (
+    updates.medicalCertificateStatus !== undefined &&
+    !isMedicalCertificateStatus(updates.medicalCertificateStatus)
+  ) {
+    return jsonNoStore({ error: "Statut de certificat médical invalide" }, { status: 400 });
+  }
+
+  if (updates.ffttLicense !== undefined) {
+    if (updates.ffttLicense === null || updates.ffttLicense === "") {
+      updates.ffttLicense = FieldValue.delete();
+      if (updates.ffttLicenseLookup === undefined) {
+        updates.ffttLicenseLookup = FieldValue.delete();
+      }
+    } else if (
+      typeof updates.ffttLicense !== "string" ||
+      !FFTT_LICENSE_RE.test(updates.ffttLicense)
+    ) {
+      return jsonNoStore({ error: "Numéro de licence invalide" }, { status: 400 });
+    } else {
+      const licenseConflicts = await findRegistrationLicenseConflicts(
+        db,
+        updates.ffttLicense,
+        registrationId
+      );
+      if (licenseConflicts.blocking.length > 0) {
+        const message = formatBlockingLicenseConflictMessage(licenseConflicts.blocking);
+        return jsonNoStore(
+          {
+            error: message,
+            fieldErrors: { ffttLicense: [message] },
+          },
+          { status: 400 }
+        );
+      }
+    }
+  }
+
+  if (updates.ffttLicenseLookup !== undefined) {
+    if (updates.ffttLicenseLookup === null) {
+      updates.ffttLicenseLookup = FieldValue.delete();
+    } else {
+      const parsed = ffttLicenseLookupSchema.safeParse(updates.ffttLicenseLookup);
+      if (!parsed.success) {
+        return jsonNoStore({ error: "Données de lookup FFTT invalides" }, { status: 400 });
+      }
+      updates.ffttLicenseLookup = parsed.data;
+    }
+  }
+
+  const docRef = db.collection(COLLECTION).doc(registrationId);
+  const snap = await docRef.get();
+  if (!snap.exists) {
+    return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
+  }
+
+  const currentData = snap.data() ?? {};
+  const currentStatus = currentData.status;
+  const statusPatch = currentStatus === "submitted" ? { status: "in_review" } : {};
+
+  if (
+    updates.medicalCertificateDeclaration !== undefined ||
+    updates.medicalCertificateStatus !== undefined
+  ) {
+    const nextDeclaration =
+      (updates.medicalCertificateDeclaration as string | undefined) ??
+      (currentData.medicalCertificateDeclaration as string | undefined);
+    const currentCertificateStatus = currentData.medicalCertificateStatus;
+    const requestedCertificateStatus =
+      updates.medicalCertificateStatus ?? currentCertificateStatus;
+    const nextCertificateStatus = normalizeMedicalCertificateStatus(
+      requestedCertificateStatus,
+      nextDeclaration
+    );
+    updates.medicalCertificateStatus = nextCertificateStatus;
+    if (nextCertificateStatus !== currentCertificateStatus) {
+      updates.medicalCertificateStatusUpdatedBy = decoded.uid;
+      updates.medicalCertificateStatusUpdatedAt = FieldValue.serverTimestamp();
+    }
+  }
+
+  const mergedForPricing = { ...currentData, ...updates };
+  const pricingPatch = await buildManagerRegistrationPricingPatch(
+    mergedForPricing,
+    currentData
+  );
+
+  if (updates.paymentAids !== undefined) {
+    await ensureRegistrationConfigSeeded();
+    const config = await getActiveRegistrationConfig();
+    const aidsUpdate = resolveManagerPaymentAidsUpdate(
+      mergedForPricing,
+      currentData,
+      updates.paymentAids,
+      config
+    );
+    if (!aidsUpdate.ok) {
+      return jsonNoStore({ error: aidsUpdate.error }, { status: 400 });
+    }
+    Object.assign(updates, aidsUpdate.patch);
+  }
+
+  await docRef.set(
+    {
+      ...updates,
+      ...pricingPatch,
+      ...statusPatch,
+      reviewedBy: decoded.uid,
+      reviewedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_UPDATED, decoded.uid, {
+    resource: "clubRegistration",
+    resourceId: registrationId,
+    details: { fields: Object.keys(updates) },
+    success: true,
+  });
+
+  return jsonNoStore({ success: true }, { status: 200 });
+}
+
+export async function handleManagerRegistrationPatch(req: Request) {
+  if (!validateOrigin(req)) {
+    return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const id = url.searchParams.get("id");
+  if (!id) {
+    return jsonNoStore({ error: "Paramètre 'id' requis" }, { status: 400 });
+  }
+
+  const { cookies } = await import("next/headers");
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get("__session")?.value;
+  if (!sessionCookie) {
+    return jsonNoStore({ error: "Authentification requise" }, { status: 401 });
+  }
+
+  const { getFirestoreAdmin } = await import("@/lib/firebase-admin");
+  const db = getFirestoreAdmin();
+
+  try {
+    return await patchManagerRegistration(req, id, sessionCookie, db);
+  } catch (error) {
+    console.error("[api/club/registration PATCH]", error);
+    return jsonNoStore({ error: "Impossible de mettre à jour le dossier" }, { status: 500 });
+  }
+}

--- a/src/lib/club-registration/payment-requested.ts
+++ b/src/lib/club-registration/payment-requested.ts
@@ -20,6 +20,7 @@ import {
 import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+import { formatRegistrationPaymentEmailsForStorage } from "@/lib/club-registration/resolve-registration-contact-email";
 import type { PriceQuote } from "@/lib/pricing/types";
 
 export function validateRegistrationStripeCheckout(params: {
@@ -104,7 +105,7 @@ export function buildPaymentRequestedFirestoreUpdate(params: {
   donationPricing: DonationPricingBreakdown | null;
   amountToPayCents: number;
   requestedByUid: string;
-  paymentEmail: string;
+  paymentEmails: string[];
 }): DocumentData {
   const waitingPayment = params.payment
     ? recalculateRegistrationPayment({
@@ -125,7 +126,7 @@ export function buildPaymentRequestedFirestoreUpdate(params: {
     paymentStatus: "pending",
     paymentRequestedAt: FieldValue.serverTimestamp(),
     paymentRequestedBy: params.requestedByUid,
-    paymentEmailSentTo: params.paymentEmail,
+    paymentEmailSentTo: formatRegistrationPaymentEmailsForStorage(params.paymentEmails),
     stripeCheckoutSessionId: FieldValue.delete(),
     stripeCheckoutUrl: FieldValue.delete(),
     updatedAt: FieldValue.serverTimestamp(),
@@ -148,7 +149,7 @@ export async function persistPaymentRequestedAndNotify(params: {
   quote: PriceQuote | null;
   donationPricing: DonationPricingBreakdown | null;
   amountToPayCents: number;
-  paymentEmail: string;
+  paymentEmails: string[];
   adherentName: string;
   baseUrl: string;
   requestedByUid: string;
@@ -161,7 +162,7 @@ export async function persistPaymentRequestedAndNotify(params: {
       donationPricing: params.donationPricing,
       amountToPayCents: params.amountToPayCents,
       requestedByUid: params.requestedByUid,
-      paymentEmail: params.paymentEmail,
+      paymentEmails: params.paymentEmails,
     }),
     { merge: true }
   );
@@ -183,7 +184,7 @@ export async function persistPaymentRequestedAndNotify(params: {
   });
 
   await sendMail({
-    to: params.paymentEmail,
+    to: params.paymentEmails,
     subject: buildPaymentRequestEmailSubject(params.adherentName, emailVariant),
     text: paymentMail.text,
     html: paymentMail.html,

--- a/src/lib/club-registration/persist-registration-on-submit.ts
+++ b/src/lib/club-registration/persist-registration-on-submit.ts
@@ -1,4 +1,5 @@
 import { FieldValue } from "firebase-admin/firestore";
+import type { UserRole } from "@/lib/auth/roles";
 import type { MedicalCertificateStatus } from "@/lib/club-registration/medical-certificate";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { calculateQuoteWithConfig } from "@/lib/club-registration-config/pricing-resolve";
@@ -12,12 +13,21 @@ export function buildRegistrationSubmitDocument(params: {
   config: RegistrationConfigV1;
   submitterUid: string;
   submitterAccountEmail: string | null;
+  submitterRole: UserRole;
   isMinor: boolean;
   medicalCertificateStatus: MedicalCertificateStatus;
   now: ReturnType<typeof FieldValue.serverTimestamp>;
 }): Record<string, unknown> {
-  const { payload, config, submitterUid, submitterAccountEmail, isMinor, medicalCertificateStatus, now } =
-    params;
+  const {
+    payload,
+    config,
+    submitterUid,
+    submitterAccountEmail,
+    submitterRole,
+    isMinor,
+    medicalCertificateStatus,
+    now,
+  } = params;
 
   const pricingCtx = buildPricingContext({
     birthDate: payload.birthDate,
@@ -84,6 +94,7 @@ export function buildRegistrationSubmitDocument(params: {
     medicalCertificateStatus,
     submitterUid,
     submitterAccountEmail,
+    submitterRole,
     schemaVersion: 1,
     status: "submitted",
     submittedAt: now,

--- a/src/lib/club-registration/registration-api-fields.ts
+++ b/src/lib/club-registration/registration-api-fields.ts
@@ -45,6 +45,7 @@ export const REGISTRATION_CLIENT_FIELDS = [
   "isMinor",
   "submitterUid",
   "submitterAccountEmail",
+  "submitterRole",
   "schemaVersion",
   "status",
   "reviewNotes",
@@ -117,6 +118,7 @@ export const MANAGER_EDITABLE_FIELDS = [
   "applicantNotes",
   "reviewNotes",
   "paymentAmountCents",
+  "paymentAids",
   "handisportPracticeLevel",
   "voluntaryDonationCents",
 ] as const;

--- a/src/lib/club-registration/request-payment-checkout.ts
+++ b/src/lib/club-registration/request-payment-checkout.ts
@@ -29,6 +29,7 @@ import { validateRegistrationStripeCheckout } from "@/lib/club-registration/paym
 import type { DonationPricingBreakdown } from "@/lib/pricing/donation-discount";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+import { formatRegistrationPaymentEmailsForStorage } from "@/lib/club-registration/resolve-registration-contact-email";
 import type { PriceQuote } from "@/lib/pricing/types";
 
 export {
@@ -52,7 +53,7 @@ export async function processManualPaymentFollowUp(params: {
   donationPricing: DonationPricingBreakdown | null;
   amountToPayCents: number;
   paymentMethod: RegistrationPayment["paymentMethod"];
-  paymentEmail: string;
+  paymentEmails: string[];
   adherentName: string;
   baseUrl: string;
   requestedByUid: string;
@@ -85,7 +86,7 @@ export async function processManualPaymentFollowUp(params: {
       donationDiscountCents: params.donationPricing?.donationDiscountCents ?? 0,
       paymentRequestedAt: FieldValue.serverTimestamp(),
       paymentRequestedBy: params.requestedByUid,
-      paymentEmailSentTo: params.paymentEmail,
+      paymentEmailSentTo: formatRegistrationPaymentEmailsForStorage(params.paymentEmails),
       updatedAt: FieldValue.serverTimestamp(),
     },
     { merge: true }
@@ -116,7 +117,7 @@ export async function processManualPaymentFollowUp(params: {
 
   try {
     await sendMail({
-      to: params.paymentEmail,
+      to: params.paymentEmails,
       subject: `Instructions de règlement — adhésion ${params.adherentName}`,
       html: instructionsMail.html,
       text: instructionsMail.text,

--- a/src/lib/club-registration/resolve-registration-contact-email.test.ts
+++ b/src/lib/club-registration/resolve-registration-contact-email.test.ts
@@ -1,9 +1,51 @@
-import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve-registration-contact-email";
+import {
+  formatRegistrationPaymentEmailsForStorage,
+  resolveRegistrationContactEmail,
+  resolveRegistrationPaymentRecipientEmails,
+  resolveRegistrationRepresentativeEmails,
+} from "@/lib/club-registration/resolve-registration-contact-email";
+import { USER_ROLES } from "@/lib/auth/roles";
+
+describe("resolveRegistrationRepresentativeEmails", () => {
+  it("retourne tous les e-mails valides des représentants", () => {
+    expect(
+      resolveRegistrationRepresentativeEmails({
+        representatives: [
+          { email: "parent1@example.com" },
+          { email: "parent2@example.com" },
+        ],
+      })
+    ).toEqual(["parent1@example.com", "parent2@example.com"]);
+  });
+
+  it("déduplique les adresses identiques", () => {
+    expect(
+      resolveRegistrationRepresentativeEmails({
+        representatives: [
+          { email: "Parent@Example.com" },
+          { email: "parent@example.com" },
+        ],
+      })
+    ).toEqual(["Parent@Example.com"]);
+  });
+});
 
 describe("resolveRegistrationContactEmail", () => {
-  it("privilégie l'e-mail adhérent", () => {
+  it("privilégie les représentants pour un mineur", () => {
     expect(
       resolveRegistrationContactEmail({
+        isMinor: true,
+        adherentEmail: "jean@example.com",
+        representatives: [{ email: "parent@example.com" }],
+        submitterAccountEmail: "staff@club.fr",
+      })
+    ).toBe("parent@example.com");
+  });
+
+  it("utilise l'e-mail adhérent pour un majeur", () => {
+    expect(
+      resolveRegistrationContactEmail({
+        isMinor: false,
         adherentEmail: "jean@example.com",
         representatives: [{ email: "parent@example.com" }],
         submitterAccountEmail: "staff@club.fr",
@@ -21,13 +63,103 @@ describe("resolveRegistrationContactEmail", () => {
     ).toBe("parent@example.com");
   });
 
-  it("n'utilise pas l'e-mail du compte soumettant comme contact", () => {
+  it("retombe sur le compte soumettant en dernier recours", () => {
     expect(
       resolveRegistrationContactEmail({
         adherentEmail: "",
         representatives: [],
-        submitterAccountEmail: "staff@club.fr",
+        submitterAccountEmail: "parent@example.com",
       })
-    ).toBeNull();
+    ).toBe("parent@example.com");
+  });
+});
+
+describe("resolveRegistrationPaymentRecipientEmails", () => {
+  it("envoie au compte soumettant pour un parent inscrivant son mineur", () => {
+    expect(
+      resolveRegistrationPaymentRecipientEmails({
+        submitterRole: USER_ROLES.PLAYER,
+        submitterAccountEmail: "parent@example.com",
+        isMinor: true,
+        adherentEmail: "enfant@example.com",
+        representatives: [
+          { email: "parent1@example.com" },
+          { email: "parent2@example.com" },
+        ],
+      })
+    ).toEqual(["parent@example.com"]);
+  });
+
+  it("envoie à tous les représentants si le dossier a été créé par un admin", () => {
+    expect(
+      resolveRegistrationPaymentRecipientEmails({
+        submitterRole: USER_ROLES.ADMIN,
+        submitterAccountEmail: "admin@club.fr",
+        isMinor: true,
+        adherentEmail: "enfant@example.com",
+        representatives: [
+          { email: "parent1@example.com" },
+          { email: "parent2@example.com" },
+        ],
+      })
+    ).toEqual(["parent1@example.com", "parent2@example.com"]);
+  });
+
+  it("envoie aux représentants si le dossier a été créé par le secrétariat", () => {
+    expect(
+      resolveRegistrationPaymentRecipientEmails({
+        submitterRole: USER_ROLES.SECRETARY,
+        submitterAccountEmail: "secretariat@club.fr",
+        isMinor: true,
+        representatives: [{ email: "parent@example.com" }],
+      })
+    ).toEqual(["parent@example.com"]);
+  });
+
+  it("retourne l'e-mail du compte soumettant pour un majeur auto-inscrit", () => {
+    expect(
+      resolveRegistrationPaymentRecipientEmails({
+        submitterRole: USER_ROLES.PLAYER,
+        submitterAccountEmail: "jean@example.com",
+        isMinor: false,
+        adherentEmail: "jean@example.com",
+        representatives: [],
+      })
+    ).toEqual(["jean@example.com"]);
+  });
+
+  it("retombe sur le contact adhérent si le compte soumettant n'a pas d'e-mail", () => {
+    expect(
+      resolveRegistrationPaymentRecipientEmails({
+        submitterRole: USER_ROLES.PLAYER,
+        submitterAccountEmail: null,
+        isMinor: false,
+        adherentEmail: "jean@example.com",
+        representatives: [],
+      })
+    ).toEqual(["jean@example.com"]);
+  });
+
+  it("retombe sur l'e-mail adhérent pour un dossier staff sans représentant", () => {
+    expect(
+      resolveRegistrationPaymentRecipientEmails({
+        submitterRole: USER_ROLES.ADMIN,
+        submitterAccountEmail: "admin@club.fr",
+        isMinor: true,
+        adherentEmail: "enfant@example.com",
+        representatives: [{ email: "" }],
+      })
+    ).toEqual(["enfant@example.com"]);
+  });
+});
+
+describe("formatRegistrationPaymentEmailsForStorage", () => {
+  it("joint les adresses pour l'affichage secrétariat", () => {
+    expect(
+      formatRegistrationPaymentEmailsForStorage([
+        "parent1@example.com",
+        "parent2@example.com",
+      ])
+    ).toBe("parent1@example.com, parent2@example.com");
   });
 });

--- a/src/lib/club-registration/resolve-registration-contact-email.ts
+++ b/src/lib/club-registration/resolve-registration-contact-email.ts
@@ -1,16 +1,106 @@
 import type { DocumentData } from "firebase-admin/firestore";
+import { isMinorAt } from "@/lib/club-registration/age";
+import { isClubRegistrationManager } from "@/lib/club-registration/registration-access";
+import { resolveRole, type UserRole } from "@/lib/auth/roles";
 
-/** Adresse e-mail de contact adhérent pour un dossier (paiement, confirmations…). */
-export function resolveRegistrationContactEmail(data: DocumentData): string | null {
-  if (typeof data.adherentEmail === "string" && data.adherentEmail.includes("@")) {
-    return data.adherentEmail.trim();
-  }
-  if (
-    Array.isArray(data.representatives) &&
-    typeof data.representatives[0]?.email === "string" &&
-    data.representatives[0].email.includes("@")
-  ) {
-    return data.representatives[0].email.trim();
+function isValidEmail(value: unknown): value is string {
+  return typeof value === "string" && value.includes("@");
+}
+
+function trimEmail(value: string): string {
+  return value.trim();
+}
+
+function resolveSubmitterRole(data: DocumentData): UserRole | null {
+  if (typeof data.submitterRole === "string") {
+    return resolveRole(data.submitterRole);
   }
   return null;
+}
+
+function wasSubmittedByClubStaff(data: DocumentData): boolean {
+  const submitterRole = resolveSubmitterRole(data);
+  return submitterRole != null && isClubRegistrationManager(submitterRole);
+}
+
+function isRegistrationMinor(data: DocumentData): boolean {
+  if (data.isMinor === true) return true;
+  if (data.adherentRole === "minor_dependent") return true;
+  if (typeof data.birthDate === "string") {
+    return isMinorAt(data.birthDate);
+  }
+  return false;
+}
+
+/** E-mails des représentants légaux (dédupliqués, ordre conservé). */
+export function resolveRegistrationRepresentativeEmails(data: DocumentData): string[] {
+  if (!Array.isArray(data.representatives)) {
+    return [];
+  }
+
+  const emails: string[] = [];
+  const seen = new Set<string>();
+  for (const rep of data.representatives) {
+    if (typeof rep?.email === "string" && isValidEmail(rep.email)) {
+      const trimmed = trimEmail(rep.email);
+      const key = trimmed.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        emails.push(trimmed);
+      }
+    }
+  }
+  return emails;
+}
+
+function resolveSubmitterAccountEmail(data: DocumentData): string | null {
+  if (typeof data.submitterAccountEmail === "string" && isValidEmail(data.submitterAccountEmail)) {
+    return trimEmail(data.submitterAccountEmail);
+  }
+  return null;
+}
+
+/** Adresse e-mail de contact adhérent pour un dossier (affichage secrétariat, confirmations…). */
+export function resolveRegistrationContactEmail(data: DocumentData): string | null {
+  const representativeEmails = resolveRegistrationRepresentativeEmails(data);
+  if (isRegistrationMinor(data) && representativeEmails.length > 0) {
+    return representativeEmails[0];
+  }
+  if (typeof data.adherentEmail === "string" && isValidEmail(data.adherentEmail)) {
+    return trimEmail(data.adherentEmail);
+  }
+  if (representativeEmails.length > 0) {
+    return representativeEmails[0];
+  }
+  return resolveSubmitterAccountEmail(data);
+}
+
+/**
+ * Destinataires pour demandes et confirmations de paiement.
+ * Compte soumettant par défaut ; représentants légaux si le dossier a été créé par le club (admin/secrétariat).
+ */
+export function resolveRegistrationPaymentRecipientEmails(data: DocumentData): string[] {
+  if (wasSubmittedByClubStaff(data)) {
+    const representativeEmails = resolveRegistrationRepresentativeEmails(data);
+    if (representativeEmails.length > 0) {
+      return representativeEmails;
+    }
+    if (typeof data.adherentEmail === "string" && isValidEmail(data.adherentEmail)) {
+      return [trimEmail(data.adherentEmail)];
+    }
+    const submitterEmail = resolveSubmitterAccountEmail(data);
+    return submitterEmail ? [submitterEmail] : [];
+  }
+
+  const submitterEmail = resolveSubmitterAccountEmail(data);
+  if (submitterEmail) {
+    return [submitterEmail];
+  }
+
+  const contactEmail = resolveRegistrationContactEmail(data);
+  return contactEmail ? [contactEmail] : [];
+}
+
+export function formatRegistrationPaymentEmailsForStorage(emails: string[]): string {
+  return emails.join(", ");
 }

--- a/src/lib/club-registration/spreadsheet/column-labels.ts
+++ b/src/lib/club-registration/spreadsheet/column-labels.ts
@@ -47,6 +47,7 @@ export const SPREADSHEET_COLUMN_LABELS: Record<SpreadsheetColumnId, string> = {
   isMinor: "Mineur",
   submitterUid: "Soumettant du dossier",
   submitterAccountEmail: "E-mail compte soumettant",
+  submitterRole: "Rôle compte soumettant",
   schemaVersion: "Version schéma",
   status: "Statut dossier",
   reviewNotes: "Notes secrétariat",

--- a/src/lib/club-registration/spreadsheet/format-cell-value.ts
+++ b/src/lib/club-registration/spreadsheet/format-cell-value.ts
@@ -45,6 +45,13 @@ const ADHERENT_ROLE_LABELS: Record<string, string> = {
   other_adult: "Autre adulte",
 };
 
+const SUBMITTER_ROLE_LABELS: Record<string, string> = {
+  admin: "Administrateur",
+  secretary: "Secrétariat",
+  coach: "Coach",
+  player: "Joueur",
+};
+
 const SEX_LABELS: Record<string, string> = {
   female: "Femme",
   male: "Homme",
@@ -190,6 +197,8 @@ export function formatSpreadsheetCellValue(
       return formatLastNameForDisplay(typeof value === "string" ? value : undefined);
     case "submitterUid":
       return resolveSpreadsheetUserLabel(value, context, row.submitterAccountEmail);
+    case "submitterRole":
+      return typeof value === "string" ? (SUBMITTER_ROLE_LABELS[value] ?? value) : "";
     case "paymentRequestedBy":
     case "medicalCertificateStatusUpdatedBy":
       return resolveSpreadsheetUserLabel(value, context);

--- a/src/lib/club-registration/spreadsheet/preferences.ts
+++ b/src/lib/club-registration/spreadsheet/preferences.ts
@@ -32,7 +32,7 @@ export type RegistrationsSpreadsheetPreferences = {
   updatedAt?: string | null;
 };
 
-const DEFAULT_HIDDEN_COLUMN_IDS = new Set<SpreadsheetColumnId>(["submitterUid"]);
+const DEFAULT_HIDDEN_COLUMN_IDS = new Set<SpreadsheetColumnId>(["submitterUid", "submitterRole"]);
 
 /** Ordre par défaut : champs utiles au secrétariat en tête, identifiants techniques à la fin. */
 const DEFAULT_COLUMN_ORDER: SpreadsheetColumnId[] = [

--- a/src/lib/email/dispatch-payment-confirmed-email.ts
+++ b/src/lib/email/dispatch-payment-confirmed-email.ts
@@ -1,6 +1,6 @@
 import type { DocumentData } from "firebase-admin/firestore";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
-import { resolveRegistrationContactEmail } from "@/lib/club-registration/resolve-registration-contact-email";
+import { resolveRegistrationPaymentRecipientEmails } from "@/lib/club-registration/resolve-registration-contact-email";
 import { getSqyPingLogoAttachment } from "@/lib/email/logo-attachment";
 import {
   buildPaymentConfirmedEmail,
@@ -28,8 +28,8 @@ export async function dispatchPaymentConfirmedEmail(params: {
   source: PaymentConfirmedSource;
   req?: Request;
 }): Promise<boolean> {
-  const contactEmail = resolveRegistrationContactEmail(params.data);
-  if (!contactEmail) {
+  const paymentEmails = resolveRegistrationPaymentRecipientEmails(params.data);
+  if (paymentEmails.length === 0) {
     return false;
   }
 
@@ -51,7 +51,7 @@ export async function dispatchPaymentConfirmedEmail(params: {
   });
 
   await sendMail({
-    to: contactEmail,
+    to: paymentEmails,
     subject: `Paiement enregistré — adhésion ${adherentName}`,
     html: mail.html,
     text: mail.text,


### PR DESCRIPTION
## Summary
- Les demandes et confirmations de paiement partent vers le compte ayant créé le dossier (`submitterAccountEmail`) pour les dossiers familiaux.
- Pour les dossiers saisis par admin ou secrétariat, les e-mails sont envoyés aux représentants légaux, avec repli sur l'e-mail adhérent puis le compte staff.
- Persistance de `submitterRole` à la création pour distinguer les cas de façon fiable.
- Extraction du PATCH manager et des aides secrétariat (refactor associé au fichier route).

## Test plan
- [x] `npm run check`
- [x] Tests unitaires `resolve-registration-contact-email.test.ts`
- [ ] Demander un paiement sur un dossier mineur créé par un parent → mail au compte parent
- [ ] Demander un paiement sur un dossier créé par admin avec représentants → mail aux représentants
- [ ] Demander un paiement sur un majeur créé par secrétariat avec `adherentEmail` → mail à l'adhérent


Made with [Cursor](https://cursor.com)