### PR TITLE
feat(club-registration): tableau des adhésions pour le secrétaire adjoint

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,6 +36,14 @@ service cloud.firestore {
       return isAdmin() || isSecretary();
     }
 
+    function isAssistantSecretary() {
+      return authRole() == "assistant_secretary";
+    }
+
+    function isClubRegistrationViewer() {
+      return isClubRegistrationManager() || isAssistantSecretary();
+    }
+
     // Liste client : uniquement ses propres dossiers (requête filtrée + plafond).
     // Les listes secrétariat passent par l'API (Admin SDK).
     function isPersonalClubRegistrationListQuery() {
@@ -214,7 +222,7 @@ service cloud.firestore {
     // peut créer plusieurs dossiers (ex. inscription de 2 enfants). Le couplage 1 dossier ↔ 1 uid
     // est volontairement abandonné.
     //
-    // - get    : owner (submitterUid == uid), admin ou secrétariat
+    // - get    : owner (submitterUid == uid), admin, secrétariat ou secrétaire adjoint
     // - list   : owner uniquement, requête where submitterUid == uid, limit <= 50
     //            (listes secrétariat via API / Admin SDK)
     // - create : owner se déclare comme submitterUid, schemaVersion strict
@@ -222,7 +230,7 @@ service cloud.firestore {
     // - delete : interdit côté client (l'admin gère via Admin SDK)
     match /clubRegistrations/{registrationId} {
       allow get: if isAuthenticated()
-                 && (isClubRegistrationManager()
+                 && (isClubRegistrationViewer()
                      || resource.data.submitterUid == request.auth.uid);
       allow list: if isAuthenticated()
                   && isPersonalClubRegistrationListQuery();

--- a/src/app/api/club/registration/route.ts
+++ b/src/app/api/club/registration/route.ts
@@ -5,7 +5,10 @@ import { mapRegistrationDocToClient } from "@/lib/club-registration/map-registra
 import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
 import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
-import { canAccessClubRegistration, isClubRegistrationManager } from "@/lib/club-registration/registration-access";
+import {
+  canViewClubRegistration,
+  isClubRegistrationManager,
+} from "@/lib/club-registration/registration-access";
 import { FieldValue } from "firebase-admin/firestore";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { logAuditAction, AUDIT_ACTIONS } from "@/lib/auth/audit-logger";
@@ -50,7 +53,7 @@ function stripUndefined<T extends Record<string, unknown>>(obj: T): Record<strin
   return out;
 }
 
-/** GET /api/club/registration?id={registrationId} — lecture d'un dossier (owner ou admin). */
+/** GET /api/club/registration?id={registrationId} — lecture d'un dossier (owner, secrétariat, secrétaire adjoint). */
 export async function GET(req: Request) {
   try {
     const url = new URL(req.url);
@@ -80,7 +83,7 @@ export async function GET(req: Request) {
 
     const submitterUid =
       typeof data.submitterUid === "string" ? data.submitterUid : undefined;
-    if (!canAccessClubRegistration(role, submitterUid, decoded.uid)) {
+    if (!canViewClubRegistration(role, submitterUid, decoded.uid)) {
       return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
     }
 

--- a/src/app/api/club/registrations/spreadsheet-preferences/route.ts
+++ b/src/app/api/club/registrations/spreadsheet-preferences/route.ts
@@ -3,15 +3,14 @@ export const runtime = "nodejs";
 import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { resolveRole } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { canAccessRegistrationsSpreadsheet } from "@/lib/club-registration/registration-access";
 import {
   loadRegistrationsSpreadsheetPreferences,
   saveRegistrationsSpreadsheetPreferences,
 } from "@/lib/club-registration/spreadsheet/preferences-store";
 import { validateSpreadsheetPreferencesPayload } from "@/lib/club-registration/spreadsheet/preferences";
-
-const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
 
 /** GET /api/club/registrations/spreadsheet-preferences — préférences colonnes utilisateur. */
 export async function GET() {
@@ -24,7 +23,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, MANAGER_ROLES)) {
+    if (!canAccessRegistrationsSpreadsheet(role)) {
       return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
     }
 
@@ -53,7 +52,7 @@ export async function PUT(req: Request) {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, MANAGER_ROLES)) {
+    if (!canAccessRegistrationsSpreadsheet(role)) {
       return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
     }
 

--- a/src/app/api/club/registrations/spreadsheet/route.ts
+++ b/src/app/api/club/registrations/spreadsheet/route.ts
@@ -3,11 +3,10 @@ export const runtime = "nodejs";
 import { jsonNoStore } from "@/lib/http/cache-headers";
 import { cookies } from "next/headers";
 import { getFirestoreAdmin, adminAuth } from "@/lib/firebase-admin";
-import { hasAnyRole, USER_ROLES, resolveRole } from "@/lib/auth/roles";
+import { resolveRole } from "@/lib/auth/roles";
+import { canAccessRegistrationsSpreadsheet } from "@/lib/club-registration/registration-access";
 import { listSpreadsheetRegistrations } from "@/lib/club-registration/list-spreadsheet-registrations";
 import { buildSpreadsheetUserLabelDirectory } from "@/lib/club-registration/spreadsheet/build-user-label-directory";
-
-const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
 
 /** GET /api/club/registrations/spreadsheet — export tabulaire (secrétariat). */
 export async function GET() {
@@ -20,7 +19,7 @@ export async function GET() {
 
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
     const role = resolveRole(decoded.role as string | undefined);
-    if (!hasAnyRole(role, MANAGER_ROLES)) {
+    if (!canAccessRegistrationsSpreadsheet(role)) {
       return jsonNoStore({ error: "Accès refusé" }, { status: 403 });
     }
 

--- a/src/app/club/adhesions-tableau/page.tsx
+++ b/src/app/club/adhesions-tableau/page.tsx
@@ -1,11 +1,11 @@
 import { AuthGuard } from "@/components/AuthGuard";
 import { RegistrationsSpreadsheetClient } from "@/components/club-registration/spreadsheet/RegistrationsSpreadsheetClient";
-import { USER_ROLES } from "@/lib/auth/roles";
+import { CLUB_REGISTRATION_SPREADSHEET_ROLES } from "@/lib/club-registration/registration-access";
 
 export default function AdhesionsTableauPage() {
   return (
     <AuthGuard
-      allowedRoles={[USER_ROLES.SECRETARY, USER_ROLES.ADMIN]}
+      allowedRoles={[...CLUB_REGISTRATION_SPREADSHEET_ROLES]}
       redirectWhenUnauthorized="/joueur"
     >
       <RegistrationsSpreadsheetClient />

--- a/src/app/joueur/page.tsx
+++ b/src/app/joueur/page.tsx
@@ -15,6 +15,7 @@ import {
   Description as DescriptionIcon,
   EventAvailable as EventAvailableIcon,
   SportsTennis as SportsTennisIcon,
+  TableChart as TableChartIcon,
 } from "@mui/icons-material";
 import Link from "next/link";
 import { AuthGuard } from "@/components/AuthGuard";
@@ -31,7 +32,7 @@ type QuickAction = {
 };
 
 export default function PlayerHomePage() {
-  const { user } = useAuth();
+  const { user, isAssistantSecretary } = useAuth();
 
   const quickActions: QuickAction[] = [
     {
@@ -51,6 +52,17 @@ export default function PlayerHomePage() {
       icon: <EventAvailableIcon color="primary" />,
     },
   ];
+
+  if (isAssistantSecretary) {
+    quickActions.push({
+      title: "Tableau des adhésions",
+      description:
+        "Consulter tous les dossiers, filtrer les colonnes et exporter le tableau.",
+      href: "/club/adhesions-tableau",
+      cta: "Ouvrir le tableau",
+      icon: <TableChartIcon color="primary" />,
+    });
+  }
 
   if (user && canAccessLicenseValidation(user.role)) {
     quickActions.push({

--- a/src/components/club-registration/spreadsheet/RegistrationsSpreadsheetClient.tsx
+++ b/src/components/club-registration/spreadsheet/RegistrationsSpreadsheetClient.tsx
@@ -12,7 +12,9 @@ import {
 } from "@mui/material";
 import RateReviewIcon from "@mui/icons-material/RateReview";
 import { PageHeader, SectionCard } from "@/components/ui";
+import { useAuth } from "@/hooks/useAuth";
 import { useRegistrationConfig } from "@/hooks/useRegistrationConfig";
+import { isClubRegistrationManager } from "@/lib/club-registration/registration-access";
 import { buildManagedTreatQueueHref } from "@/lib/club-registration/managed-queue-summary";
 import {
   buildSpreadsheetCsvContent,
@@ -43,9 +45,12 @@ import { useSpreadsheetFilterState } from "./useSpreadsheetFilterState";
 import { useSpreadsheetUrlSync } from "./useSpreadsheetUrlSync";
 
 export function RegistrationsSpreadsheetClient() {
+  const { user } = useAuth();
+  const canTreatDossiers = Boolean(user && isClubRegistrationManager(user.role));
   const { config } = useRegistrationConfig();
   const { initial, syncToUrl } = useSpreadsheetUrlSync();
-  const { summary: queueSummary, loading: queueSummaryLoading } = useManagedQueueSummary();
+  const { summary: queueSummary, loading: queueSummaryLoading } =
+    useManagedQueueSummary(canTreatDossiers);
   const {
     registrations,
     userLabels,
@@ -230,14 +235,16 @@ export function RegistrationsSpreadsheetClient() {
           subtitle="Filtrez, exportez et ouvrez un dossier en modale."
           sx={{ "& h1": { fontSize: { xs: "1.5rem", sm: "1.75rem" } } }}
           actions={
-            <Button
-              component={Link}
-              href={treatQueueHref}
-              variant="outlined"
-              startIcon={<RateReviewIcon />}
-            >
-              {treatQueueLabel}
-            </Button>
+            canTreatDossiers ? (
+              <Button
+                component={Link}
+                href={treatQueueHref}
+                variant="outlined"
+                startIcon={<RateReviewIcon />}
+              >
+                {treatQueueLabel}
+              </Button>
+            ) : undefined
           }
         />
 

--- a/src/components/layout-navigation.test.ts
+++ b/src/components/layout-navigation.test.ts
@@ -38,6 +38,7 @@ describe("buildLayoutNavigation", () => {
       "/joueur",
       "/club/inscription",
       "/club/mes-inscriptions",
+      "/club/adhesions-tableau",
       "/club/validations-licence",
     ]);
   });

--- a/src/components/layout-navigation.tsx
+++ b/src/components/layout-navigation.tsx
@@ -156,7 +156,7 @@ export function buildLayoutNavigation(
       NAV.mesDossiers,
     ];
     if (isAssistantSecretary) {
-      primary.push(NAV.validationsLicence);
+      primary.push(NAV.tableauAdhesions, NAV.validationsLicence);
     }
     return { primary, groups: [] };
   }

--- a/src/lib/club-registration/registration-access.test.ts
+++ b/src/lib/club-registration/registration-access.test.ts
@@ -1,5 +1,10 @@
 import { USER_ROLES } from "@/lib/auth/roles";
-import { canAccessClubRegistration, isClubRegistrationManager } from "./registration-access";
+import {
+  canAccessClubRegistration,
+  canAccessRegistrationsSpreadsheet,
+  canViewClubRegistration,
+  isClubRegistrationManager,
+} from "./registration-access";
 
 describe("club registration access", () => {
   const ownerUid = "user-owner";
@@ -9,8 +14,44 @@ describe("club registration access", () => {
     it("autorise admin et secrétariat uniquement", () => {
       expect(isClubRegistrationManager(USER_ROLES.ADMIN)).toBe(true);
       expect(isClubRegistrationManager(USER_ROLES.SECRETARY)).toBe(true);
+      expect(isClubRegistrationManager(USER_ROLES.ASSISTANT_SECRETARY)).toBe(
+        false
+      );
       expect(isClubRegistrationManager(USER_ROLES.COACH)).toBe(false);
       expect(isClubRegistrationManager(USER_ROLES.PLAYER)).toBe(false);
+    });
+  });
+
+  describe("canAccessRegistrationsSpreadsheet", () => {
+    it("autorise admin, secrétariat et secrétaire adjoint", () => {
+      expect(canAccessRegistrationsSpreadsheet(USER_ROLES.ADMIN)).toBe(true);
+      expect(canAccessRegistrationsSpreadsheet(USER_ROLES.SECRETARY)).toBe(true);
+      expect(
+        canAccessRegistrationsSpreadsheet(USER_ROLES.ASSISTANT_SECRETARY)
+      ).toBe(true);
+      expect(canAccessRegistrationsSpreadsheet(USER_ROLES.COACH)).toBe(false);
+      expect(canAccessRegistrationsSpreadsheet(USER_ROLES.PLAYER)).toBe(false);
+    });
+  });
+
+  describe("canViewClubRegistration", () => {
+    it("autorise le secrétaire adjoint sur un dossier tiers", () => {
+      expect(
+        canViewClubRegistration(
+          USER_ROLES.ASSISTANT_SECRETARY,
+          ownerUid,
+          otherUid
+        )
+      ).toBe(true);
+    });
+
+    it("refuse coach et joueur sur le dossier d'un autre", () => {
+      expect(
+        canViewClubRegistration(USER_ROLES.COACH, ownerUid, otherUid)
+      ).toBe(false);
+      expect(
+        canViewClubRegistration(USER_ROLES.PLAYER, ownerUid, otherUid)
+      ).toBe(false);
     });
   });
 
@@ -24,9 +65,26 @@ describe("club registration access", () => {
       ).toBe(true);
     });
 
+    it("refuse le secrétaire adjoint sur un dossier tiers", () => {
+      expect(
+        canAccessClubRegistration(
+          USER_ROLES.ASSISTANT_SECRETARY,
+          ownerUid,
+          otherUid
+        )
+      ).toBe(false);
+    });
+
     it("autorise le propriétaire (submitterUid)", () => {
       expect(
         canAccessClubRegistration(USER_ROLES.PLAYER, ownerUid, ownerUid)
+      ).toBe(true);
+      expect(
+        canAccessClubRegistration(
+          USER_ROLES.ASSISTANT_SECRETARY,
+          ownerUid,
+          ownerUid
+        )
       ).toBe(true);
     });
 

--- a/src/lib/club-registration/registration-access.ts
+++ b/src/lib/club-registration/registration-access.ts
@@ -1,18 +1,56 @@
 import { hasAnyRole, USER_ROLES, type UserRole } from "@/lib/auth/roles";
 
-/** Rôles pouvant consulter n'importe quel dossier d'inscription (secrétariat). */
+/** Rôles pouvant traiter les dossiers (validation, paiement, suppression). */
 export const CLUB_REGISTRATION_MANAGER_ROLES = [
   USER_ROLES.ADMIN,
   USER_ROLES.SECRETARY,
+] as const;
+
+/** Rôles pouvant ouvrir le tableau des adhésions (lecture, export, préférences). */
+export const CLUB_REGISTRATION_SPREADSHEET_ROLES = [
+  USER_ROLES.ADMIN,
+  USER_ROLES.SECRETARY,
+  USER_ROLES.ASSISTANT_SECRETARY,
 ] as const;
 
 export function isClubRegistrationManager(role: UserRole): boolean {
   return hasAnyRole(role, CLUB_REGISTRATION_MANAGER_ROLES);
 }
 
+export function canAccessRegistrationsSpreadsheet(role: UserRole): boolean {
+  return hasAnyRole(role, CLUB_REGISTRATION_SPREADSHEET_ROLES);
+}
+
+function isRegistrationOwner(
+  submitterUid: string | undefined,
+  requestUid: string
+): boolean {
+  return (
+    typeof submitterUid === "string" &&
+    submitterUid.length > 0 &&
+    submitterUid === requestUid
+  );
+}
+
 /**
- * Accès lecture / facture : admin ou secrétariat, ou soumettant du dossier (propriétaire).
- * Les coachs et autres rôles n'ont pas accès aux dossiers d'autrui.
+ * Accès lecture d'un dossier : tableau (admin, secrétariat, secrétaire adjoint)
+ * ou soumettant du dossier (propriétaire).
+ */
+export function canViewClubRegistration(
+  role: UserRole,
+  submitterUid: string | undefined,
+  requestUid: string
+): boolean {
+  if (canAccessRegistrationsSpreadsheet(role)) {
+    return true;
+  }
+  return isRegistrationOwner(submitterUid, requestUid);
+}
+
+/**
+ * Accès lecture / facture / paiement self-service : admin ou secrétariat,
+ * ou soumettant du dossier (propriétaire).
+ * Les coachs, secrétaires adjoints et autres rôles n'ont pas accès aux dossiers d'autrui.
  */
 export function canAccessClubRegistration(
   role: UserRole,
@@ -22,5 +60,5 @@ export function canAccessClubRegistration(
   if (isClubRegistrationManager(role)) {
     return true;
   }
-  return typeof submitterUid === "string" && submitterUid.length > 0 && submitterUid === requestUid;
+  return isRegistrationOwner(submitterUid, requestUid);
 }


### PR DESCRIPTION
## Summary
- Ouvre `/club/adhesions-tableau` au rôle secrétaire adjoint (page, API tableau/préférences, lecture d’un dossier).
- Masque le lien « Traiter les dossiers » : `/club/demandes-adhesion` et les mutations secrétariat restent admin/secrétaire uniquement.
- Ajoute le raccourci dans la navigation et sur l’accueil `/joueur`.

## Test plan
- [ ] Se connecter en secrétaire adjoint : le tableau est accessible, le bouton « Traiter les dossiers » est absent.
- [ ] Vérifier le lien dans la nav et la carte sur `/joueur`.
- [ ] Ouvrir `/club/demandes-adhesion` en secrétaire adjoint : accès refusé / redirection.
- [ ] Se connecter en secrétaire : le bouton « Traiter les dossiers » est toujours présent et fonctionnel.


Made with [Cursor](https://cursor.com)