### PR TITLE
fix(club-registration): PPS mineurs de saison et saisie licence secrétariat

### DIFF
--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -28,7 +28,8 @@ import { scrollToFormTarget } from "@/lib/club-registration/scroll-to-form-targe
 import type { ClubRegistrationPayload } from "@/lib/club-registration/schema";
 import { useRegistrationConfig } from "@/hooks/useRegistrationConfig";
 import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
-import { isAtLeast65At, isMinorAt } from "@/lib/club-registration/age";
+import { isMinorAt } from "@/lib/club-registration/age";
+import { isAtLeast65ForClubSeason } from "@/lib/club-registration/season-age";
 import {
   shouldAutofillAdherentEmailFromAccount,
   shouldAutofillRepresentativeEmailFromAccount,
@@ -176,7 +177,7 @@ export function ClubRegistrationWizard({
     ) {
       return null;
     }
-    const senior = isAtLeast65At(draft.birthDate);
+    const senior = isAtLeast65ForClubSeason(draft.birthDate);
     const hadLicense = effectiveHadFfttLicense(
       medicalVeteranPath,
       hasVerifiedFfttLicense

--- a/src/components/club-registration/MedicalDeclarationSection.tsx
+++ b/src/components/club-registration/MedicalDeclarationSection.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from "@mui/material";
 import { CLUB_REGISTRATION_EXTERNAL_LINKS } from "@/lib/club-registration/constants";
-import { isMinorAt } from "@/lib/club-registration/age";
+import { isMinorForClubSeason } from "@/lib/club-registration/season-age";
 import { isMedicalCertificateRequired } from "@/lib/club-registration/medical-certificate";
 import {
   createEmptyMedicalQuestionnaire,
@@ -288,7 +288,7 @@ function SeniorVeteranBlock({
 }
 
 export function MedicalDeclarationSection({ draft, patchMedical }: Props) {
-  const minor = isMinorAt(draft.birthDate);
+  const minor = isMinorForClubSeason(draft.birthDate);
   const senior = isSeniorMedicalVeteranPath(draft.birthDate);
   const hasVerifiedFfttLicense = Boolean(draft.ffttLicenseLookup?.licence);
   const skipFirstLicenseQuestion = senior && hasVerifiedFfttLicense;

--- a/src/components/club-registration/PpsFollowUpPanel.tsx
+++ b/src/components/club-registration/PpsFollowUpPanel.tsx
@@ -23,6 +23,7 @@ import {
 type Props = {
   registrationId: string;
   medicalCertificateDeclaration: string | null | undefined;
+  birthDate?: string | null;
   ppsFollowUp: PpsFollowUpState;
   onUpdated: (next: PpsFollowUpState) => void | Promise<void>;
 };
@@ -56,6 +57,7 @@ function formatEventAt(iso: string): string {
 export function PpsFollowUpPanel({
   registrationId,
   medicalCertificateDeclaration,
+  birthDate,
   ppsFollowUp,
   onUpdated,
 }: Props) {
@@ -72,7 +74,7 @@ export function PpsFollowUpPanel({
 
   const state = localOverride ?? ppsFollowUp;
 
-  if (!isPpsFollowUpApplicable(medicalCertificateDeclaration)) {
+  if (!isPpsFollowUpApplicable(medicalCertificateDeclaration, birthDate)) {
     return null;
   }
 

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailPanel.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailPanel.tsx
@@ -70,6 +70,7 @@ export function MembershipRequestDetailPanel({
         <PpsFollowUpPanel
           registrationId={registrationId}
           medicalCertificateDeclaration={selected.medicalCertificateDeclaration}
+          birthDate={selected.birthDate ?? null}
           ppsFollowUp={readPpsFollowUpState(
             selected as unknown as Record<string, unknown>,
             selected.medicalCertificateDeclaration

--- a/src/components/club-registration/membership-requests/RegistrationSupplementarySections.tsx
+++ b/src/components/club-registration/membership-requests/RegistrationSupplementarySections.tsx
@@ -10,7 +10,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { isAtLeast65At } from "@/lib/club-registration/age";
+import { isAtLeast65ForClubSeason } from "@/lib/club-registration/season-age";
 import { MEDICAL_QUESTIONNAIRE_SUMMARY_LABELS } from "@/lib/club-registration/medical-declaration-labels";
 import {
   buildApplyFfttIdentityPatch,
@@ -309,7 +309,7 @@ type MedicalDossierDetailProps = {
 export function RegistrationMedicalDossierDetail({
   registration,
 }: MedicalDossierDetailProps) {
-  const senior = isAtLeast65At(registration.birthDate ?? "");
+  const senior = isAtLeast65ForClubSeason(registration.birthDate ?? "");
   const summary = registration.medicalQuestionnaire?.summary;
   const veteranPath = registration.medicalVeteranPath;
   const hasVerifiedFfttLicense = Boolean(registration.ffttLicenseLookup?.licence);

--- a/src/components/club-registration/membership-requests/to-editable-registration.ts
+++ b/src/components/club-registration/membership-requests/to-editable-registration.ts
@@ -7,6 +7,7 @@ import { normalizeReductionReferenceCodes } from "@/lib/club-registration/reduct
 import { expandCompetitionIdsForFormFromConfig } from "@/lib/club-registration-config/helpers";
 import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
 import type { PaymentAid, RegistrationPayment } from "@/lib/club-registration/payment/types";
+import { isMinorForClubSeason } from "@/lib/club-registration/season-age";
 import type { EditableRegistration, RegistrationDetail } from "./types";
 
 /** Reprend les aides déclarées à la soumission (objet `payment` après persist). */
@@ -55,7 +56,10 @@ export function toEditableRegistration(
     slotIds: registration.slotIds ?? [],
     schoolPickupSlotIds: registration.schoolPickupSlotIds ?? [],
     medicalCertificateDeclaration:
-      registration.medicalCertificateDeclaration ?? "adult_pps_declared",
+      registration.medicalCertificateDeclaration ??
+      (isMinorForClubSeason(registration.birthDate ?? "")
+        ? "minor_all_no"
+        : "adult_pps_declared"),
     medicalCertificateStatus: normalizeMedicalCertificateStatus(
       registration.medicalCertificateStatus,
       registration.medicalCertificateDeclaration

--- a/src/components/club-registration/step-validation.ts
+++ b/src/components/club-registration/step-validation.ts
@@ -1,4 +1,5 @@
 import { isMinorAt } from "@/lib/club-registration/age";
+import { isMinorForClubSeason } from "@/lib/club-registration/season-age";
 import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationStepId } from "@/lib/club-registration/field-to-step";
@@ -26,7 +27,7 @@ function invalid(
 }
 
 function getMedicalFocusSelector(draft: RegistrationDraft): string {
-  const minor = isMinorAt(draft.birthDate);
+  const minor = isMinorForClubSeason(draft.birthDate);
   const senior = isSeniorMedicalVeteranPath(draft.birthDate);
   const hasVerified = Boolean(draft.ffttLicenseLookup?.licence);
   const hadLicense = effectiveHadFfttLicense(
@@ -246,7 +247,7 @@ export function validateStep(
 
   if (stepId === "admin") {
     const senior = isSeniorMedicalVeteranPath(draft.birthDate);
-    const minor = isMinorAt(draft.birthDate);
+    const minor = isMinorForClubSeason(draft.birthDate);
     const decl = draft.medicalCertificateDeclaration;
     if (
       !decl ||

--- a/src/components/license-validation/LicenseValidationLicenseDetailPanel.tsx
+++ b/src/components/license-validation/LicenseValidationLicenseDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Alert,
   Box,
@@ -18,8 +18,10 @@ import {
 import {
   LICENSE_VALIDATION_STATUS_LABELS,
   LICENSE_VALIDATION_STATUS_VALUES,
+  requiresFfttLicenseNumber,
   type LicenseValidationStatus,
 } from "@/lib/license-validation/license-validation-status";
+import { LICENSE_REQUIRED_MESSAGE } from "@/lib/license-validation/resolve-license-validation-patch";
 import {
   formatRegistrationAddress,
   type LicenseValidationDetail,
@@ -61,20 +63,33 @@ export function LicenseValidationLicenseDetailPanel({
   const { detail, loading, error, reload, setDetail } = useLicenseValidationDetail(registrationId);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [ffttLicense, setFfttLicense] = useState("");
-  const [licenseValidationStatus, setLicenseValidationStatus] =
-    useState<LicenseValidationStatus>("to_do");
+  const [licenseDraft, setLicenseDraft] = useState<string | null>(null);
+  const [statusDraft, setStatusDraft] = useState<LicenseValidationStatus | null>(
+    null
+  );
+  const [draftRegistrationId, setDraftRegistrationId] = useState<string | null>(
+    null
+  );
 
-  useEffect(() => {
-    if (!detail) {
-      return;
-    }
-    setFfttLicense(detail.ffttLicense ?? "");
-    setLicenseValidationStatus(detail.licenseValidationStatus);
-  }, [detail]);
+  const isDraftForCurrent =
+    Boolean(registrationId) && draftRegistrationId === registrationId;
+  const knownLicense =
+    detail && detail.id === registrationId ? (detail.ffttLicense ?? "") : "";
+  const ffttLicense =
+    isDraftForCurrent && licenseDraft !== null ? licenseDraft : knownLicense;
+  const licenseValidationStatus: LicenseValidationStatus =
+    isDraftForCurrent && statusDraft !== null
+      ? statusDraft
+      : (detail?.id === registrationId
+          ? detail.licenseValidationStatus
+          : "to_do");
 
   const handleSave = async () => {
     if (!registrationId) {
+      return;
+    }
+    if (requiresFfttLicenseNumber(licenseValidationStatus) && ffttLicense.trim().length < 5) {
+      setSaveError(LICENSE_REQUIRED_MESSAGE);
       return;
     }
     setSaving(true);
@@ -94,6 +109,9 @@ export function LicenseValidationLicenseDetailPanel({
         throw new Error(json.error || "Enregistrement impossible");
       }
       const registration = json.registration as LicenseValidationDetail;
+      setLicenseDraft(null);
+      setStatusDraft(null);
+      setDraftRegistrationId(null);
       await reload();
       await onSaved(registration);
     } catch (err) {
@@ -137,11 +155,6 @@ export function LicenseValidationLicenseDetailPanel({
     return null;
   }
 
-  const lookupLicense =
-    typeof detail.ffttLicenseLookup?.licence === "string"
-      ? detail.ffttLicenseLookup.licence
-      : null;
-
   const infoFields: Array<{ label: string; value: string; fullWidth?: boolean }> = [
     { label: "Date de naissance", value: formatBirthDate(detail.birthDate) },
     { label: "Sexe", value: formatSexLabel(detail.sex) },
@@ -159,39 +172,13 @@ export function LicenseValidationLicenseDetailPanel({
     infoFields.push({
       label: "E-mail",
       value: "—",
-      fullWidth: !lookupLicense,
     });
-    if (lookupLicense) {
-      infoFields.push({
-        label: "Licence enregistrée (dossier)",
-        value: lookupLicense,
-      });
-    }
-  } else if (contactEmails.length === 1) {
-    infoFields.push({
-      label: contactEmails[0]!.label,
-      value: contactEmails[0]!.email,
-      fullWidth: !lookupLicense,
-    });
-    if (lookupLicense) {
-      infoFields.push({
-        label: "Licence enregistrée (dossier)",
-        value: lookupLicense,
-      });
-    }
   } else {
     for (const contact of contactEmails) {
       infoFields.push({
         label: contact.label,
         value: contact.email,
-        fullWidth: true,
-      });
-    }
-    if (lookupLicense) {
-      infoFields.push({
-        label: "Licence enregistrée (dossier)",
-        value: lookupLicense,
-        fullWidth: true,
+        fullWidth: contactEmails.length > 1,
       });
     }
   }
@@ -212,7 +199,8 @@ export function LicenseValidationLicenseDetailPanel({
       value: formatMedicalCertificateLabel(
         detail.medicalCertificateStatus,
         detail.medicalCertificateDeclaration,
-        detail.ppsFollowUp.status
+        detail.ppsFollowUp.status,
+        detail.birthDate
       ),
     },
     {
@@ -244,12 +232,21 @@ export function LicenseValidationLicenseDetailPanel({
         <Grid container spacing={1.5}>
           <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
-              label="Nouveau numéro de licence"
+              label="Numéro de licence"
               value={ffttLicense}
-              onChange={(e) => setFfttLicense(e.target.value.replace(/\D/g, ""))}
+              onChange={(e) => {
+                setDraftRegistrationId(registrationId);
+                setLicenseDraft(e.target.value.replace(/\D/g, ""));
+              }}
               fullWidth
               size="small"
+              required={requiresFfttLicenseNumber(licenseValidationStatus)}
               inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
+              helperText={
+                requiresFfttLicenseNumber(licenseValidationStatus)
+                  ? "Obligatoire pour Traité et Validé sans pratique sportive"
+                  : " "
+              }
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }}>
@@ -259,9 +256,10 @@ export function LicenseValidationLicenseDetailPanel({
                 labelId="license-validation-status-label"
                 label="Statut licence"
                 value={licenseValidationStatus}
-                onChange={(e) =>
-                  setLicenseValidationStatus(e.target.value as LicenseValidationStatus)
-                }
+                onChange={(e) => {
+                  setDraftRegistrationId(registrationId);
+                  setStatusDraft(e.target.value as LicenseValidationStatus);
+                }}
               >
                 {LICENSE_VALIDATION_STATUS_VALUES.map((status) => (
                   <MenuItem key={status} value={status}>
@@ -282,6 +280,7 @@ export function LicenseValidationLicenseDetailPanel({
         <PpsFollowUpPanel
           registrationId={registrationId}
           medicalCertificateDeclaration={detail.medicalCertificateDeclaration}
+          birthDate={detail.birthDate}
           ppsFollowUp={detail.ppsFollowUp}
           onUpdated={(next) => {
             setDetail((current) =>

--- a/src/components/license-validation/license-validation-labels.test.ts
+++ b/src/components/license-validation/license-validation-labels.test.ts
@@ -21,6 +21,33 @@ describe("resolveMedicalFollowUpKind", () => {
     expect(resolveMedicalFollowUpKind("minor_all_no", "not_required")).toBe("ok");
   });
 
+  it("ne traite pas l’ancien régime comme PPS pour un mineur de saison", () => {
+    expect(
+      resolveMedicalFollowUpKind(
+        "under_40_all_no",
+        "not_required",
+        undefined,
+        "2012-06-01"
+      )
+    ).toBe("ok");
+    expect(
+      formatMedicalCertificateLabel(
+        "not_required",
+        "adult_pps_declared",
+        "expected",
+        "2008-01-15"
+      )
+    ).toBe("OK");
+    expect(
+      resolveMedicalFollowUpKind(
+        "under_40_all_no",
+        "not_required",
+        undefined,
+        "2000-04-12"
+      )
+    ).toBe("pps_expected");
+  });
+
   it("distingue certificat attendu, reçu et validé", () => {
     expect(
       resolveMedicalFollowUpKind("adult_certificate_required", "required_not_received")

--- a/src/components/license-validation/license-validation-labels.ts
+++ b/src/components/license-validation/license-validation-labels.ts
@@ -32,9 +32,15 @@ export function formatSexLabel(sex: string | null | undefined): string {
 export function formatMedicalCertificateLabel(
   status: string | null,
   declaration?: string | null,
-  ppsFollowUpStatus?: string | null
+  ppsFollowUpStatus?: string | null,
+  birthDate?: string | null
 ): string {
-  return formatMedicalFollowUpLabel(declaration, status, ppsFollowUpStatus);
+  return formatMedicalFollowUpLabel(
+    declaration,
+    status,
+    ppsFollowUpStatus,
+    birthDate
+  );
 }
 
 export function formatAttestationLabel(wantsRegistrationCertificate: boolean): string {

--- a/src/components/license-validation/useLicenseValidationDetail.ts
+++ b/src/components/license-validation/useLicenseValidationDetail.ts
@@ -39,6 +39,7 @@ export function useLicenseValidationDetail(registrationId: string | null) {
   }, [registrationId]);
 
   useEffect(() => {
+    setDetail(null);
     void reload();
   }, [reload]);
 

--- a/src/lib/club-registration/apply-pps-follow-up-event.ts
+++ b/src/lib/club-registration/apply-pps-follow-up-event.ts
@@ -41,8 +41,9 @@ export async function applyPpsFollowUpEvent(
     typeof data.medicalCertificateDeclaration === "string"
       ? data.medicalCertificateDeclaration
       : null;
+  const birthDate = typeof data.birthDate === "string" ? data.birthDate : null;
 
-  if (!isPpsFollowUpApplicable(declaration)) {
+  if (!isPpsFollowUpApplicable(declaration, birthDate)) {
     return {
       ok: false,
       status: 400,

--- a/src/lib/club-registration/build-payload-schema.ts
+++ b/src/lib/club-registration/build-payload-schema.ts
@@ -10,6 +10,7 @@ import { getToggleAidRules } from "@/lib/club-registration-config/aid-rules";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { preprocessRegistrationPayloadInput } from "./reduction-reference-codes";
 import { isMinorAt } from "./age";
+import { isMinorForClubSeason } from "./season-age";
 import {
   createEmptyMedicalVeteranPath,
   deriveMedicalCertificateDeclaration,
@@ -248,7 +249,8 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
       }
 
       const senior = isSeniorMedicalVeteranPath(data.birthDate);
-      const minor = isMinorAt(data.birthDate);
+      const seasonMinor = isMinorForClubSeason(data.birthDate);
+      const legalMinor = isMinorAt(data.birthDate);
       const decl = data.medicalCertificateDeclaration;
       const hasVerifiedFfttLicense = Boolean(data.ffttLicenseLookup?.licence);
       const veteranPath: MedicalVeteranPath = data.medicalVeteranPath
@@ -283,7 +285,7 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
         });
       }
 
-      if (minor) {
+      if (seasonMinor) {
         if (!data.medicalQuestionnaire.summary) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -361,14 +363,14 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
         }
       }
 
-      if (!minor && !data.adherentEmail?.trim()) {
+      if (!legalMinor && !data.adherentEmail?.trim()) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "L'e-mail de contact est obligatoire pour un adhérent majeur.",
           path: ["adherentEmail"],
         });
       }
-      if (minor) {
+      if (legalMinor) {
         if (data.emergencyMedicalAuthorization !== "yes") {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -404,7 +406,7 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
         }
       }
 
-      if (minor && data.adherentRole === "self") {
+      if (legalMinor && data.adherentRole === "self") {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message:

--- a/src/lib/club-registration/list-registrations.ts
+++ b/src/lib/club-registration/list-registrations.ts
@@ -70,7 +70,8 @@ export function mapRegistrationDocToSummary(
     data.ppsFollowUpStatus,
     typeof data.medicalCertificateDeclaration === "string"
       ? data.medicalCertificateDeclaration
-      : undefined
+      : undefined,
+    typeof data.birthDate === "string" ? data.birthDate : undefined
   );
   const submittedAtMs: number = data.submittedAt?.toMillis?.() ?? 0;
   summary.submittedAt = data.submittedAt?.toDate?.()?.toISOString?.() ?? null;
@@ -255,7 +256,8 @@ function filterManagedSummaries(
         : undefined;
     const ppsStatus = normalizePpsFollowUpStatus(
       summary.ppsFollowUpStatus,
-      declaration
+      declaration,
+      typeof summary.birthDate === "string" ? summary.birthDate : undefined
     );
     return (
       matchesManagedStatusFilter(summary, params.statusFilter) &&

--- a/src/lib/club-registration/medical-certificate.ts
+++ b/src/lib/club-registration/medical-certificate.ts
@@ -1,3 +1,5 @@
+import { isMinorForClubSeason } from "@/lib/club-registration/season-age";
+
 export const MEDICAL_CERTIFICATE_STATUS_VALUES = [
   "not_required",
   "required_not_received",
@@ -178,13 +180,19 @@ function resolvePpsFollowUpKind(
 export function resolveMedicalFollowUpKind(
   declaration: string | null | undefined,
   status: string | null | undefined,
-  ppsFollowUpStatus?: string | null
+  ppsFollowUpStatus?: string | null,
+  birthDate?: string | null
 ): MedicalFollowUpKind | null {
   if (!declaration && !status && !ppsFollowUpStatus) {
     return null;
   }
 
+  const seasonMinor = Boolean(birthDate && isMinorForClubSeason(birthDate));
+
   if (declaration && PPS_EQUIVALENT_DECLARATIONS.has(declaration)) {
+    if (seasonMinor) {
+      return "ok";
+    }
     return resolvePpsFollowUpKind(ppsFollowUpStatus);
   }
 
@@ -212,8 +220,14 @@ export function resolveMedicalFollowUpKind(
 export function formatMedicalFollowUpLabel(
   declaration: string | null | undefined,
   status: string | null | undefined,
-  ppsFollowUpStatus?: string | null
+  ppsFollowUpStatus?: string | null,
+  birthDate?: string | null
 ): string {
-  const kind = resolveMedicalFollowUpKind(declaration, status, ppsFollowUpStatus);
+  const kind = resolveMedicalFollowUpKind(
+    declaration,
+    status,
+    ppsFollowUpStatus,
+    birthDate
+  );
   return kind ? MEDICAL_FOLLOW_UP_LABELS[kind] : "—";
 }

--- a/src/lib/club-registration/medical-dossier.test.ts
+++ b/src/lib/club-registration/medical-dossier.test.ts
@@ -106,4 +106,23 @@ describe("medical-dossier", () => {
       })
     ).toBe(false);
   });
+
+  it("traite comme mineur un joueur déjà majeur au calendrier mais pas à la date de saison", () => {
+    expect(
+      deriveMedicalCertificateDeclaration({
+        birthDate: "2008-01-15",
+        questionnaire: { summary: "all_no", answers: {} },
+        veteranPath: createEmptyMedicalVeteranPath(),
+        hasVerifiedFfttLicense: false,
+      })
+    ).toBe("minor_all_no");
+    expect(
+      deriveMedicalCertificateDeclaration({
+        birthDate: "2008-01-15",
+        questionnaire: { summary: "pps_declared", answers: {} },
+        veteranPath: createEmptyMedicalVeteranPath(),
+        hasVerifiedFfttLicense: false,
+      })
+    ).toBe("");
+  });
 });

--- a/src/lib/club-registration/medical-dossier.ts
+++ b/src/lib/club-registration/medical-dossier.ts
@@ -1,4 +1,7 @@
-import { isAtLeast65At, isMinorAt } from "./age";
+import {
+  isAtLeast65ForClubSeason,
+  isMinorForClubSeason,
+} from "./season-age";
 import type { ClubRegistrationPayload } from "./schema";
 
 export const MEDICAL_YES_NO_VALUES = ["yes", "no"] as const;
@@ -69,13 +72,13 @@ export function deriveMedicalCertificateDeclaration(params: {
 }): MedicalCertificateDeclaration | "" {
   const { summary } = params.questionnaire;
 
-  if (isMinorAt(params.birthDate)) {
+  if (isMinorForClubSeason(params.birthDate)) {
     if (summary === "all_no") return "minor_all_no";
     if (summary === "has_yes") return "minor_yes_certificate_required";
     return "";
   }
 
-  if (isAtLeast65At(params.birthDate)) {
+  if (isAtLeast65ForClubSeason(params.birthDate)) {
     const hadLicense = effectiveHadFfttLicense(
       params.veteranPath,
       params.hasVerifiedFfttLicense
@@ -113,7 +116,7 @@ export function inferMedicalDossierFromDeclaration(
     return { questionnaire, veteranPath };
   }
 
-  const senior = isAtLeast65At(birthDate);
+  const senior = isAtLeast65ForClubSeason(birthDate);
 
   switch (declaration) {
     case "minor_all_no":
@@ -122,7 +125,9 @@ export function inferMedicalDossierFromDeclaration(
       break;
     case "minor_yes_certificate_required":
     case "questionnaire_yes_certificate_required":
-      questionnaire.summary = isMinorAt(birthDate) ? "has_yes" : "certificate_choice";
+      questionnaire.summary = isMinorForClubSeason(birthDate)
+        ? "has_yes"
+        : "certificate_choice";
       break;
     case "adult_pps_declared":
       questionnaire.summary = "pps_declared";
@@ -182,7 +187,7 @@ export function syncMedicalCertificateDeclaration<
 
 /** True si le parcours vétéran (licence / catégorie) s’applique à cette date de naissance. */
 export function isSeniorMedicalVeteranPath(birthDate: string): boolean {
-  return isAtLeast65At(birthDate);
+  return isAtLeast65ForClubSeason(birthDate);
 }
 
 /** True si l’adhérent doit choisir PPS ou certificat (adulte sans obligation certificat vétéran). */
@@ -192,8 +197,8 @@ export function needsAdultPpsOrCertificateChoice(params: {
   veteranPath: MedicalVeteranPath;
   hasVerifiedFfttLicense: boolean;
 }): boolean {
-  if (isMinorAt(params.birthDate)) return false;
-  if (!isAtLeast65At(params.birthDate)) return true;
+  if (isMinorForClubSeason(params.birthDate)) return false;
+  if (!isAtLeast65ForClubSeason(params.birthDate)) return true;
 
   const hadLicense = effectiveHadFfttLicense(
     params.veteranPath,

--- a/src/lib/club-registration/patch-manager-registration.ts
+++ b/src/lib/club-registration/patch-manager-registration.ts
@@ -177,7 +177,12 @@ export async function patchManagerRegistration(
     if (nextDeclaration !== previousDeclaration) {
       const nextPpsStatus = normalizePpsFollowUpStatus(
         currentData.ppsFollowUpStatus,
-        nextDeclaration
+        nextDeclaration,
+        typeof updates.birthDate === "string"
+          ? updates.birthDate
+          : typeof currentData.birthDate === "string"
+            ? currentData.birthDate
+            : undefined
       );
       updates.ppsFollowUpStatus = nextPpsStatus;
       if (nextPpsStatus !== currentData.ppsFollowUpStatus) {

--- a/src/lib/club-registration/persist-registration-on-submit.ts
+++ b/src/lib/club-registration/persist-registration-on-submit.ts
@@ -94,7 +94,8 @@ export function buildRegistrationSubmitDocument(params: {
     isMinor,
     medicalCertificateStatus,
     ppsFollowUpStatus: initialPpsFollowUpStatus(
-      payload.medicalCertificateDeclaration
+      payload.medicalCertificateDeclaration,
+      payload.birthDate
     ),
     ppsFollowUpEvents: [],
     licenseValidationStatus: "to_do",

--- a/src/lib/club-registration/pps-follow-up.test.ts
+++ b/src/lib/club-registration/pps-follow-up.test.ts
@@ -19,6 +19,24 @@ describe("pps-follow-up", () => {
     expect(initialPpsFollowUpStatus("minor_all_no")).toBe("not_applicable");
   });
 
+  it("n’applique pas le suivi PPS aux mineurs de saison", () => {
+    expect(
+      isPpsFollowUpApplicable("adult_pps_declared", "2008-01-15", "2025-2026")
+    ).toBe(false);
+    expect(
+      isPpsFollowUpApplicable("under_40_all_no", "2012-06-01", "2025-2026")
+    ).toBe(false);
+    expect(
+      isPpsFollowUpApplicable("under_40_all_no", "2000-04-12", "2025-2026")
+    ).toBe(true);
+    expect(
+      initialPpsFollowUpStatus("under_40_all_no", "2012-06-01", "2025-2026")
+    ).toBe("not_applicable");
+    expect(
+      normalizePpsFollowUpStatus("expected", "under_40_all_no", "2012-06-01")
+    ).toBe("not_applicable");
+  });
+
   it("normalise le statut selon la déclaration", () => {
     expect(normalizePpsFollowUpStatus("ok", "adult_pps_declared")).toBe("ok");
     expect(

--- a/src/lib/club-registration/pps-follow-up.ts
+++ b/src/lib/club-registration/pps-follow-up.ts
@@ -1,3 +1,5 @@
+import { isMinorForClubSeason } from "@/lib/club-registration/season-age";
+
 /**
  * Suivi local historisé du PPS (Parcours Prévention Santé FFTT).
  * L’app n’a pas accès à l’espace licencié : saisie manuelle secrétariat / adjoint.
@@ -73,22 +75,33 @@ export function isPpsFollowUpEventType(
 }
 
 export function isPpsFollowUpApplicable(
-  declaration: string | null | undefined
+  declaration: string | null | undefined,
+  birthDate?: string | null,
+  seasonLabel?: string
 ): boolean {
+  if (birthDate && isMinorForClubSeason(birthDate, seasonLabel)) {
+    return false;
+  }
   return Boolean(declaration && PPS_FOLLOW_UP_DECLARATIONS.has(declaration));
 }
 
 export function initialPpsFollowUpStatus(
-  declaration: string | null | undefined
+  declaration: string | null | undefined,
+  birthDate?: string | null,
+  seasonLabel?: string
 ): PpsFollowUpStatus {
-  return isPpsFollowUpApplicable(declaration) ? "expected" : "not_applicable";
+  return isPpsFollowUpApplicable(declaration, birthDate, seasonLabel)
+    ? "expected"
+    : "not_applicable";
 }
 
 export function normalizePpsFollowUpStatus(
   status: unknown,
-  declaration: string | null | undefined
+  declaration: string | null | undefined,
+  birthDate?: string | null,
+  seasonLabel?: string
 ): PpsFollowUpStatus {
-  if (!isPpsFollowUpApplicable(declaration)) {
+  if (!isPpsFollowUpApplicable(declaration, birthDate, seasonLabel)) {
     return "not_applicable";
   }
   if (isPpsFollowUpStatus(status) && status !== "not_applicable") {
@@ -207,7 +220,15 @@ export function readPpsFollowUpState(
   data: Record<string, unknown>,
   declaration: string | null | undefined
 ): PpsFollowUpState {
-  const status = normalizePpsFollowUpStatus(data.ppsFollowUpStatus, declaration);
+  const birthDate =
+    typeof data.birthDate === "string" && data.birthDate.length > 0
+      ? data.birthDate
+      : undefined;
+  const status = normalizePpsFollowUpStatus(
+    data.ppsFollowUpStatus,
+    declaration,
+    birthDate
+  );
   const updatedAt = readEventAt(data.ppsFollowUpUpdatedAt);
   const updatedBy =
     typeof data.ppsFollowUpUpdatedBy === "string" &&

--- a/src/lib/club-registration/season-age.test.ts
+++ b/src/lib/club-registration/season-age.test.ts
@@ -1,0 +1,53 @@
+import {
+  getClubSeasonAgeReferenceDate,
+  isAdultPpsEligibleForClubSeason,
+  isAtLeast65ForClubSeason,
+  isMinorForClubSeason,
+  parseSeasonAgeReferenceDate,
+} from "./season-age";
+
+describe("parseSeasonAgeReferenceDate", () => {
+  it("prend le 1er septembre de la première année", () => {
+    const at = parseSeasonAgeReferenceDate("2025-2026");
+    expect(at).not.toBeNull();
+    expect(at?.getFullYear()).toBe(2025);
+    expect(at?.getMonth()).toBe(8);
+    expect(at?.getDate()).toBe(1);
+  });
+
+  it("accepte le séparateur slash et une année de fin courte", () => {
+    const at = parseSeasonAgeReferenceDate("2026/27");
+    expect(at?.getFullYear()).toBe(2026);
+    expect(at?.getMonth()).toBe(8);
+  });
+
+  it("rejette un libellé invalide", () => {
+    expect(parseSeasonAgeReferenceDate("saison 26")).toBeNull();
+    expect(parseSeasonAgeReferenceDate("")).toBeNull();
+  });
+});
+
+describe("âge de saison club", () => {
+  const season = "2025-2026";
+
+  it("classe mineur un joueur majeur au calendrier mais pas au 1er septembre", () => {
+    expect(isMinorForClubSeason("2008-01-15", season)).toBe(true);
+    expect(isAdultPpsEligibleForClubSeason("2008-01-15", season)).toBe(false);
+  });
+
+  it("classe adulte PPS un joueur déjà majeur au 1er septembre", () => {
+    expect(isMinorForClubSeason("2007-08-01", season)).toBe(false);
+    expect(isAdultPpsEligibleForClubSeason("2007-08-01", season)).toBe(true);
+  });
+
+  it("applique le seuil vétéran 65 ans à la date de saison", () => {
+    expect(isAtLeast65ForClubSeason("1960-09-01", season)).toBe(true);
+    expect(isAtLeast65ForClubSeason("1960-09-02", season)).toBe(false);
+  });
+
+  it("utilise la saison par défaut de la config si le libellé est omis", () => {
+    const at = getClubSeasonAgeReferenceDate();
+    expect(at.getMonth()).toBe(8);
+    expect(at.getDate()).toBe(1);
+  });
+});

--- a/src/lib/club-registration/season-age.ts
+++ b/src/lib/club-registration/season-age.ts
@@ -1,0 +1,61 @@
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import { isAdultAt, isAtLeast65At, isMinorAt } from "@/lib/club-registration/age";
+
+/**
+ * Date de référence des tranches d’âge club / FFTT : 1er septembre
+ * de la première année de `meta.seasonLabel` (ex. 2025-2026 → 2025-09-01).
+ * Aligné sur `pricingDate` des tests tarifaires.
+ */
+export const CLUB_SEASON_AGE_MONTH = 9;
+export const CLUB_SEASON_AGE_DAY = 1;
+
+const SEASON_LABEL_RE = /^(\d{4})\s*[-/]\s*(\d{2,4})$/;
+
+function localNoon(year: number, month: number, day: number): Date {
+  return new Date(year, month - 1, day, 12, 0, 0);
+}
+
+/** Parse « 2025-2026 » / « 2025/26 » → 1er septembre de l’année de début. */
+export function parseSeasonAgeReferenceDate(seasonLabel: string): Date | null {
+  const match = SEASON_LABEL_RE.exec(seasonLabel.trim());
+  if (!match) {
+    return null;
+  }
+  const startYear = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(startYear) || startYear < 2000 || startYear > 2100) {
+    return null;
+  }
+  return localNoon(startYear, CLUB_SEASON_AGE_MONTH, CLUB_SEASON_AGE_DAY);
+}
+
+export function getClubSeasonAgeReferenceDate(seasonLabel?: string): Date {
+  const label = seasonLabel?.trim()
+    ? seasonLabel
+    : getDefaultRegistrationConfig().meta.seasonLabel;
+  return (
+    parseSeasonAgeReferenceDate(label) ??
+    localNoon(2025, CLUB_SEASON_AGE_MONTH, CLUB_SEASON_AGE_DAY)
+  );
+}
+
+export function isMinorForClubSeason(
+  birthDate: string,
+  seasonLabel?: string
+): boolean {
+  return isMinorAt(birthDate, getClubSeasonAgeReferenceDate(seasonLabel));
+}
+
+export function isAtLeast65ForClubSeason(
+  birthDate: string,
+  seasonLabel?: string
+): boolean {
+  return isAtLeast65At(birthDate, getClubSeasonAgeReferenceDate(seasonLabel));
+}
+
+export function isAdultPpsEligibleForClubSeason(
+  birthDate: string,
+  seasonLabel?: string
+): boolean {
+  const at = getClubSeasonAgeReferenceDate(seasonLabel);
+  return isAdultAt(birthDate, at) && !isAtLeast65At(birthDate, at);
+}

--- a/src/lib/license-validation/known-fftt-license.test.ts
+++ b/src/lib/license-validation/known-fftt-license.test.ts
@@ -1,0 +1,44 @@
+import {
+  readKnownFfttLicenseFromRegistrationData,
+  resolveKnownFfttLicenseNumber,
+} from "@/lib/license-validation/known-fftt-license";
+
+describe("resolveKnownFfttLicenseNumber", () => {
+  it("prefers the stored license over the lookup", () => {
+    expect(resolveKnownFfttLicenseNumber("1111111", "2222222")).toBe("1111111");
+  });
+
+  it("falls back to the lookup when the stored field is empty", () => {
+    expect(resolveKnownFfttLicenseNumber(null, "1234567")).toBe("1234567");
+    expect(resolveKnownFfttLicenseNumber("", "1234567")).toBe("1234567");
+    expect(resolveKnownFfttLicenseNumber("   ", "1234567")).toBe("1234567");
+  });
+
+  it("accepts numeric values stored by Firestore", () => {
+    expect(resolveKnownFfttLicenseNumber(7654321, undefined)).toBe("7654321");
+    expect(resolveKnownFfttLicenseNumber(null, 1234567)).toBe("1234567");
+  });
+});
+
+describe("readKnownFfttLicenseFromRegistrationData", () => {
+  it("reads the lookup licence when ffttLicense is missing", () => {
+    expect(
+      readKnownFfttLicenseFromRegistrationData({
+        ffttLicenseLookup: { licence: "9876543", nomClub: "SQY Ping" },
+      })
+    ).toBe("9876543");
+  });
+
+  it("keeps an explicitly cleared license empty even if a lookup exists", () => {
+    expect(
+      readKnownFfttLicenseFromRegistrationData({
+        ffttLicense: "",
+        ffttLicenseLookup: { licence: "9876543" },
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when no license is known", () => {
+    expect(readKnownFfttLicenseFromRegistrationData({})).toBeNull();
+  });
+});

--- a/src/lib/license-validation/known-fftt-license.ts
+++ b/src/lib/license-validation/known-fftt-license.ts
@@ -1,0 +1,40 @@
+function licenseDigits(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value)).replace(/\D/g, "");
+  }
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.replace(/\D/g, "");
+}
+
+/** Numéro déjà connu : champ saisi, sinon licence du lookup FFTT. */
+export function resolveKnownFfttLicenseNumber(
+  ffttLicense: unknown,
+  lookupLicence: unknown
+): string {
+  const stored = licenseDigits(ffttLicense);
+  if (stored.length > 0) {
+    return stored;
+  }
+  return licenseDigits(lookupLicence);
+}
+
+/**
+ * Champ présent (même vide) = saisie secrétariat, on ne reprend pas le lookup.
+ * Champ absent = jamais saisi, on peut préremplir depuis le lookup FFTT.
+ */
+export function readKnownFfttLicenseFromRegistrationData(
+  data: Record<string, unknown>
+): string | null {
+  if (Object.prototype.hasOwnProperty.call(data, "ffttLicense")) {
+    const stored = licenseDigits(data.ffttLicense);
+    return stored.length > 0 ? stored : null;
+  }
+  const lookup =
+    data.ffttLicenseLookup && typeof data.ffttLicenseLookup === "object"
+      ? (data.ffttLicenseLookup as Record<string, unknown>).licence
+      : undefined;
+  const fromLookup = licenseDigits(lookup);
+  return fromLookup.length > 0 ? fromLookup : null;
+}

--- a/src/lib/license-validation/license-validation-status.ts
+++ b/src/lib/license-validation/license-validation-status.ts
@@ -20,6 +20,13 @@ export const LICENSE_VALIDATION_STATUS_LABELS: Record<
 
 export const DEFAULT_LICENSE_VALIDATION_STATUS: LicenseValidationStatus = "to_do";
 
+/** Le numéro FFTT est obligatoire pour « Traité » et « Validé sans pratique sportive ». */
+export function requiresFfttLicenseNumber(
+  status: LicenseValidationStatus
+): boolean {
+  return status === "done" || status === "validated_without_sport";
+}
+
 export function isLicenseValidationStatus(
   value: unknown
 ): value is LicenseValidationStatus {

--- a/src/lib/license-validation/map-registration.ts
+++ b/src/lib/license-validation/map-registration.ts
@@ -15,6 +15,7 @@ import {
   resolveRegistrationDisplayContactEmails,
   type RegistrationDisplayContactEmail,
 } from "@/lib/club-registration/resolve-registration-contact-email";
+import { readKnownFfttLicenseFromRegistrationData } from "@/lib/license-validation/known-fftt-license";
 import {
   normalizeLicenseValidationStatus,
   type LicenseValidationStatus,
@@ -85,7 +86,7 @@ export function mapRegistrationToLicenseValidationListItem(
     lastName: readString(data, "lastName") ?? "",
     adherentEmail: readString(data, "adherentEmail") ?? "",
     birthDate: readString(data, "birthDate"),
-    ffttLicense: readString(data, "ffttLicense"),
+    ffttLicense: readKnownFfttLicenseFromRegistrationData(data),
     licenseValidationStatus: normalizeLicenseValidationStatus(
       data.licenseValidationStatus
     ),

--- a/src/lib/license-validation/patch-license-validation.test.ts
+++ b/src/lib/license-validation/patch-license-validation.test.ts
@@ -1,14 +1,25 @@
 import {
   isLicenseValidationStatus,
   normalizeLicenseValidationStatus,
+  requiresFfttLicenseNumber,
   resolveLicenseValidationListFilter,
 } from "@/lib/license-validation/license-validation-status";
 import type { LicenseValidationPatchInput } from "@/lib/license-validation/patch-license-validation";
+import {
+  LICENSE_REQUIRED_MESSAGE,
+  resolveLicenseValidationPatchFields,
+} from "@/lib/license-validation/resolve-license-validation-patch";
 
 const EDITABLE_FIELDS: Array<keyof LicenseValidationPatchInput> = [
   "ffttLicense",
   "licenseValidationStatus",
 ];
+
+const BASE_RESOLVE = {
+  currentLicense: null as string | null,
+  currentLookupLicense: null as string | null,
+  currentStatus: "to_do" as const,
+};
 
 describe("license validation patch constraints", () => {
   it("only exposes ffttLicense and licenseValidationStatus as editable fields", () => {
@@ -26,6 +37,13 @@ describe("license validation patch constraints", () => {
     expect(isLicenseValidationStatus("other_federation")).toBe(true);
   });
 
+  it("exige le numéro de licence pour Traité et Validé sans pratique sportive", () => {
+    expect(requiresFfttLicenseNumber("done")).toBe(true);
+    expect(requiresFfttLicenseNumber("validated_without_sport")).toBe(true);
+    expect(requiresFfttLicenseNumber("to_do")).toBe(false);
+    expect(requiresFfttLicenseNumber("other_federation")).toBe(false);
+  });
+
   it("resolves list filters safely", () => {
     expect(resolveLicenseValidationListFilter("done")).toBe("done");
     expect(
@@ -33,5 +51,121 @@ describe("license validation patch constraints", () => {
     ).toBe("validated_without_sport");
     expect(resolveLicenseValidationListFilter("unknown")).toBe("all");
     expect(resolveLicenseValidationListFilter(null)).toBe("all");
+  });
+});
+
+describe("resolveLicenseValidationPatchFields", () => {
+  it("autorise un statut sans licence hors Traité et Validé sans pratique sportive", () => {
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "",
+        hasLicense: true,
+        bodyStatus: "to_do",
+        hasStatus: true,
+      })
+    ).toEqual({
+      ok: true,
+      fields: { ffttLicense: null, licenseValidationStatus: "to_do" },
+    });
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "",
+        hasLicense: true,
+        bodyStatus: "other_federation",
+        hasStatus: true,
+        currentLookupLicense: "9876543",
+      })
+    ).toEqual({
+      ok: true,
+      fields: {
+        ffttLicense: null,
+        licenseValidationStatus: "other_federation",
+      },
+    });
+  });
+
+  it("refuse Traité ou Validé sans pratique sportive sans numéro de licence", () => {
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "",
+        hasLicense: true,
+        bodyStatus: "done",
+        hasStatus: true,
+      })
+    ).toEqual({ ok: false, error: LICENSE_REQUIRED_MESSAGE });
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "",
+        hasLicense: true,
+        bodyStatus: "validated_without_sport",
+        hasStatus: true,
+      })
+    ).toEqual({ ok: false, error: LICENSE_REQUIRED_MESSAGE });
+  });
+
+  it("accepte Traité ou Validé sans pratique sportive avec un numéro valide", () => {
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "1234567",
+        hasLicense: true,
+        bodyStatus: "done",
+        hasStatus: true,
+      })
+    ).toEqual({
+      ok: true,
+      fields: { ffttLicense: "1234567", licenseValidationStatus: "done" },
+    });
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "1234567",
+        hasLicense: true,
+        bodyStatus: "validated_without_sport",
+        hasStatus: true,
+      })
+    ).toEqual({
+      ok: true,
+      fields: {
+        ffttLicense: "1234567",
+        licenseValidationStatus: "validated_without_sport",
+      },
+    });
+  });
+
+  it("reprend la licence déjà connue si le champ est vide", () => {
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "",
+        hasLicense: true,
+        bodyStatus: "done",
+        hasStatus: true,
+        currentLookupLicense: "9876543",
+      })
+    ).toEqual({
+      ok: true,
+      fields: { ffttLicense: "9876543", licenseValidationStatus: "done" },
+    });
+    expect(
+      resolveLicenseValidationPatchFields({
+        ...BASE_RESOLVE,
+        bodyLicense: "",
+        hasLicense: true,
+        bodyStatus: "validated_without_sport",
+        hasStatus: true,
+        currentLookupLicense: "9876543",
+      })
+    ).toEqual({
+      ok: true,
+      fields: {
+        ffttLicense: "9876543",
+        licenseValidationStatus: "validated_without_sport",
+      },
+    });
   });
 });

--- a/src/lib/license-validation/patch-license-validation.ts
+++ b/src/lib/license-validation/patch-license-validation.ts
@@ -7,13 +7,9 @@ import {
   formatBlockingLicenseConflictMessage,
 } from "@/lib/club-registration/find-registration-license-conflicts";
 import { COLLECTION } from "@/lib/club-registration/list-registrations";
-import {
-  isLicenseValidationStatus,
-  type LicenseValidationStatus,
-} from "@/lib/license-validation/license-validation-status";
+import { normalizeLicenseValidationStatus } from "@/lib/license-validation/license-validation-status";
 import { mapRegistrationToLicenseValidationDetail } from "@/lib/license-validation/map-registration";
-
-const FFTT_LICENSE_RE = /^[0-9]{5,12}$/;
+import { resolveLicenseValidationPatchFields } from "@/lib/license-validation/resolve-license-validation-patch";
 
 export type LicenseValidationPatchInput = {
   ffttLicense?: unknown;
@@ -24,42 +20,20 @@ export type LicenseValidationPatchResult =
   | { ok: true; data: ReturnType<typeof mapRegistrationToLicenseValidationDetail> }
   | { ok: false; status: number; error: string };
 
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 export async function patchLicenseValidation(
   db: Firestore,
   registrationId: string,
   actorUid: string,
   body: LicenseValidationPatchInput
 ): Promise<LicenseValidationPatchResult> {
-  const updates: Record<string, unknown> = {};
   const hasLicense = body.ffttLicense !== undefined;
   const hasStatus = body.licenseValidationStatus !== undefined;
-
   if (!hasLicense && !hasStatus) {
     return { ok: false, status: 400, error: "Aucun champ modifiable fourni" };
-  }
-
-  if (hasLicense) {
-    if (typeof body.ffttLicense !== "string") {
-      return { ok: false, status: 400, error: "Numéro de licence invalide" };
-    }
-    const normalized = body.ffttLicense.replace(/\D/g, "");
-    if (!FFTT_LICENSE_RE.test(normalized)) {
-      return {
-        ok: false,
-        status: 400,
-        error: "Le numéro de licence doit contenir entre 5 et 12 chiffres",
-      };
-    }
-    updates.ffttLicense = normalized;
-  }
-
-  if (hasStatus) {
-    if (!isLicenseValidationStatus(body.licenseValidationStatus)) {
-      return { ok: false, status: 400, error: "Statut de licence invalide" };
-    }
-    updates.licenseValidationStatus = body.licenseValidationStatus as LicenseValidationStatus;
-    updates.licenseValidationStatusUpdatedAt = FieldValue.serverTimestamp();
-    updates.licenseValidationStatusUpdatedBy = actorUid;
   }
 
   const docRef = db.collection(COLLECTION).doc(registrationId);
@@ -68,10 +42,41 @@ export async function patchLicenseValidation(
     return { ok: false, status: 404, error: "Dossier introuvable" };
   }
 
-  if (hasLicense) {
+  const data = snap.data() ?? {};
+  const lookup =
+    data.ffttLicenseLookup && typeof data.ffttLicenseLookup === "object"
+      ? (data.ffttLicenseLookup as Record<string, unknown>)
+      : null;
+  const resolved = resolveLicenseValidationPatchFields({
+    bodyLicense: body.ffttLicense,
+    hasLicense,
+    bodyStatus: body.licenseValidationStatus,
+    hasStatus,
+    currentLicense: readOptionalString(data.ffttLicense),
+    currentLookupLicense: lookup ? readOptionalString(lookup.licence) : null,
+    currentStatus: normalizeLicenseValidationStatus(data.licenseValidationStatus),
+  });
+  if (!resolved.ok) {
+    return { ok: false, status: 400, error: resolved.error };
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (resolved.fields.ffttLicense !== undefined) {
+    // Chaîne vide = vidage volontaire : au rechargement on ne reprend pas le lookup.
+    updates.ffttLicense = resolved.fields.ffttLicense ?? "";
+  }
+  if (resolved.fields.licenseValidationStatus !== undefined) {
+    updates.licenseValidationStatus = resolved.fields.licenseValidationStatus;
+    updates.licenseValidationStatusUpdatedAt = FieldValue.serverTimestamp();
+    updates.licenseValidationStatusUpdatedBy = actorUid;
+  }
+
+  const licenseToCheck =
+    typeof updates.ffttLicense === "string" ? updates.ffttLicense : null;
+  if (licenseToCheck) {
     const conflicts = await findRegistrationLicenseConflicts(
       db,
-      updates.ffttLicense as string,
+      licenseToCheck,
       registrationId
     );
     if (conflicts.blocking.length > 0) {

--- a/src/lib/license-validation/resolve-license-validation-patch.ts
+++ b/src/lib/license-validation/resolve-license-validation-patch.ts
@@ -1,0 +1,108 @@
+import {
+  isLicenseValidationStatus,
+  normalizeLicenseValidationStatus,
+  requiresFfttLicenseNumber,
+  type LicenseValidationStatus,
+} from "@/lib/license-validation/license-validation-status";
+
+const FFTT_LICENSE_RE = /^[0-9]{5,12}$/;
+
+export const LICENSE_REQUIRED_MESSAGE =
+  "Le numéro de licence est obligatoire pour les statuts Traité et Validé sans pratique sportive";
+
+export function isValidFfttLicenseNumber(value: string): boolean {
+  return FFTT_LICENSE_RE.test(value);
+}
+
+export function parseOptionalFfttLicenseInput(
+  value: unknown
+): { ok: true; license: string | null } | { ok: false; error: string } {
+  if (typeof value !== "string") {
+    return { ok: false, error: "Numéro de licence invalide" };
+  }
+  const normalized = value.replace(/\D/g, "");
+  if (normalized.length === 0) {
+    return { ok: true, license: null };
+  }
+  if (!isValidFfttLicenseNumber(normalized)) {
+    return {
+      ok: false,
+      error: "Le numéro de licence doit contenir entre 5 et 12 chiffres",
+    };
+  }
+  return { ok: true, license: normalized };
+}
+
+function firstValidLicense(
+  ...candidates: Array<string | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    if (candidate && isValidFfttLicenseNumber(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export type LicenseValidationPatchFields = {
+  ffttLicense?: string | null;
+  licenseValidationStatus?: LicenseValidationStatus;
+};
+
+export function resolveLicenseValidationPatchFields(params: {
+  bodyLicense: unknown;
+  hasLicense: boolean;
+  bodyStatus: unknown;
+  hasStatus: boolean;
+  currentLicense: string | null;
+  currentLookupLicense: string | null;
+  currentStatus: LicenseValidationStatus;
+}):
+  | { ok: true; fields: LicenseValidationPatchFields }
+  | { ok: false; error: string } {
+  if (!params.hasLicense && !params.hasStatus) {
+    return { ok: false, error: "Aucun champ modifiable fourni" };
+  }
+
+  const fields: LicenseValidationPatchFields = {};
+
+  if (params.hasStatus) {
+    if (!isLicenseValidationStatus(params.bodyStatus)) {
+      return { ok: false, error: "Statut de licence invalide" };
+    }
+    fields.licenseValidationStatus = params.bodyStatus;
+  }
+
+  if (params.hasLicense) {
+    const parsed = parseOptionalFfttLicenseInput(params.bodyLicense);
+    if (!parsed.ok) {
+      return parsed;
+    }
+    fields.ffttLicense = parsed.license;
+  }
+
+  const nextStatus =
+    fields.licenseValidationStatus ??
+    normalizeLicenseValidationStatus(params.currentStatus);
+  const storedLicense = firstValidLicense(
+    params.currentLicense,
+    params.currentLookupLicense
+  );
+
+  if (fields.ffttLicense === null) {
+    if (requiresFfttLicenseNumber(nextStatus)) {
+      if (!storedLicense) {
+        return { ok: false, error: LICENSE_REQUIRED_MESSAGE };
+      }
+      fields.ffttLicense = storedLicense;
+    }
+  } else if (
+    fields.ffttLicense === undefined &&
+    requiresFfttLicenseNumber(nextStatus) &&
+    !storedLicense
+  ) {
+    return { ok: false, error: LICENSE_REQUIRED_MESSAGE };
+  }
+
+  return { ok: true, fields };
+}


### PR DESCRIPTION
## Summary
- Masque le suivi PPS pour les mineurs selon l’âge de saison (1er septembre), pas l’âge civil du jour
- Le numéro de licence n’est obligatoire que pour **Traité** et **Validé sans pratique sportive**
- Préremplit le numéro déjà connu ; un vidage volontaire (ex. Autre fédération) reste vide au retour

## Test plan
- [ ] Mineur de saison : pas de bloc Suivi PPS côté secrétariat / validations licence
- [ ] Adulte : suivi PPS inchangé
- [ ] Traité ou Validé sans pratique sportive sans numéro → erreur
- [ ] Autre fédération / À faire : numéro optionnel
- [ ] Dossier avec licence lookup : champ prérempli à l’ouverture
- [ ] Vider le champ, enregistrer Autre fédération, revenir → champ vide


Made with [Cursor](https://cursor.com)