### PR TITLE
fix(license-validation): UX validations licence et suivi médical

### DIFF
--- a/src/app/api/club/license-validations/route.ts
+++ b/src/app/api/club/license-validations/route.ts
@@ -8,6 +8,7 @@ import {
   LICENSE_VALIDATION_PAGE_SIZE_MAX,
   listLicenseValidations,
   resolveLicenseValidationListFilter,
+  resolveLicenseValidationPaymentListFilter,
 } from "@/lib/license-validation/list-license-validations";
 
 export async function GET(req: Request) {
@@ -19,6 +20,9 @@ export async function GET(req: Request) {
 
     const url = new URL(req.url);
     const statusFilter = resolveLicenseValidationListFilter(url.searchParams.get("status"));
+    const paymentStatusFilter = resolveLicenseValidationPaymentListFilter(
+      url.searchParams.get("paymentStatus")
+    );
     const rawLimit = Number.parseInt(url.searchParams.get("limit") ?? "", 10);
     const pageSize = Number.isFinite(rawLimit)
       ? Math.min(Math.max(rawLimit, 1), LICENSE_VALIDATION_PAGE_SIZE_MAX)
@@ -29,6 +33,7 @@ export async function GET(req: Request) {
     const db = getFirestoreAdmin();
     const page = await listLicenseValidations(db, {
       statusFilter,
+      paymentStatusFilter,
       pageSize,
       cursor,
       searchQuery,

--- a/src/app/club/validations-licence/_containers/LicenseValidationsContainer.tsx
+++ b/src/app/club/validations-licence/_containers/LicenseValidationsContainer.tsx
@@ -6,11 +6,9 @@ import {
   Box,
   Button,
   Container,
-  Grid,
   Paper,
   Tab,
   Tabs,
-  Typography,
 } from "@mui/material";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import PaymentsOutlinedIcon from "@mui/icons-material/PaymentsOutlined";
@@ -21,11 +19,31 @@ import { LicenseValidationListPanel } from "@/components/license-validation/Lice
 import { LicenseValidationPaymentDetailPanel } from "@/components/license-validation/LicenseValidationPaymentDetailPanel";
 import { LicenseValidationPaymentSearchPanel } from "@/components/license-validation/LicenseValidationPaymentSearchPanel";
 import {
-  LICENSE_VALIDATION_WORKSPACE_DESCRIPTIONS,
   LICENSE_VALIDATION_WORKSPACE_LABELS,
   type LicenseValidationWorkspace,
 } from "@/components/license-validation/license-validation-workspace";
 import { useLicenseValidations } from "@/components/license-validation/useLicenseValidations";
+
+const workspaceShellSx = {
+  display: { xs: "flex", lg: "grid" },
+  flexDirection: { xs: "column" },
+  gridTemplateColumns: { lg: "minmax(300px, 380px) minmax(0, 1fr)" },
+  alignItems: "stretch",
+  border: 1,
+  borderColor: "divider",
+  borderRadius: 2,
+  overflow: "hidden",
+  bgcolor: "background.paper",
+  minHeight: { xs: 420, lg: "calc(100vh - 220px)" },
+  height: { lg: "calc(100vh - 220px)" },
+} as const;
+
+const columnSx = {
+  minHeight: 0,
+  overflowY: "auto",
+  overscrollBehavior: "contain",
+  p: 2,
+} as const;
 
 function WorkspaceTabPanel({
   active,
@@ -39,7 +57,7 @@ function WorkspaceTabPanel({
   if (active !== workspace) {
     return null;
   }
-  return <Box sx={{ pt: 3 }}>{children}</Box>;
+  return <Box sx={{ pt: 2 }}>{children}</Box>;
 }
 
 export function LicenseValidationsContainer() {
@@ -49,6 +67,8 @@ export function LicenseValidationsContainer() {
   const {
     statusFilter,
     setStatusFilter,
+    paymentStatusFilter,
+    setPaymentStatusFilter,
     searchInput,
     setSearchInput,
     registrations,
@@ -73,7 +93,6 @@ export function LicenseValidationsContainer() {
       <PageHeader
         eyebrow="Secrétariat"
         title="Adhésions — licences et encaissements"
-        subtitle="Deux espaces de travail distincts selon l'action à réaliser."
         actions={
           workspace === "licenses" ? (
             <Button
@@ -88,7 +107,7 @@ export function LicenseValidationsContainer() {
         marginBottom={2}
       />
 
-      <Paper sx={{ px: { xs: 1, sm: 2 }, pt: 1 }}>
+      <Paper sx={{ px: { xs: 1, sm: 2 }, pt: 1, pb: 1 }}>
         <Tabs
           value={workspace}
           onChange={(_event, value: LicenseValidationWorkspace) => setWorkspace(value)}
@@ -108,10 +127,6 @@ export function LicenseValidationsContainer() {
             label={LICENSE_VALIDATION_WORKSPACE_LABELS.payments}
           />
         </Tabs>
-
-        <Typography variant="body2" color="text.secondary" sx={{ px: 1, pb: 1 }}>
-          {LICENSE_VALIDATION_WORKSPACE_DESCRIPTIONS[workspace]}
-        </Typography>
       </Paper>
 
       {error && workspace === "licenses" ? (
@@ -121,54 +136,64 @@ export function LicenseValidationsContainer() {
       ) : null}
 
       <WorkspaceTabPanel active={workspace} workspace="licenses">
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, lg: 4 }}>
-            <Paper sx={{ p: 2, minHeight: 480 }}>
-              <LicenseValidationListPanel
-                registrations={registrations}
-                selectedId={licenseSelectedId}
-                statusFilter={statusFilter}
-                searchInput={searchInput}
-                loading={loadingList}
-                loadingMore={loadingMore}
-                hasNextPage={pageInfo.hasNextPage}
-                onSelect={setLicenseSelectedId}
-                onStatusFilterChange={setStatusFilter}
-                onSearchInputChange={setSearchInput}
-                onLoadMore={() => void loadMore()}
-              />
-            </Paper>
-          </Grid>
-          <Grid size={{ xs: 12, lg: 8 }}>
-            <Paper sx={{ p: 2, minHeight: 480 }}>
-              <LicenseValidationLicenseDetailPanel
-                registrationId={licenseSelectedId}
-                onSaved={handleLicenseSaved}
-              />
-            </Paper>
-          </Grid>
-        </Grid>
+        <Box sx={workspaceShellSx}>
+          <Box
+            sx={{
+              ...columnSx,
+              borderBottom: { xs: 1, lg: 0 },
+              borderRight: { lg: 1 },
+              borderColor: "divider",
+              maxHeight: { xs: 420, lg: "none" },
+            }}
+          >
+            <LicenseValidationListPanel
+              registrations={registrations}
+              selectedId={licenseSelectedId}
+              statusFilter={statusFilter}
+              paymentStatusFilter={paymentStatusFilter}
+              searchInput={searchInput}
+              loading={loadingList}
+              loadingMore={loadingMore}
+              hasNextPage={pageInfo.hasNextPage}
+              onSelect={setLicenseSelectedId}
+              onStatusFilterChange={setStatusFilter}
+              onPaymentStatusFilterChange={setPaymentStatusFilter}
+              onSearchInputChange={setSearchInput}
+              onLoadMore={() => void loadMore()}
+            />
+          </Box>
+          <Box sx={columnSx}>
+            <LicenseValidationLicenseDetailPanel
+              registrationId={licenseSelectedId}
+              onSaved={handleLicenseSaved}
+            />
+          </Box>
+        </Box>
       </WorkspaceTabPanel>
 
       <WorkspaceTabPanel active={workspace} workspace="payments">
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, md: 5, lg: 4 }}>
-            <Paper sx={{ p: 2, minHeight: 480 }}>
-              <LicenseValidationPaymentSearchPanel
-                selectedId={paymentSelectedId}
-                onSelectRegistration={setPaymentSelectedId}
-              />
-            </Paper>
-          </Grid>
-          <Grid size={{ xs: 12, md: 7, lg: 8 }}>
-            <Paper sx={{ p: 2, minHeight: 480 }}>
-              <LicenseValidationPaymentDetailPanel
-                registrationId={paymentSelectedId}
-                onSaved={handlePaymentSaved}
-              />
-            </Paper>
-          </Grid>
-        </Grid>
+        <Box sx={workspaceShellSx}>
+          <Box
+            sx={{
+              ...columnSx,
+              borderBottom: { xs: 1, lg: 0 },
+              borderRight: { lg: 1 },
+              borderColor: "divider",
+              maxHeight: { xs: 420, lg: "none" },
+            }}
+          >
+            <LicenseValidationPaymentSearchPanel
+              selectedId={paymentSelectedId}
+              onSelectRegistration={setPaymentSelectedId}
+            />
+          </Box>
+          <Box sx={columnSx}>
+            <LicenseValidationPaymentDetailPanel
+              registrationId={paymentSelectedId}
+              onSaved={handlePaymentSaved}
+            />
+          </Box>
+        </Box>
       </WorkspaceTabPanel>
     </Container>
   );

--- a/src/components/license-validation/LicenseValidationLicenseDetailPanel.tsx
+++ b/src/components/license-validation/LicenseValidationLicenseDetailPanel.tsx
@@ -5,9 +5,9 @@ import {
   Alert,
   Box,
   Button,
-  Chip,
   Divider,
   FormControl,
+  Grid,
   InputLabel,
   MenuItem,
   Select,
@@ -28,6 +28,7 @@ import {
   formatMedicalCertificateLabel,
   formatPaidLabel,
 } from "@/components/license-validation/license-validation-labels";
+import { LicenseValidationLineSecondaryText } from "@/components/license-validation/LicenseValidationLineSecondaryText";
 import { useLicenseValidationDetail } from "@/components/license-validation/useLicenseValidationDetail";
 
 type Props = {
@@ -35,9 +36,16 @@ type Props = {
   onSaved: () => Promise<void>;
 };
 
-function ReadOnlyField({ label, value }: { label: string; value: string }) {
+function InfoRow({ label, value }: { label: string; value: string }) {
   return (
-    <TextField label={label} value={value} fullWidth size="small" disabled />
+    <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ wordBreak: "break-word" }}>
+        {value}
+      </Typography>
+    </Stack>
   );
 }
 
@@ -128,82 +136,118 @@ export function LicenseValidationLicenseDetailPanel({
       ? detail.ffttLicenseLookup.licence
       : null;
 
+  const infoFields: Array<{ label: string; value: string; fullWidth?: boolean }> = [
+    { label: "Date de naissance", value: formatBirthDate(detail.birthDate) },
+    { label: "Ville de naissance", value: detail.birthCity || "—" },
+    {
+      label: "E-mail",
+      value: detail.adherentEmail || "—",
+      fullWidth: !lookupLicense,
+    },
+  ];
+  if (lookupLicense) {
+    infoFields.push({
+      label: "Licence enregistrée (dossier)",
+      value: lookupLicense,
+    });
+  }
+  infoFields.push(
+    {
+      label: "Adresse",
+      value: formatRegistrationAddress(detail) || "—",
+      fullWidth: true,
+    },
+    {
+      label: "Compétiteur",
+      value: formatCompetitorLabel(detail.wantsCompetitorExtras),
+    },
+    { label: "Paiement", value: formatPaidLabel(detail.paymentStatus) },
+    {
+      label: "Suivi médical",
+      value: formatMedicalCertificateLabel(
+        detail.medicalCertificateStatus,
+        detail.medicalCertificateDeclaration
+      ),
+    },
+    {
+      label: "Attestation d'inscription",
+      value: formatAttestationLabel(detail.wantsRegistrationCertificate),
+    }
+  );
+
   return (
     <Stack spacing={2.5}>
-      <Box>
-        <Typography variant="h6" component="h2" sx={{ mb: 0.75 }}>
+      <Stack spacing={1}>
+        <Typography variant="h6" component="h2">
           {[detail.firstName, detail.lastName].filter(Boolean).join(" ")}
         </Typography>
-        <Chip
-          size="small"
-          label={LICENSE_VALIDATION_STATUS_LABELS[detail.licenseValidationStatus]}
-        />
-      </Box>
+        <LicenseValidationLineSecondaryText registration={detail} />
+      </Stack>
 
-      <Stack spacing={1.5}>
-        <Typography variant="subtitle2" color="text.secondary">
-          Informations adhérent
-        </Typography>
-        <ReadOnlyField label="Prénom" value={detail.firstName || "—"} />
-        <ReadOnlyField label="Nom" value={detail.lastName || "—"} />
-        <ReadOnlyField label="E-mail" value={detail.adherentEmail || "—"} />
-        <ReadOnlyField label="Date de naissance" value={formatBirthDate(detail.birthDate)} />
-        <ReadOnlyField label="Ville de naissance" value={detail.birthCity || "—"} />
-        <ReadOnlyField label="Adresse" value={formatRegistrationAddress(detail) || "—"} />
-        <ReadOnlyField
-          label="Compétiteur"
-          value={formatCompetitorLabel(detail.wantsCompetitorExtras)}
-        />
-        <ReadOnlyField label="Payé ?" value={formatPaidLabel(detail.paymentStatus)} />
-        <ReadOnlyField
-          label="Certificat médical"
-          value={formatMedicalCertificateLabel(detail.medicalCertificateStatus)}
-        />
-        <ReadOnlyField
-          label="Attestation d'inscription"
-          value={formatAttestationLabel(detail.wantsRegistrationCertificate)}
-        />
-        {lookupLicense ? (
-          <ReadOnlyField label="Licence enregistrée (dossier)" value={lookupLicense} />
-        ) : null}
+      <Stack
+        spacing={1.5}
+        sx={{
+          p: 2,
+          borderRadius: 2,
+          border: 1,
+          borderColor: "divider",
+          bgcolor: "grey.50",
+        }}
+      >
+        <Typography variant="subtitle2">Saisie licence</Typography>
+        <Grid container spacing={1.5}>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <TextField
+              label="Nouveau numéro de licence"
+              value={ffttLicense}
+              onChange={(e) => setFfttLicense(e.target.value.replace(/\D/g, ""))}
+              fullWidth
+              size="small"
+              inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <FormControl fullWidth size="small">
+              <InputLabel id="license-validation-status-label">Statut licence</InputLabel>
+              <Select
+                labelId="license-validation-status-label"
+                label="Statut licence"
+                value={licenseValidationStatus}
+                onChange={(e) =>
+                  setLicenseValidationStatus(e.target.value as LicenseValidationStatus)
+                }
+              >
+                {LICENSE_VALIDATION_STATUS_VALUES.map((status) => (
+                  <MenuItem key={status} value={status}>
+                    {LICENSE_VALIDATION_STATUS_LABELS[status]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
+        {saveError ? <Alert severity="error">{saveError}</Alert> : null}
+        <Button variant="contained" onClick={() => void handleSave()} disabled={saving}>
+          {saving ? "Enregistrement…" : "Enregistrer la licence"}
+        </Button>
       </Stack>
 
       <Divider />
 
       <Stack spacing={1.5}>
         <Typography variant="subtitle2" color="text.secondary">
-          Saisie licence
+          Informations adhérent
         </Typography>
-        <TextField
-          label="Nouveau numéro de licence"
-          value={ffttLicense}
-          onChange={(e) => setFfttLicense(e.target.value.replace(/\D/g, ""))}
-          fullWidth
-          size="small"
-          inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
-          helperText="Seul champ modifiable de la fiche."
-        />
-        <FormControl fullWidth size="small">
-          <InputLabel id="license-validation-status-label">Statut licence</InputLabel>
-          <Select
-            labelId="license-validation-status-label"
-            label="Statut licence"
-            value={licenseValidationStatus}
-            onChange={(e) =>
-              setLicenseValidationStatus(e.target.value as LicenseValidationStatus)
-            }
-          >
-            {LICENSE_VALIDATION_STATUS_VALUES.map((status) => (
-              <MenuItem key={status} value={status}>
-                {LICENSE_VALIDATION_STATUS_LABELS[status]}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        {saveError ? <Alert severity="error">{saveError}</Alert> : null}
-        <Button variant="contained" onClick={() => void handleSave()} disabled={saving}>
-          {saving ? "Enregistrement…" : "Enregistrer la licence"}
-        </Button>
+        <Grid container spacing={1.5}>
+          {infoFields.map((field) => (
+            <Grid
+              key={field.label}
+              size={{ xs: 12, sm: field.fullWidth ? 12 : 6 }}
+            >
+              <InfoRow label={field.label} value={field.value} />
+            </Grid>
+          ))}
+        </Grid>
       </Stack>
     </Stack>
   );

--- a/src/components/license-validation/LicenseValidationLineSecondaryText.tsx
+++ b/src/components/license-validation/LicenseValidationLineSecondaryText.tsx
@@ -1,28 +1,48 @@
+import { Chip, Stack } from "@mui/material";
 import type { LicenseValidationListItem } from "@/lib/license-validation/map-registration";
 import { LICENSE_VALIDATION_STATUS_LABELS } from "@/lib/license-validation/license-validation-status";
-import {
-  formatCompetitorLabel,
-  formatPaidLabel,
-} from "@/components/license-validation/license-validation-labels";
+import { formatPaidLabel } from "@/components/license-validation/license-validation-labels";
 
 type Props = {
   registration: LicenseValidationListItem;
 };
 
+function paymentChipColor(
+  paymentStatus: LicenseValidationListItem["paymentStatus"]
+): "success" | "warning" | "default" {
+  if (paymentStatus === "paid") {
+    return "success";
+  }
+  if (paymentStatus === "partially_paid") {
+    return "warning";
+  }
+  return "default";
+}
+
 export function LicenseValidationLineSecondaryText({
   registration,
 }: Props) {
   return (
-    <>
-      <strong>Licence</strong>:{" "}
-      {registration.ffttLicense ? `${registration.ffttLicense} — ` : ""}
-      {LICENSE_VALIDATION_STATUS_LABELS[registration.licenseValidationStatus]}
-      {" · "}
-      <strong>Compétiteur</strong>:{" "}
-      {formatCompetitorLabel(registration.wantsCompetitorExtras)}
-      {" · "}
-      <strong>Paiement</strong>: {formatPaidLabel(registration.paymentStatus)}
-    </>
+    <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mt: 0.5 }}>
+      {registration.ffttLicense ? (
+        <Chip size="small" variant="outlined" label={registration.ffttLicense} />
+      ) : null}
+      <Chip
+        size="small"
+        variant="outlined"
+        label={LICENSE_VALIDATION_STATUS_LABELS[registration.licenseValidationStatus]}
+      />
+      <Chip
+        size="small"
+        variant="outlined"
+        label={registration.wantsCompetitorExtras ? "Compétiteur" : "Loisir"}
+      />
+      <Chip
+        size="small"
+        variant="outlined"
+        color={paymentChipColor(registration.paymentStatus)}
+        label={formatPaidLabel(registration.paymentStatus)}
+      />
+    </Stack>
   );
 }
-

--- a/src/components/license-validation/LicenseValidationListPanel.tsx
+++ b/src/components/license-validation/LicenseValidationListPanel.tsx
@@ -5,9 +5,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  List,
-  ListItemButton,
-  ListItemText,
   Stack,
   TextField,
   Typography,
@@ -17,6 +14,11 @@ import {
   LICENSE_VALIDATION_STATUS_VALUES,
   type LicenseValidationListFilter,
 } from "@/lib/license-validation/license-validation-status";
+import {
+  LICENSE_VALIDATION_PAYMENT_FILTER_LABELS,
+  LICENSE_VALIDATION_PAYMENT_FILTER_VALUES,
+  type LicenseValidationPaymentListFilter,
+} from "@/lib/license-validation/payment-status-filter";
 import type { LicenseValidationListItem } from "@/lib/license-validation/map-registration";
 import { LicenseValidationLineSecondaryText } from "@/components/license-validation/LicenseValidationLineSecondaryText";
 
@@ -24,12 +26,14 @@ type Props = {
   registrations: LicenseValidationListItem[];
   selectedId: string | null;
   statusFilter: LicenseValidationListFilter;
+  paymentStatusFilter: LicenseValidationPaymentListFilter;
   searchInput: string;
   loading: boolean;
   loadingMore: boolean;
   hasNextPage: boolean;
   onSelect: (id: string) => void;
   onStatusFilterChange: (filter: LicenseValidationListFilter) => void;
+  onPaymentStatusFilterChange: (filter: LicenseValidationPaymentListFilter) => void;
   onSearchInputChange: (value: string) => void;
   onLoadMore: () => void;
 };
@@ -38,12 +42,14 @@ export function LicenseValidationListPanel({
   registrations,
   selectedId,
   statusFilter,
+  paymentStatusFilter,
   searchInput,
   loading,
   loadingMore,
   hasNextPage,
   onSelect,
   onStatusFilterChange,
+  onPaymentStatusFilterChange,
   onSearchInputChange,
   onLoadMore,
 }: Props) {
@@ -57,33 +63,45 @@ export function LicenseValidationListPanel({
         fullWidth
       />
 
-      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-        <Chip
-          label="Tous"
-          clickable
-          color={statusFilter === "all" ? "primary" : "default"}
-          onClick={() => onStatusFilterChange("all")}
-        />
-        {LICENSE_VALIDATION_STATUS_VALUES.map((status) => (
+      <Stack spacing={0.75}>
+        <Typography variant="caption" color="text.secondary">
+          Licence
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
           <Chip
-            key={status}
-            label={LICENSE_VALIDATION_STATUS_LABELS[status]}
+            label="Tous"
             clickable
-            color={statusFilter === status ? "primary" : "default"}
-            onClick={() => onStatusFilterChange(status)}
+            color={statusFilter === "all" ? "primary" : "default"}
+            onClick={() => onStatusFilterChange("all")}
           />
-        ))}
+          {LICENSE_VALIDATION_STATUS_VALUES.map((status) => (
+            <Chip
+              key={status}
+              label={LICENSE_VALIDATION_STATUS_LABELS[status]}
+              clickable
+              color={statusFilter === status ? "primary" : "default"}
+              onClick={() => onStatusFilterChange(status)}
+            />
+          ))}
+        </Stack>
       </Stack>
 
-      <Box>
-        <Typography variant="caption" color="text.secondary" display="block">
-          Statuts d’une ligne :
+      <Stack spacing={0.75}>
+        <Typography variant="caption" color="text.secondary">
+          Paiement
         </Typography>
-        <Typography variant="caption" color="text.secondary" display="block">
-          Licence = suivi licence FFTT / Compétiteur = Oui/Non / Paiement =
-          statut paiement.
-        </Typography>
-      </Box>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {LICENSE_VALIDATION_PAYMENT_FILTER_VALUES.map((filter) => (
+            <Chip
+              key={filter}
+              label={LICENSE_VALIDATION_PAYMENT_FILTER_LABELS[filter]}
+              clickable
+              color={paymentStatusFilter === filter ? "primary" : "default"}
+              onClick={() => onPaymentStatusFilterChange(filter)}
+            />
+          ))}
+        </Stack>
+      </Stack>
 
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
@@ -92,32 +110,53 @@ export function LicenseValidationListPanel({
       ) : registrations.length === 0 ? (
         <Typography color="text.secondary">Aucun dossier trouvé.</Typography>
       ) : (
-        <List disablePadding>
+        <Stack spacing={0.5}>
           {registrations.map((registration) => {
             const name = [registration.firstName, registration.lastName]
               .filter(Boolean)
               .join(" ");
+            const selected = registration.id === selectedId;
             return (
-              <ListItemButton
+              <Box
                 key={registration.id}
-                selected={registration.id === selectedId}
+                component="button"
+                type="button"
                 onClick={() => onSelect(registration.id)}
-                sx={{ borderRadius: 1, mb: 0.5 }}
+                sx={{
+                  display: "block",
+                  width: "100%",
+                  textAlign: "left",
+                  border: 1,
+                  borderColor: selected ? "primary.main" : "divider",
+                  bgcolor: selected ? "action.selected" : "transparent",
+                  borderRadius: 1.5,
+                  px: 1.5,
+                  py: 1.25,
+                  cursor: "pointer",
+                  font: "inherit",
+                  color: "inherit",
+                  "&:hover": {
+                    borderColor: "primary.light",
+                    bgcolor: selected ? "action.selected" : "action.hover",
+                  },
+                }}
               >
-                <ListItemText
-                  primary={name || "Adhérent"}
-                  secondary={
-                    <LicenseValidationLineSecondaryText registration={registration} />
-                  }
-                />
-              </ListItemButton>
+                <Typography
+                  variant="subtitle2"
+                  fontWeight={700}
+                  color={selected ? "primary.main" : "text.primary"}
+                >
+                  {name || "Adhérent"}
+                </Typography>
+                <LicenseValidationLineSecondaryText registration={registration} />
+              </Box>
             );
           })}
-        </List>
+        </Stack>
       )}
 
       {hasNextPage ? (
-        <Button onClick={() => void onLoadMore()} disabled={loadingMore}>
+        <Button onClick={() => void onLoadMore()} disabled={loadingMore} variant="outlined">
           {loadingMore ? "Chargement…" : "Charger plus"}
         </Button>
       ) : null}

--- a/src/components/license-validation/LicenseValidationPaymentSearchPanel.tsx
+++ b/src/components/license-validation/LicenseValidationPaymentSearchPanel.tsx
@@ -125,11 +125,9 @@ export function LicenseValidationPaymentSearchPanel({
                     <Typography variant="subtitle1" fontWeight={600}>
                       {name || "Adhérent"}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      <LicenseValidationLineSecondaryText
-                        registration={registration}
-                      />
-                    </Typography>
+                    <LicenseValidationLineSecondaryText
+                      registration={registration}
+                    />
                   </CardContent>
                 </CardActionArea>
               </Card>

--- a/src/components/license-validation/license-validation-labels.test.ts
+++ b/src/components/license-validation/license-validation-labels.test.ts
@@ -1,0 +1,66 @@
+import { formatMedicalCertificateLabel } from "@/components/license-validation/license-validation-labels";
+import {
+  formatMedicalFollowUpLabel,
+  resolveMedicalFollowUpKind,
+} from "@/lib/club-registration/medical-certificate";
+
+describe("resolveMedicalFollowUpKind", () => {
+  it("traite le PPS et l’ancien régime équivalent comme PPS attendu", () => {
+    expect(resolveMedicalFollowUpKind("adult_pps_declared", "not_required")).toBe(
+      "pps_expected"
+    );
+    expect(resolveMedicalFollowUpKind("under_40_all_no", "not_required")).toBe(
+      "pps_expected"
+    );
+    expect(
+      resolveMedicalFollowUpKind("over_40_cert_unchanged_all_no", "not_required")
+    ).toBe("pps_expected");
+  });
+
+  it("marque OK le questionnaire mineur sans certificat", () => {
+    expect(resolveMedicalFollowUpKind("minor_all_no", "not_required")).toBe("ok");
+  });
+
+  it("distingue certificat attendu, reçu et validé", () => {
+    expect(
+      resolveMedicalFollowUpKind("adult_certificate_required", "required_not_received")
+    ).toBe("certificate_expected");
+    expect(
+      resolveMedicalFollowUpKind("adult_certificate_required", "received")
+    ).toBe("certificate_received");
+    expect(
+      resolveMedicalFollowUpKind("adult_certificate_required", "validated")
+    ).toBe("ok");
+    expect(
+      resolveMedicalFollowUpKind(
+        "questionnaire_yes_certificate_required",
+        "required_not_received"
+      )
+    ).toBe("certificate_expected");
+  });
+});
+
+describe("formatMedicalFollowUpLabel / formatMedicalCertificateLabel", () => {
+  it("expose les wordings secrétariat rationnalisés", () => {
+    expect(formatMedicalFollowUpLabel("adult_pps_declared", "not_required")).toBe(
+      "PPS attendu"
+    );
+    expect(formatMedicalCertificateLabel("not_required", "under_40_all_no")).toBe(
+      "PPS attendu"
+    );
+    expect(formatMedicalCertificateLabel("not_required", "minor_all_no")).toBe("OK");
+    expect(
+      formatMedicalCertificateLabel(
+        "required_not_received",
+        "adult_certificate_required"
+      )
+    ).toBe("Certificat médical attendu");
+    expect(
+      formatMedicalCertificateLabel("received", "senior_certificate_required")
+    ).toBe("Certificat médical reçu");
+    expect(
+      formatMedicalCertificateLabel("validated", "minor_yes_certificate_required")
+    ).toBe("OK");
+    expect(formatMedicalCertificateLabel(null, null)).toBe("—");
+  });
+});

--- a/src/components/license-validation/license-validation-labels.ts
+++ b/src/components/license-validation/license-validation-labels.ts
@@ -1,5 +1,5 @@
-import { MEDICAL_CERTIFICATE_STATUS_LABELS } from "@/lib/club-registration/medical-certificate";
 import { PAYMENT_STATUS_LABELS } from "@/lib/club-registration/payment-constants";
+import { formatMedicalFollowUpLabel } from "@/lib/club-registration/medical-certificate";
 import { LICENSE_VALIDATION_STATUS_LABELS } from "@/lib/license-validation/license-validation-status";
 
 export { LICENSE_VALIDATION_STATUS_LABELS };
@@ -15,15 +15,12 @@ export function formatPaidLabel(paymentStatus: string | null): string {
   return PAYMENT_STATUS_LABELS[paymentStatus as keyof typeof PAYMENT_STATUS_LABELS] ?? paymentStatus;
 }
 
-export function formatMedicalCertificateLabel(status: string | null): string {
-  if (!status) {
-    return "—";
-  }
-  return (
-    MEDICAL_CERTIFICATE_STATUS_LABELS[
-      status as keyof typeof MEDICAL_CERTIFICATE_STATUS_LABELS
-    ] ?? status
-  );
+/** Synthèse secrétariat : OK / PPS attendu / certificat attendu ou reçu. */
+export function formatMedicalCertificateLabel(
+  status: string | null,
+  declaration?: string | null
+): string {
+  return formatMedicalFollowUpLabel(declaration, status);
 }
 
 export function formatAttestationLabel(wantsRegistrationCertificate: boolean): string {

--- a/src/components/license-validation/license-validation-workspace.ts
+++ b/src/components/license-validation/license-validation-workspace.ts
@@ -12,13 +12,3 @@ export const LICENSE_VALIDATION_WORKSPACE_LABELS: Record<
   licenses: "Saisie des licences",
   payments: "Encaissements",
 };
-
-export const LICENSE_VALIDATION_WORKSPACE_DESCRIPTIONS: Record<
-  LicenseValidationWorkspace,
-  string
-> = {
-  licenses:
-    "Parcourez les dossiers à traiter et renseignez le numéro de licence FFTT.",
-  payments:
-    "Recherchez un adhérent par nom ou licence pour enregistrer un chèque ou des chèques vacances.",
-};

--- a/src/components/license-validation/useLicenseValidations.ts
+++ b/src/components/license-validation/useLicenseValidations.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { LicenseValidationListFilter } from "@/lib/license-validation/license-validation-status";
+import type { LicenseValidationPaymentListFilter } from "@/lib/license-validation/payment-status-filter";
 import type { LicenseValidationListItem } from "@/lib/license-validation/map-registration";
 
 type PageInfo = {
@@ -12,6 +13,8 @@ type PageInfo = {
 export function useLicenseValidations(initialStatus: LicenseValidationListFilter = "all") {
   const [statusFilter, setStatusFilter] =
     useState<LicenseValidationListFilter>(initialStatus);
+  const [paymentStatusFilter, setPaymentStatusFilter] =
+    useState<LicenseValidationPaymentListFilter>("paid");
   const [searchInput, setSearchInput] = useState("");
   const [registrations, setRegistrations] = useState<LicenseValidationListItem[]>([]);
   const [pageInfo, setPageInfo] = useState<PageInfo>({
@@ -27,6 +30,9 @@ export function useLicenseValidations(initialStatus: LicenseValidationListFilter
       const params = new URLSearchParams();
       if (statusFilter !== "all") {
         params.set("status", statusFilter);
+      }
+      if (paymentStatusFilter !== "all") {
+        params.set("paymentStatus", paymentStatusFilter);
       }
       if (searchInput.trim().length >= 2) {
         params.set("q", searchInput.trim());
@@ -52,7 +58,7 @@ export function useLicenseValidations(initialStatus: LicenseValidationListFilter
         nextCursor: typeof json.nextCursor === "string" ? json.nextCursor : null,
       });
     },
-    [searchInput, statusFilter]
+    [paymentStatusFilter, searchInput, statusFilter]
   );
 
   const reload = useCallback(async () => {
@@ -89,6 +95,8 @@ export function useLicenseValidations(initialStatus: LicenseValidationListFilter
   return {
     statusFilter,
     setStatusFilter,
+    paymentStatusFilter,
+    setPaymentStatusFilter,
     searchInput,
     setSearchInput,
     registrations,

--- a/src/lib/club-registration/medical-certificate.ts
+++ b/src/lib/club-registration/medical-certificate.ts
@@ -120,3 +120,84 @@ export function matchesMedicalCertificateFilter(
   }
   return summaryMedicalCertificateStatus(summary) === filter;
 }
+
+/**
+ * Synthèse secrétariat du parcours médical (nouvelles règles + rétrocompat).
+ * Les déclarations ancien régime sans certificat (`under_40_all_no`,
+ * `over_40_cert_unchanged_all_no`) sont traitées comme un PPS attendu.
+ */
+export type MedicalFollowUpKind =
+  | "ok"
+  | "pps_expected"
+  | "certificate_expected"
+  | "certificate_received";
+
+export const MEDICAL_FOLLOW_UP_LABELS: Record<MedicalFollowUpKind, string> = {
+  ok: "OK",
+  pps_expected: "PPS attendu",
+  certificate_expected: "Certificat médical attendu",
+  certificate_received: "Certificat médical reçu",
+};
+
+const PPS_EQUIVALENT_DECLARATIONS: ReadonlySet<string> = new Set([
+  "adult_pps_declared",
+  "under_40_all_no",
+  "over_40_cert_unchanged_all_no",
+]);
+
+const OK_WITHOUT_FOLLOW_UP_DECLARATIONS: ReadonlySet<string> = new Set([
+  "minor_all_no",
+]);
+
+function resolveCertificateFollowUpKind(
+  status: string | null | undefined
+): MedicalFollowUpKind {
+  if (status === "validated") {
+    return "ok";
+  }
+  if (status === "received") {
+    return "certificate_received";
+  }
+  return "certificate_expected";
+}
+
+export function resolveMedicalFollowUpKind(
+  declaration: string | null | undefined,
+  status: string | null | undefined
+): MedicalFollowUpKind | null {
+  if (!declaration && !status) {
+    return null;
+  }
+
+  if (declaration && PPS_EQUIVALENT_DECLARATIONS.has(declaration)) {
+    return "pps_expected";
+  }
+
+  if (declaration && OK_WITHOUT_FOLLOW_UP_DECLARATIONS.has(declaration)) {
+    return "ok";
+  }
+
+  if (declaration && isMedicalCertificateRequired(declaration)) {
+    return resolveCertificateFollowUpKind(status);
+  }
+
+  if (status === "validated" || status === "not_required") {
+    return "ok";
+  }
+  if (status === "received") {
+    return "certificate_received";
+  }
+  if (status === "required_not_received") {
+    return "certificate_expected";
+  }
+
+  return null;
+}
+
+export function formatMedicalFollowUpLabel(
+  declaration: string | null | undefined,
+  status: string | null | undefined
+): string {
+  const kind = resolveMedicalFollowUpKind(declaration, status);
+  return kind ? MEDICAL_FOLLOW_UP_LABELS[kind] : "—";
+}

--- a/src/lib/license-validation/list-license-validations.test.ts
+++ b/src/lib/license-validation/list-license-validations.test.ts
@@ -1,6 +1,10 @@
 import { matchesLicenseStatusFilter } from "@/lib/license-validation/list-license-validations";
 import { normalizeLicenseValidationStatus } from "@/lib/license-validation/license-validation-status";
 import type { LicenseValidationListItem } from "@/lib/license-validation/map-registration";
+import {
+  matchesPaymentStatusFilter,
+  resolveLicenseValidationPaymentListFilter,
+} from "@/lib/license-validation/payment-status-filter";
 
 function item(
   overrides: Partial<LicenseValidationListItem> = {}
@@ -30,5 +34,35 @@ describe("matchesLicenseStatusFilter", () => {
     expect(matchesLicenseStatusFilter(legacy, "to_do")).toBe(true);
     expect(matchesLicenseStatusFilter(legacy, "done")).toBe(false);
     expect(matchesLicenseStatusFilter(legacy, "all")).toBe(true);
+  });
+});
+
+describe("payment status list filter", () => {
+  it("resolves compact payment filters and falls back to all", () => {
+    expect(resolveLicenseValidationPaymentListFilter("paid")).toBe("paid");
+    expect(resolveLicenseValidationPaymentListFilter("partially_paid")).toBe(
+      "partially_paid"
+    );
+    expect(resolveLicenseValidationPaymentListFilter("unpaid")).toBe("unpaid");
+    expect(resolveLicenseValidationPaymentListFilter("waiting_payment")).toBe(
+      "all"
+    );
+    expect(resolveLicenseValidationPaymentListFilter("unknown")).toBe("all");
+    expect(resolveLicenseValidationPaymentListFilter(null)).toBe("all");
+  });
+
+  it("keeps partially_paid separate from unpaid", () => {
+    expect(matchesPaymentStatusFilter("paid", "paid")).toBe(true);
+    expect(matchesPaymentStatusFilter("partially_paid", "partially_paid")).toBe(
+      true
+    );
+    expect(matchesPaymentStatusFilter("partially_paid", "unpaid")).toBe(false);
+    expect(matchesPaymentStatusFilter("partially_paid", "paid")).toBe(false);
+    expect(matchesPaymentStatusFilter("waiting_payment", "unpaid")).toBe(true);
+    expect(matchesPaymentStatusFilter("pending_validation", "unpaid")).toBe(true);
+    expect(matchesPaymentStatusFilter("manual_follow_up", "unpaid")).toBe(true);
+    expect(matchesPaymentStatusFilter("paid", "unpaid")).toBe(false);
+    expect(matchesPaymentStatusFilter(null, "unpaid")).toBe(false);
+    expect(matchesPaymentStatusFilter(null, "all")).toBe(true);
   });
 });

--- a/src/lib/license-validation/list-license-validations.ts
+++ b/src/lib/license-validation/list-license-validations.ts
@@ -8,6 +8,10 @@ import {
   resolveLicenseValidationListFilter,
   type LicenseValidationListFilter,
 } from "@/lib/license-validation/license-validation-status";
+import {
+  matchesPaymentStatusFilter,
+  type LicenseValidationPaymentListFilter,
+} from "@/lib/license-validation/payment-status-filter";
 import { registrationMatchesLicenseValidationSearch } from "@/lib/license-validation/search-registrations";
 
 export const LICENSE_VALIDATION_PAGE_SIZE_DEFAULT = 25;
@@ -92,6 +96,7 @@ export async function listLicenseValidations(
   db: Firestore,
   params: {
     statusFilter: LicenseValidationListFilter;
+    paymentStatusFilter?: LicenseValidationPaymentListFilter;
     pageSize: number;
     cursor?: string | null;
     searchQuery?: string | null;
@@ -102,6 +107,7 @@ export async function listLicenseValidations(
     LICENSE_VALIDATION_PAGE_SIZE_MAX
   );
   const searchQuery = params.searchQuery?.trim() ?? "";
+  const paymentStatusFilter = params.paymentStatusFilter ?? "all";
 
   const summaries = await fetchLicenseValidationSummaries(
     db,
@@ -112,6 +118,7 @@ export async function listLicenseValidations(
   const filtered = summaries.filter(
     (item) =>
       matchesLicenseStatusFilter(item, params.statusFilter) &&
+      matchesPaymentStatusFilter(item.paymentStatus, paymentStatusFilter) &&
       registrationMatchesLicenseValidationSearch(item, searchQuery)
   );
 
@@ -151,3 +158,4 @@ export async function searchLicenseValidations(
 }
 
 export { resolveLicenseValidationListFilter };
+export { resolveLicenseValidationPaymentListFilter } from "@/lib/license-validation/payment-status-filter";

--- a/src/lib/license-validation/payment-status-filter.ts
+++ b/src/lib/license-validation/payment-status-filter.ts
@@ -1,0 +1,67 @@
+import {
+  type PaymentStatusId,
+} from "@/lib/club-registration/payment-constants";
+
+/**
+ * Filtres paiement compactés pour la liste validations licence.
+ * `partially_paid` est isolé ; le reste du non soldé est regroupé
+ * (aligné sur la vue tableau « Paiement en attente », hors partiel).
+ */
+export const LICENSE_VALIDATION_PAYMENT_FILTER_VALUES = [
+  "all",
+  "paid",
+  "partially_paid",
+  "unpaid",
+] as const;
+
+export type LicenseValidationPaymentListFilter =
+  (typeof LICENSE_VALIDATION_PAYMENT_FILTER_VALUES)[number];
+
+export const LICENSE_VALIDATION_PAYMENT_FILTER_LABELS: Record<
+  LicenseValidationPaymentListFilter,
+  string
+> = {
+  all: "Tous",
+  paid: "Payé",
+  partially_paid: "Paiement partiel",
+  unpaid: "Paiement en attente",
+};
+
+const UNPAID_PAYMENT_STATUSES: ReadonlySet<PaymentStatusId> = new Set([
+  "pending_validation",
+  "waiting_payment",
+  "manual_follow_up",
+]);
+
+export function resolveLicenseValidationPaymentListFilter(
+  raw: string | null | undefined
+): LicenseValidationPaymentListFilter {
+  if (
+    raw === "paid" ||
+    raw === "partially_paid" ||
+    raw === "unpaid" ||
+    raw === "all"
+  ) {
+    return raw;
+  }
+  return "all";
+}
+
+export function matchesPaymentStatusFilter(
+  paymentStatus: PaymentStatusId | null,
+  filter: LicenseValidationPaymentListFilter
+): boolean {
+  if (filter === "all") {
+    return true;
+  }
+  if (filter === "paid") {
+    return paymentStatus === "paid";
+  }
+  if (filter === "partially_paid") {
+    return paymentStatus === "partially_paid";
+  }
+  if (paymentStatus == null) {
+    return false;
+  }
+  return UNPAID_PAYMENT_STATUSES.has(paymentStatus);
+}


### PR DESCRIPTION
## Summary
- Layout master-detail à hauteur égale avec scroll interne, chips homogènes liste/détail
- Filtre paiement compacté (Tous / Payé / Partiel / En attente), défaut Payé
- Synthèse suivi médical secrétariat (OK / PPS attendu / certificat attendu|reçu), ancien régime mappé vers PPS

## Test plan
- [ ] `/club/validations-licence` : colonnes alignées, détail sticky/scroll, chips cohérents
- [ ] Filtrer Payé / Paiement partiel / En attente
- [ ] Vérifier wordings Suivi médical (PPS, certificat, OK) dont dossiers ancien régime

Made with [Cursor](https://cursor.com)