### PR TITLE
fix(license-validation): chips filtre paiement sur une ligne

### DIFF
--- a/src/components/license-validation/LicenseValidationListPanel.tsx
+++ b/src/components/license-validation/LicenseValidationListPanel.tsx
@@ -67,7 +67,7 @@ export function LicenseValidationListPanel({
         <Typography variant="caption" color="text.secondary">
           Licence
         </Typography>
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
           <Chip
             label="Tous"
             clickable
@@ -90,7 +90,7 @@ export function LicenseValidationListPanel({
         <Typography variant="caption" color="text.secondary">
           Paiement
         </Typography>
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
           {LICENSE_VALIDATION_PAYMENT_FILTER_VALUES.map((filter) => (
             <Chip
               key={filter}

--- a/src/lib/license-validation/payment-status-filter.ts
+++ b/src/lib/license-validation/payment-status-filter.ts
@@ -23,8 +23,8 @@ export const LICENSE_VALIDATION_PAYMENT_FILTER_LABELS: Record<
 > = {
   all: "Tous",
   paid: "Payé",
-  partially_paid: "Paiement partiel",
-  unpaid: "Paiement en attente",
+  partially_paid: "Partiel",
+  unpaid: "En attente",
 };
 
 const UNPAID_PAYMENT_STATUSES: ReadonlySet<PaymentStatusId> = new Set([


### PR DESCRIPTION
## Summary
- Libellés paiement raccourcis (`Partiel`, `En attente`) pour une seule ligne
- Espacement des chips aligné entre filtres licence et paiement

## Test plan
- [ ] Vérifier que les 4 chips paiement tiennent sur une ligne
- [ ] Vérifier taille/espacement cohérents avec le filtre licence

Made with [Cursor](https://cursor.com)