### PR TITLE
release: fix filtre À faire validations licence

### DIFF
--- a/src/lib/license-validation/list-license-validations.test.ts
+++ b/src/lib/license-validation/list-license-validations.test.ts
@@ -1,0 +1,34 @@
+import { matchesLicenseStatusFilter } from "@/lib/license-validation/list-license-validations";
+import { normalizeLicenseValidationStatus } from "@/lib/license-validation/license-validation-status";
+import type { LicenseValidationListItem } from "@/lib/license-validation/map-registration";
+
+function item(
+  overrides: Partial<LicenseValidationListItem> = {}
+): LicenseValidationListItem {
+  return {
+    id: "reg_1",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    adherentEmail: "ada@example.com",
+    birthDate: null,
+    ffttLicense: null,
+    licenseValidationStatus: "to_do",
+    wantsCompetitorExtras: false,
+    paymentStatus: null,
+    status: "submitted",
+    submittedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("matchesLicenseStatusFilter", () => {
+  it("treats normalized missing status as to_do", () => {
+    const legacy = item({
+      licenseValidationStatus: normalizeLicenseValidationStatus(undefined),
+    });
+    expect(legacy.licenseValidationStatus).toBe("to_do");
+    expect(matchesLicenseStatusFilter(legacy, "to_do")).toBe(true);
+    expect(matchesLicenseStatusFilter(legacy, "done")).toBe(false);
+    expect(matchesLicenseStatusFilter(legacy, "all")).toBe(true);
+  });
+});

--- a/src/lib/license-validation/list-license-validations.ts
+++ b/src/lib/license-validation/list-license-validations.ts
@@ -22,11 +22,24 @@ export type LicenseValidationPage = {
   nextCursor: string | null;
 };
 
+/**
+ * Firestore `==` ignore les docs sans le champ. Or les dossiers créés avant
+ * l’introduction de `licenseValidationStatus` n’ont pas ce champ : ils doivent
+ * compter comme `to_do` (voir `normalizeLicenseValidationStatus`).
+ * On ne pousse donc le filtre Firestore que pour les statuts explicitement
+ * renseignés (`done`, `other_federation`).
+ */
+function canFilterLicenseStatusInFirestore(
+  statusFilter: LicenseValidationListFilter
+): boolean {
+  return statusFilter === "done" || statusFilter === "other_federation";
+}
+
 function applyLicenseValidationStatusFilter(
   query: Query,
   statusFilter: LicenseValidationListFilter
 ): Query {
-  if (statusFilter === "all") {
+  if (!canFilterLicenseStatusInFirestore(statusFilter)) {
     return query;
   }
   return query.where("licenseValidationStatus", "==", statusFilter);
@@ -36,7 +49,7 @@ function matchesSubmittedStatus(status: string | null): boolean {
   return typeof status === "string" && SUBMITTED_STATUSES.includes(status);
 }
 
-function matchesLicenseStatusFilter(
+export function matchesLicenseStatusFilter(
   item: LicenseValidationListItem,
   statusFilter: LicenseValidationListFilter
 ): boolean {


### PR DESCRIPTION
## Summary
- Hotfix : dossiers sans `licenseValidationStatus` apparaissent dans « À faire »

## Test plan
- [ ] Vérifier en prod le filtre « À faire » après déploiement


Made with [Cursor](https://cursor.com)