### PR TITLE
feat(club-registration): remise exceptionnelle secrétariat

### DIFF
--- a/src/components/club-registration/secretariat/SecretariatAidAmountFields.tsx
+++ b/src/components/club-registration/secretariat/SecretariatAidAmountFields.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/club-registration/payment/payment-draft-helpers";
 import type { PaymentAid } from "@/lib/club-registration/payment/types";
 import { getReductionReferenceCode } from "@/lib/club-registration/reduction-reference-codes";
+import { SecretariatExceptionalDiscountFields } from "./SecretariatExceptionalDiscountFields";
 
 type Props = {
   config: RegistrationConfigV1;
@@ -87,10 +88,6 @@ export function SecretariatAidAmountFields({
     .map((id) => findAidRuleById(config, id))
     .filter((rule): rule is NonNullable<typeof rule> => rule !== undefined);
 
-  if (selectedRules.length === 0) {
-    return null;
-  }
-
   const labelsByType = Object.fromEntries(config.aidRules.map((rule) => [rule.id, rule.label]));
 
   const updateAidAmount = (aidId: string, amountCents: number) => {
@@ -113,48 +110,57 @@ export function SecretariatAidAmountFields({
 
   return (
     <Box sx={{ gridColumn: "1 / -1" }}>
-      <Stack spacing={2}>
-        <Typography variant="subtitle2" fontWeight={600}>
-          Montants des aides
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Ajustez le montant déclaré pour chaque aide cochée. Ces montants sont déduits du reste
-          à payer estimé.
-        </Typography>
-        <Stack spacing={2}>
-          {selectedRules.map((rule) => {
-            const aid = findPaymentAid(normalizedAids, rule.id);
-            const fixedAmountCents = getAidRuleFixedAmountCents(rule);
-            const maxAmountCents = getAidRuleMaxAmountCents(rule);
+      <Stack spacing={3}>
+        {selectedRules.length > 0 ? (
+          <Stack spacing={2}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              Montants des aides
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Ajustez le montant déclaré pour chaque aide cochée. Ces montants sont déduits du
+              reste à payer estimé.
+            </Typography>
+            <Stack spacing={2}>
+              {selectedRules.map((rule) => {
+                const aid = findPaymentAid(normalizedAids, rule.id);
+                const fixedAmountCents = getAidRuleFixedAmountCents(rule);
+                const maxAmountCents = getAidRuleMaxAmountCents(rule);
 
-            if (fixedAmountCents !== undefined) {
-              return (
-                <FixedAidAmountRow
-                  key={rule.id}
-                  ruleId={rule.id}
-                  ruleLabel={rule.label}
-                  fixedAmountCents={fixedAmountCents}
-                  dossierAmountCents={aid?.amountCents ?? 0}
-                  onApplyFixedAmount={() => updateAidAmount(rule.id, fixedAmountCents)}
-                />
-              );
-            }
+                if (fixedAmountCents !== undefined) {
+                  return (
+                    <FixedAidAmountRow
+                      key={rule.id}
+                      ruleId={rule.id}
+                      ruleLabel={rule.label}
+                      fixedAmountCents={fixedAmountCents}
+                      dossierAmountCents={aid?.amountCents ?? 0}
+                      onApplyFixedAmount={() => updateAidAmount(rule.id, fixedAmountCents)}
+                    />
+                  );
+                }
 
-            const maxHelperText = aidMaxAmountHelperText(maxAmountCents);
-            return (
-              <AidEuroAmountField
-                key={rule.id}
-                label={`Montant (${rule.label})`}
-                amountCents={aid?.amountCents ?? 0}
-                onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
-                required
-                sx={AID_AMOUNT_FIELD_SX}
-                dataField={`paymentAid.${rule.id}`}
-                {...(maxHelperText ? { helperText: maxHelperText } : {})}
-              />
-            );
-          })}
-        </Stack>
+                const maxHelperText = aidMaxAmountHelperText(maxAmountCents);
+                return (
+                  <AidEuroAmountField
+                    key={rule.id}
+                    label={`Montant (${rule.label})`}
+                    amountCents={aid?.amountCents ?? 0}
+                    onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
+                    required
+                    sx={AID_AMOUNT_FIELD_SX}
+                    dataField={`paymentAid.${rule.id}`}
+                    {...(maxHelperText ? { helperText: maxHelperText } : {})}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+        ) : null}
+
+        <SecretariatExceptionalDiscountFields
+          paymentAids={paymentAids}
+          onPaymentAidsChange={onPaymentAidsChange}
+        />
       </Stack>
     </Box>
   );

--- a/src/components/club-registration/secretariat/SecretariatExceptionalDiscountFields.tsx
+++ b/src/components/club-registration/secretariat/SecretariatExceptionalDiscountFields.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Box, Button, Stack, TextField, Typography } from "@mui/material";
+import { PAYMENT_AID_NOTE_MAX_LENGTH } from "@/lib/club-registration/payment-constants";
+import {
+  EXCEPTIONAL_DISCOUNT_AID_LABEL,
+  findExceptionalDiscountAid,
+  removeExceptionalDiscountAid,
+  upsertExceptionalDiscountAid,
+} from "@/lib/club-registration/payment/exceptional-discount";
+import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import { AidEuroAmountField } from "../AidEuroAmountField";
+
+type Props = {
+  paymentAids: PaymentAid[];
+  onPaymentAidsChange: (aids: PaymentAid[]) => void;
+};
+
+const AMOUNT_FIELD_SX = {
+  width: "100%",
+  maxWidth: 220,
+} as const;
+
+export function SecretariatExceptionalDiscountFields({
+  paymentAids,
+  onPaymentAidsChange,
+}: Props) {
+  const normalizedAids = normalizePaymentAidList(paymentAids);
+  const exceptional = findExceptionalDiscountAid(normalizedAids);
+  const amountCents = exceptional?.amountCents ?? 0;
+  const note = exceptional?.note ?? "";
+  const isActive = amountCents > 0 || Boolean(note.trim());
+
+  const commit = (next: { amountCents: number; note: string }) => {
+    if (next.amountCents <= 0 && !next.note.trim()) {
+      onPaymentAidsChange(removeExceptionalDiscountAid(normalizedAids));
+      return;
+    }
+    onPaymentAidsChange(
+      upsertExceptionalDiscountAid(
+        normalizedAids,
+        {
+          amountCents: next.amountCents,
+          note: next.note,
+        },
+        { retainZero: true }
+      )
+    );
+  };
+
+  return (
+    <Box sx={{ gridColumn: "1 / -1" }} data-field="paymentAid.other">
+      <Stack spacing={2}>
+        <Typography variant="subtitle2" fontWeight={600}>
+          {EXCEPTIONAL_DISCOUNT_AID_LABEL}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Remise secrétariat à montant libre, déduite du reste à payer. Indiquez le motif lorsque
+          un montant est saisi.
+        </Typography>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="flex-start">
+          <AidEuroAmountField
+            label="Montant de la remise"
+            amountCents={amountCents}
+            onCommitCents={(cents) => commit({ amountCents: cents, note })}
+            sx={AMOUNT_FIELD_SX}
+            dataField="paymentAid.other.amount"
+            helperText="Montant libre (0 € pour retirer la remise)."
+          />
+          {isActive ? (
+            <Button
+              color="inherit"
+              onClick={() => onPaymentAidsChange(removeExceptionalDiscountAid(normalizedAids))}
+              sx={{ mt: { sm: 0.5 } }}
+            >
+              Retirer
+            </Button>
+          ) : null}
+        </Stack>
+        <TextField
+          label="Motif de la remise"
+          value={note}
+          onChange={(e) => commit({ amountCents, note: e.target.value })}
+          onBlur={() => {
+            const trimmed = note.trim();
+            if (trimmed !== note) {
+              commit({ amountCents, note: trimmed });
+            }
+          }}
+          fullWidth
+          multiline
+          minRows={2}
+          required={amountCents > 0}
+          inputProps={{
+            maxLength: PAYMENT_AID_NOTE_MAX_LENGTH,
+            "data-field": "paymentAid.other.note",
+          }}
+          helperText={
+            amountCents > 0
+              ? "Obligatoire dès qu’un montant est saisi (ex. geste commercial, cas social)."
+              : "Facultatif tant qu’aucun montant n’est saisi."
+          }
+        />
+      </Stack>
+    </Box>
+  );
+}

--- a/src/lib/club-registration/build-manager-registration-aids-patch.test.ts
+++ b/src/lib/club-registration/build-manager-registration-aids-patch.test.ts
@@ -51,4 +51,123 @@ describe("buildManagerRegistrationAidsPatch", () => {
       ],
     });
   });
+
+  it("régénère le chèque attendu après une remise exceptionnelle", () => {
+    const currentPayment: RegistrationPayment = {
+      totalAmountCents: 11_500,
+      assistanceTotalAmountCents: 0,
+      amountToPayCents: 11_500,
+      aids: [],
+      paymentMethod: "cheque",
+      paymentInstallments: 1,
+      expectedPayments: [
+        {
+          id: "ep_old",
+          method: "cheque",
+          label: "Chèque 1/1",
+          expectedAmountCents: 11_500,
+          status: "expected",
+        },
+      ],
+      receivedPayments: [],
+      paidAmountCents: 0,
+      remainingAmountCents: 11_500,
+      paymentStatus: "pending_validation",
+    };
+
+    const patch = buildManagerRegistrationAidsPatch(
+      {
+        reductionTypes: [],
+        reductionReferenceCodes: {},
+        paymentAids: [
+          {
+            type: "other",
+            label: "Remise exceptionnelle",
+            amountCents: 4_000,
+            note: "Bonne raison",
+          },
+        ],
+      },
+      { payment: currentPayment },
+      config as never,
+      [
+        {
+          type: "other",
+          label: "Remise exceptionnelle",
+          amountCents: 4_000,
+          note: "Bonne raison",
+        },
+      ]
+    );
+
+    const payment = patch.payment as RegistrationPayment;
+    expect(payment.amountToPayCents).toBe(7_500);
+    expect(payment.assistanceTotalAmountCents).toBe(4_000);
+    expect(payment.expectedPayments).toHaveLength(1);
+    expect(payment.expectedPayments[0]?.expectedAmountCents).toBe(7_500);
+    expect(payment.expectedPayments[0]?.status).toBe("expected");
+    expect(payment.expectedPayments[0]?.id).not.toBe("ep_old");
+  });
+
+  it("ne régénère pas les échéances déjà encaissées", () => {
+    const currentPayment: RegistrationPayment = {
+      totalAmountCents: 11_500,
+      assistanceTotalAmountCents: 0,
+      amountToPayCents: 11_500,
+      aids: [],
+      paymentMethod: "cheque",
+      paymentInstallments: 1,
+      expectedPayments: [
+        {
+          id: "ep_received",
+          method: "cheque",
+          label: "Chèque 1/1",
+          expectedAmountCents: 11_500,
+          status: "received",
+        },
+      ],
+      receivedPayments: [
+        {
+          id: "rp_1",
+          method: "cheque",
+          label: "Chèque 1/1",
+          amountCents: 11_500,
+          receivedAt: "2026-07-01T00:00:00.000Z",
+          expectedPaymentId: "ep_received",
+        },
+      ],
+      paidAmountCents: 11_500,
+      remainingAmountCents: 0,
+      paymentStatus: "paid",
+    };
+
+    const patch = buildManagerRegistrationAidsPatch(
+      {
+        reductionTypes: [],
+        reductionReferenceCodes: {},
+        paymentAids: [
+          {
+            type: "other",
+            label: "Remise exceptionnelle",
+            amountCents: 4_000,
+            note: "Trop tard",
+          },
+        ],
+      },
+      { payment: currentPayment },
+      config as never,
+      [
+        {
+          type: "other",
+          label: "Remise exceptionnelle",
+          amountCents: 4_000,
+          note: "Trop tard",
+        },
+      ]
+    );
+
+    const payment = patch.payment as RegistrationPayment;
+    expect(payment.expectedPayments[0]?.id).toBe("ep_received");
+    expect(payment.expectedPayments[0]?.expectedAmountCents).toBe(11_500);
+  });
 });

--- a/src/lib/club-registration/build-manager-registration-aids-patch.ts
+++ b/src/lib/club-registration/build-manager-registration-aids-patch.ts
@@ -6,8 +6,11 @@ import {
   paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
 import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
-import { recalculateRegistrationPayment } from "@/lib/club-registration/payment/payment-mutations";
-import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import {
+  recalculateRegistrationPayment,
+  regenerateExpectedPayments,
+} from "@/lib/club-registration/payment/payment-mutations";
+import type { PaymentAid, RegistrationPayment } from "@/lib/club-registration/payment/types";
 import { paymentAidPayloadSchema } from "@/lib/club-registration/payment-payload-schema";
 import { validateAdminAids } from "@/lib/club-registration/validate-admin-aids";
 import { PRICING_CATALOG_VERSION, type FamilyRegistrationOrder, type PriceQuote } from "@/lib/pricing/types";
@@ -141,12 +144,32 @@ export function buildManagerRegistrationAidsPatch(
 
   const payment = normalizeRegistrationPayment(currentData);
   if (payment) {
-    const nextPayment = recalculateRegistrationPayment(
-      { ...payment, aids: mergedAids },
-      { preserveManualFollowUp: true }
-    );
+    const nextPayment = syncPaymentAfterAidsChange(payment, mergedAids);
     Object.assign(patch, paymentToFirestoreUpdate(nextPayment));
   }
 
   return patch;
+}
+
+/**
+ * Recalcule totaux après changement d’aides et régénère les échéances chèque
+ * tant qu’aucune n’a encore été encaissée.
+ */
+export function syncPaymentAfterAidsChange(
+  payment: RegistrationPayment,
+  aids: PaymentAid[]
+): RegistrationPayment {
+  let next = recalculateRegistrationPayment(
+    { ...payment, aids },
+    { preserveManualFollowUp: true }
+  );
+
+  const hasReceivedExpected = next.expectedPayments.some(
+    (line) => line.status === "received"
+  );
+  if (!hasReceivedExpected && (next.paymentMethod === "cheque" || next.paymentMethod === "card")) {
+    next = regenerateExpectedPayments(next);
+  }
+
+  return next;
 }

--- a/src/lib/club-registration/payment-payload-schema.ts
+++ b/src/lib/club-registration/payment-payload-schema.ts
@@ -6,6 +6,7 @@ import {
   PAYMENT_NOTE_MAX_LENGTH,
   REMAINING_PAYMENT_METHOD_IDS,
 } from "./payment-constants";
+import { EXCEPTIONAL_DISCOUNT_AID_LABEL, isExceptionalDiscountAidType } from "./payment/exceptional-discount";
 
 export const paymentAidPayloadSchema = z.object({
   type: z.string().trim().min(1).max(80),
@@ -89,10 +90,10 @@ export function refinePaymentPayload(
   }
 
   for (const aid of data.paymentAids) {
-    if (aid.type === "other" && aid.amountCents > 0 && !aid.note?.trim()) {
+    if (isExceptionalDiscountAidType(aid.type) && aid.amountCents > 0 && !aid.note?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Indiquez un commentaire pour l'autre aide.",
+        message: `Indiquez un motif pour la ${EXCEPTIONAL_DISCOUNT_AID_LABEL.toLowerCase()}.`,
         path: ["paymentAids"],
       });
     }

--- a/src/lib/club-registration/payment/build-payment-from-draft.ts
+++ b/src/lib/club-registration/payment/build-payment-from-draft.ts
@@ -2,6 +2,10 @@ import type { PriceQuote } from "@/lib/pricing/types";
 import { resolveDonationPricing } from "@/lib/pricing/donation-discount";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { calculatePaymentSummary } from "./calculate-payment-summary";
+import {
+  EXCEPTIONAL_DISCOUNT_AID_LABEL,
+  isExceptionalDiscountAidType,
+} from "./exceptional-discount";
 import { generateExpectedPayments } from "./generate-expected-payments";
 import type { PaymentAid, PaymentDraftFields, RegistrationPayment } from "./types";
 import type { PaymentMethodId } from "../payment-constants";
@@ -15,6 +19,9 @@ export type BuildPaymentFromDraftInput = PaymentDraftFields & {
 };
 
 function findAidLabel(config: RegistrationConfigV1, aidType: string): string {
+  if (isExceptionalDiscountAidType(aidType)) {
+    return EXCEPTIONAL_DISCOUNT_AID_LABEL;
+  }
   const rule = config.aidRules.find((r) => r.id === aidType);
   return rule?.label ?? aidType;
 }

--- a/src/lib/club-registration/payment/exceptional-discount.test.ts
+++ b/src/lib/club-registration/payment/exceptional-discount.test.ts
@@ -1,0 +1,57 @@
+import {
+  EXCEPTIONAL_DISCOUNT_AID_LABEL,
+  EXCEPTIONAL_DISCOUNT_AID_TYPE,
+  exceptionalDiscountAidLabel,
+  findExceptionalDiscountAid,
+  removeExceptionalDiscountAid,
+  upsertExceptionalDiscountAid,
+} from "./exceptional-discount";
+import type { PaymentAid } from "./types";
+
+describe("exceptional-discount", () => {
+  it("étiquette la remise exceptionnelle", () => {
+    expect(exceptionalDiscountAidLabel(EXCEPTIONAL_DISCOUNT_AID_TYPE)).toBe(
+      EXCEPTIONAL_DISCOUNT_AID_LABEL
+    );
+    expect(exceptionalDiscountAidLabel("pass_sport", "Pass Sport")).toBe("Pass Sport");
+  });
+
+  it("upsert une remise avec montant et motif", () => {
+    const next = upsertExceptionalDiscountAid([], {
+      amountCents: 1_500,
+      note: "Cas social",
+    });
+    expect(next).toEqual([
+      {
+        type: EXCEPTIONAL_DISCOUNT_AID_TYPE,
+        label: EXCEPTIONAL_DISCOUNT_AID_LABEL,
+        amountCents: 1_500,
+        note: "Cas social",
+      },
+    ]);
+  });
+
+  it("conserve un espace final dans le motif (saisie en cours)", () => {
+    const next = upsertExceptionalDiscountAid([], {
+      amountCents: 1_500,
+      note: "Cas ",
+    });
+    expect(next[0]?.note).toBe("Cas ");
+  });
+
+  it("retrouve et retire la remise", () => {
+    const aids: PaymentAid[] = [
+      { type: "pass_sport", label: "Pass Sport", amountCents: 5_000 },
+      {
+        type: EXCEPTIONAL_DISCOUNT_AID_TYPE,
+        label: EXCEPTIONAL_DISCOUNT_AID_LABEL,
+        amountCents: 1_000,
+        note: "Geste",
+      },
+    ];
+    expect(findExceptionalDiscountAid(aids)?.amountCents).toBe(1_000);
+    expect(removeExceptionalDiscountAid(aids)).toEqual([
+      { type: "pass_sport", label: "Pass Sport", amountCents: 5_000 },
+    ]);
+  });
+});

--- a/src/lib/club-registration/payment/exceptional-discount.ts
+++ b/src/lib/club-registration/payment/exceptional-discount.ts
@@ -1,0 +1,43 @@
+import type { PaymentAid } from "./types";
+import { findPaymentAid, removePaymentAid, upsertPaymentAid } from "./payment-draft-helpers";
+
+/** Type d’aide secrétariat pour une remise ad hoc (hors catalogue des aides déclarées). */
+export const EXCEPTIONAL_DISCOUNT_AID_TYPE = "other" as const;
+
+export const EXCEPTIONAL_DISCOUNT_AID_LABEL = "Remise exceptionnelle";
+
+export function isExceptionalDiscountAidType(type: string): boolean {
+  return type === EXCEPTIONAL_DISCOUNT_AID_TYPE;
+}
+
+export function exceptionalDiscountAidLabel(type: string, fallbackLabel?: string): string {
+  if (isExceptionalDiscountAidType(type)) {
+    return EXCEPTIONAL_DISCOUNT_AID_LABEL;
+  }
+  return fallbackLabel?.trim() || type;
+}
+
+export function findExceptionalDiscountAid(aids: PaymentAid[]): PaymentAid | undefined {
+  return findPaymentAid(aids, EXCEPTIONAL_DISCOUNT_AID_TYPE);
+}
+
+export function upsertExceptionalDiscountAid(
+  aids: PaymentAid[],
+  patch: { amountCents: number; note?: string },
+  options?: { retainZero?: boolean }
+): PaymentAid[] {
+  return upsertPaymentAid(
+    aids,
+    {
+      type: EXCEPTIONAL_DISCOUNT_AID_TYPE,
+      label: EXCEPTIONAL_DISCOUNT_AID_LABEL,
+      amountCents: patch.amountCents,
+      ...(patch.note != null && patch.note.length > 0 ? { note: patch.note } : {}),
+    },
+    options
+  );
+}
+
+export function removeExceptionalDiscountAid(aids: PaymentAid[]): PaymentAid[] {
+  return removePaymentAid(aids, EXCEPTIONAL_DISCOUNT_AID_TYPE);
+}

--- a/src/lib/club-registration/payment/payment-draft-helpers.test.ts
+++ b/src/lib/club-registration/payment/payment-draft-helpers.test.ts
@@ -38,4 +38,18 @@ describe("upsertPaymentAid retainZero", () => {
     });
     expect(next).toHaveLength(0);
   });
+
+  it("conserve les espaces dans la note pendant la saisie", () => {
+    const next = upsertPaymentAid(
+      [],
+      {
+        type: "other",
+        label: "Remise exceptionnelle",
+        amountCents: 1000,
+        note: "Geste ",
+      },
+      { retainZero: true }
+    );
+    expect(next[0]?.note).toBe("Geste ");
+  });
 });

--- a/src/lib/club-registration/payment/payment-draft-helpers.ts
+++ b/src/lib/club-registration/payment/payment-draft-helpers.ts
@@ -1,3 +1,4 @@
+import { EXCEPTIONAL_DISCOUNT_AID_TYPE } from "./exceptional-discount";
 import type { PaymentAid } from "./types";
 
 export function normalizePaymentAidList(
@@ -84,8 +85,14 @@ export function upsertPaymentAid(
       label: patch.label,
       amountCents: patch.amountCents,
     };
-    if (patch.reference?.trim()) next.reference = patch.reference.trim();
-    if (patch.note?.trim()) next.note = patch.note.trim();
+    // Ne pas trimmer à chaque frappe : sinon un espace final (mot suivant) disparaît.
+    // Le trim d’enregistrement reste côté schéma API / validation.
+    if (patch.reference != null && patch.reference.length > 0) {
+      next.reference = patch.reference;
+    }
+    if (patch.note != null && patch.note.length > 0) {
+      next.note = patch.note;
+    }
     return [...without, next];
   }
   return without;
@@ -95,14 +102,14 @@ export function removePaymentAid(aids: PaymentAid[], type: string): PaymentAid[]
   return aids.filter((a) => a.type !== type);
 }
 
-/** Garde les lignes d’aide alignées sur les cases cochées (+ « autre »). */
+/** Garde les lignes d’aide alignées sur les cases cochées (+ remise exceptionnelle). */
 export function syncPaymentAidsWithReductionTypes(
   paymentAids: PaymentAid[],
   reductionTypes: string[],
   labelsByType: Record<string, string>
 ): PaymentAid[] {
   let next = paymentAids.filter(
-    (a) => a.type === "other" || reductionTypes.includes(a.type)
+    (a) => a.type === EXCEPTIONAL_DISCOUNT_AID_TYPE || reductionTypes.includes(a.type)
   );
 
   for (const type of reductionTypes) {

--- a/src/lib/club-registration/recap-aids.ts
+++ b/src/lib/club-registration/recap-aids.ts
@@ -2,6 +2,10 @@ import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types"
 import { getCheckboxAidRules, getToggleAidRules } from "@/lib/club-registration-config/aid-rules";
 import { getReductionReferenceCode } from "@/lib/club-registration/reduction-reference-codes";
 import {
+  EXCEPTIONAL_DISCOUNT_AID_LABEL,
+  findExceptionalDiscountAid,
+} from "@/lib/club-registration/payment/exceptional-discount";
+import {
   findPaymentAid,
   normalizePaymentAidList,
 } from "@/lib/club-registration/payment/payment-draft-helpers";
@@ -54,12 +58,12 @@ export function buildAdminAidRecapFields(
     });
   }
 
-  const otherAid = findPaymentAid(paymentAids, "other");
+  const otherAid = findExceptionalDiscountAid(paymentAids);
   if (otherAid && (otherAid.amountCents > 0 || otherAid.note?.trim())) {
     const detail = otherAid.note?.trim()
       ? `${formatAidAmount(otherAid.amountCents)} — ${otherAid.note.trim()}`
       : formatAidAmount(otherAid.amountCents);
-    fields.push({ label: "Autre aide", value: detail });
+    fields.push({ label: EXCEPTIONAL_DISCOUNT_AID_LABEL, value: detail });
   }
 
   return fields;

--- a/src/lib/club-registration/validate-admin-aids.test.ts
+++ b/src/lib/club-registration/validate-admin-aids.test.ts
@@ -78,4 +78,36 @@ describe("validateAdminAids", () => {
     expect(issue?.message).toMatch(/50,00/);
     expect(issue?.focusSelector).toBe('[data-field="paymentAid.pass_sport"]');
   });
+
+  it("exige un motif pour une remise exceptionnelle avec montant", () => {
+    const issue = validateAdminAids(
+      {
+        ...baseDraft,
+        paymentAids: [
+          { type: "other", label: "Remise exceptionnelle", amountCents: 2_500 },
+        ],
+      },
+      config
+    );
+    expect(issue?.message).toMatch(/motif/i);
+    expect(issue?.focusSelector).toBe('[data-field="paymentAid.other.note"]');
+  });
+
+  it("accepte une remise exceptionnelle avec montant et motif", () => {
+    const issue = validateAdminAids(
+      {
+        ...baseDraft,
+        paymentAids: [
+          {
+            type: "other",
+            label: "Remise exceptionnelle",
+            amountCents: 2_500,
+            note: "Geste commercial",
+          },
+        ],
+      },
+      config
+    );
+    expect(issue).toBeNull();
+  });
 });

--- a/src/lib/club-registration/validate-admin-aids.ts
+++ b/src/lib/club-registration/validate-admin-aids.ts
@@ -2,6 +2,10 @@ import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types"
 import { findAidRuleById, getAidRuleFixedAmountCents, getAidRuleMaxAmountCents } from "@/lib/club-registration-config/aid-rules";
 import { buildPricingContext, calculateQuote, formatCentsAsEuros } from "@/lib/pricing";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
+import {
+  EXCEPTIONAL_DISCOUNT_AID_LABEL,
+  findExceptionalDiscountAid,
+} from "@/lib/club-registration/payment/exceptional-discount";
 import { findPaymentAid, normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
 import type { RegistrationDraft } from "@/components/club-registration/registration-defaults";
 
@@ -86,6 +90,14 @@ export function validateAdminAids(
         focusSelector: `[data-field="paymentAid.${reductionId}"]`,
       };
     }
+  }
+
+  const exceptional = findExceptionalDiscountAid(aids);
+  if (exceptional && exceptional.amountCents > 0 && !exceptional.note?.trim()) {
+    return {
+      message: `Indiquez un motif pour la ${EXCEPTIONAL_DISCOUNT_AID_LABEL.toLowerCase()}.`,
+      focusSelector: '[data-field="paymentAid.other.note"]',
+    };
   }
 
   const totalCents = quoteTotalCents(draft, config);


### PR DESCRIPTION
## Summary
- Ajoute une remise exceptionnelle côté secrétariat (montant libre + motif obligatoire)
- Recalcule le solde et régénère les échéances chèque/carte non encore encaissées
- Renomme le type d’aide `other` en libellé « Remise exceptionnelle » dans le récap et les validations

## Test plan
- [ ] Ouvrir un dossier d’adhésion en secrétariat
- [ ] Saisir une remise exceptionnelle avec montant + motif → enregistrement OK
- [ ] Montant sans motif → erreur de validation
- [ ] Sur un dossier chèque non encaissé, vérifier que l’échéance attendue est recalculée
- [ ] Bouton « Retirer » enlève la remise


Made with [Cursor](https://cursor.com)