### PR TITLE
feat(club-registration): suivi de réception des aides déclarées

### DIFF
--- a/src/app/api/club/registration/[id]/request-payment/route.ts
+++ b/src/app/api/club/registration/[id]/request-payment/route.ts
@@ -24,6 +24,7 @@ import { resolveRegistrationDonationPricing } from "@/lib/club-registration/reso
 import {
   resolveRegistrationPaymentRecipientEmails,
 } from "@/lib/club-registration/resolve-registration-contact-email";
+import { getRegistrationPaymentAids, resolveZeroDueDossierStatus } from "@/lib/club-registration/payment/aid-receipt";
 import {
   persistPaymentRequestedAndNotify,
   processManualPaymentFollowUp,
@@ -89,12 +90,6 @@ export async function POST(
 
     const isResend = data.status === "payment_requested";
     const requestedAmount = body.amountCents ?? data.paymentAmountCents;
-    if (!Number.isInteger(requestedAmount) || requestedAmount <= 0) {
-      return jsonNoStore(
-        { error: "Indiquez un montant strictement positif avant de demander le paiement." },
-        { status: 400 }
-      );
-    }
 
     const paymentEmails = resolveRegistrationPaymentRecipientEmails(data);
     const paymentEmail = paymentEmails[0] ?? null;
@@ -134,13 +129,16 @@ export async function POST(
       (typeof requestedAmount === "number" ? requestedAmount : 0);
 
     if (amountToPayCents <= 0) {
+      const zeroDue = resolveZeroDueDossierStatus(
+        payment?.aids ?? getRegistrationPaymentAids(data)
+      );
       const zeroPayment = payment
         ? recalculateRegistrationPayment({ ...payment, paymentStatus: "paid" })
         : null;
       await docRef.set(
         {
           ...(zeroPayment ? paymentToFirestoreUpdate(zeroPayment) : {}),
-          status: "approved",
+          status: zeroDue.status,
           updatedAt: FieldValue.serverTimestamp(),
         },
         { merge: true }
@@ -148,9 +146,17 @@ export async function POST(
       return jsonNoStore(
         {
           success: true,
-          message: "Aucun paiement n'est dû pour ce dossier.",
+          zeroDue: true,
+          message: zeroDue.message,
         },
         { status: 200 }
+      );
+    }
+
+    if (!Number.isInteger(requestedAmount) || requestedAmount <= 0) {
+      return jsonNoStore(
+        { error: "Indiquez un montant strictement positif avant de demander le paiement." },
+        { status: 400 }
       );
     }
 

--- a/src/app/api/club/registrations/route.ts
+++ b/src/app/api/club/registrations/route.ts
@@ -13,6 +13,7 @@ import {
 import { resolveManagedListStatusFilter } from "@/lib/club-registration/registration-status";
 import { resolveManagedListMedicalCertificateFilter } from "@/lib/club-registration/medical-certificate";
 import { resolveManagedListPpsFollowUpFilter } from "@/lib/club-registration/pps-follow-up";
+import { resolveManagedListAidReceiptFilter } from "@/lib/club-registration/payment/aid-receipt";
 
 const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
 
@@ -55,6 +56,9 @@ export async function GET(req: Request) {
       const ppsFollowUpFilter = resolveManagedListPpsFollowUpFilter(
         url.searchParams.get("ppsFollowUp")
       );
+      const aidReceiptFilter = resolveManagedListAidReceiptFilter(
+        url.searchParams.get("aidReceipt")
+      );
       const rawLimit = Number.parseInt(url.searchParams.get("limit") ?? "", 10);
       const pageSize = Number.isFinite(rawLimit)
         ? Math.min(Math.max(rawLimit, 1), MANAGED_PAGE_SIZE_MAX)
@@ -66,6 +70,7 @@ export async function GET(req: Request) {
         statusFilter,
         medicalCertificateFilter,
         ppsFollowUpFilter,
+        aidReceiptFilter,
         pageSize,
         cursor,
         searchQuery,

--- a/src/components/club-registration/MembershipRequestsClient.tsx
+++ b/src/components/club-registration/MembershipRequestsClient.tsx
@@ -43,6 +43,8 @@ export function MembershipRequestsClient() {
     setMedicalCertificateFilter,
     ppsFollowUpFilter,
     setPpsFollowUpFilter,
+    aidReceiptFilter,
+    setAidReceiptFilter,
     searchInput,
     setSearchInput,
     registrations,
@@ -57,6 +59,7 @@ export function MembershipRequestsClient() {
     statusFilter: initialUrlState.statusFilter,
     medicalCertificateFilter: initialUrlState.medicalCertificateFilter,
     ppsFollowUpFilter: initialUrlState.ppsFollowUpFilter,
+    aidReceiptFilter: initialUrlState.aidReceiptFilter,
   });
   const [selectedId, setSelectedId] = useState<string | null>(initialUrlState.selectedId);
   const [mobileListVisible, setMobileListVisible] = useState(true);
@@ -64,8 +67,13 @@ export function MembershipRequestsClient() {
     useManagedQueueSummary();
 
   const activeViewId = useMemo(
-    () => resolveManagedListSavedViewFromFilters(statusFilter, medicalCertificateFilter),
-    [medicalCertificateFilter, statusFilter]
+    () =>
+      resolveManagedListSavedViewFromFilters(
+        statusFilter,
+        medicalCertificateFilter,
+        aidReceiptFilter
+      ),
+    [aidReceiptFilter, medicalCertificateFilter, statusFilter]
   );
 
   const {
@@ -98,8 +106,9 @@ export function MembershipRequestsClient() {
       const filters = getManagedListFiltersForSavedView(viewId);
       setStatusFilter(filters.statusFilter);
       setMedicalCertificateFilter(filters.medicalCertificateFilter);
+      setAidReceiptFilter(filters.aidReceiptFilter);
     },
-    [setMedicalCertificateFilter, setStatusFilter]
+    [setAidReceiptFilter, setMedicalCertificateFilter, setStatusFilter]
   );
 
   useEffect(() => {
@@ -107,9 +116,17 @@ export function MembershipRequestsClient() {
       statusFilter,
       medicalCertificateFilter,
       ppsFollowUpFilter,
+      aidReceiptFilter,
       selectedId,
     });
-  }, [medicalCertificateFilter, ppsFollowUpFilter, selectedId, statusFilter, syncToUrl]);
+  }, [
+    aidReceiptFilter,
+    medicalCertificateFilter,
+    ppsFollowUpFilter,
+    selectedId,
+    statusFilter,
+    syncToUrl,
+  ]);
 
   useEffect(() => {
     if (registrations.length === 0) {
@@ -182,6 +199,7 @@ export function MembershipRequestsClient() {
       onMedicalCertificateFilterChange={setMedicalCertificateFilter}
       ppsFollowUpFilter={ppsFollowUpFilter}
       onPpsFollowUpFilterChange={setPpsFollowUpFilter}
+      aidReceiptFilter={aidReceiptFilter}
       searchInput={searchInput}
       onSearchInputChange={setSearchInput}
       pageInfo={pageInfo}

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
@@ -61,6 +61,7 @@ export function MembershipRequestDetailFormSecondary({
     expectedPayableAfterAidsCents,
     amountDiffersFromQuote,
     fetchDetail,
+    applyPaymentAids,
     updateField,
     updateReductionTypes,
     updateMedicalDeclaration,
@@ -358,6 +359,7 @@ export function MembershipRequestDetailFormSecondary({
               await fetchDetail(registrationId);
             }
           }}
+          onAidsChange={applyPaymentAids}
         />
       ) : null}
 
@@ -374,9 +376,7 @@ export function MembershipRequestDetailFormSecondary({
         saving={saving}
         requestingPayment={requestingPayment}
         persistingQuote={persistingQuote}
-        onSave={async () => {
-          await save();
-        }}
+        onSave={() => void save()}
         onRequestPayment={requestPayment}
       />
 

--- a/src/components/club-registration/membership-requests/MembershipRequestsListPanel.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestsListPanel.tsx
@@ -34,6 +34,7 @@ import {
   type ManagedListPpsFollowUpFilter,
   type PpsFollowUpStatus,
 } from "@/lib/club-registration/pps-follow-up";
+import type { ManagedListAidReceiptFilter } from "@/lib/club-registration/payment/aid-receipt";
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
 import { PaymentSummaryCard } from "../secretariat/PaymentSummaryCard";
 import { ManagedListMedicalCertificateChips } from "./ManagedListMedicalCertificateChips";
@@ -84,6 +85,7 @@ type MembershipRequestsListPanelProps = {
   onMedicalCertificateFilterChange: (value: ManagedListMedicalCertificateFilter) => void;
   ppsFollowUpFilter: ManagedListPpsFollowUpFilter;
   onPpsFollowUpFilterChange: (value: ManagedListPpsFollowUpFilter) => void;
+  aidReceiptFilter: ManagedListAidReceiptFilter;
   searchInput: string;
   onSearchInputChange: (value: string) => void;
   pageInfo: ManagedRegistrationsPageInfo;
@@ -108,6 +110,7 @@ export function MembershipRequestsListPanel({
   onMedicalCertificateFilterChange,
   ppsFollowUpFilter,
   onPpsFollowUpFilterChange,
+  aidReceiptFilter,
   searchInput,
   onSearchInputChange,
   pageInfo,
@@ -124,9 +127,11 @@ export function MembershipRequestsListPanel({
   const searchActive = searchInput.trim().length >= 2;
   const medicalFilterActive = medicalCertificateFilter !== "all";
   const ppsFilterActive = ppsFollowUpFilter !== "all";
+  const aidFilterActive = aidReceiptFilter !== "all";
   const showResultCount =
     searchActive ||
-    ((medicalFilterActive || ppsFilterActive) && pageInfo.totalMatched != null);
+    ((medicalFilterActive || ppsFilterActive || aidFilterActive) &&
+      pageInfo.totalMatched != null);
   const hasActiveSelection = selectedId != null;
   const activeTabIndex = MANAGED_LIST_STATUS_FILTER_OPTIONS.findIndex(
     (option) => option.value === statusFilter

--- a/src/components/club-registration/membership-requests/useManagedRegistrations.ts
+++ b/src/components/club-registration/membership-requests/useManagedRegistrations.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ManagedListMedicalCertificateFilter } from "@/lib/club-registration/medical-certificate";
+import type { ManagedListAidReceiptFilter } from "@/lib/club-registration/payment/aid-receipt";
 import type { ManagedListPpsFollowUpFilter } from "@/lib/club-registration/pps-follow-up";
 import type { ManagedListUrlState } from "@/lib/club-registration/managed-list-url-state";
 import type { ManagedListStatusFilter } from "@/lib/club-registration/registration-status";
@@ -24,6 +25,7 @@ function buildManagedRegistrationsUrl(params: {
   statusFilter: ManagedListStatusFilter;
   medicalCertificateFilter: ManagedListMedicalCertificateFilter;
   ppsFollowUpFilter: ManagedListPpsFollowUpFilter;
+  aidReceiptFilter: ManagedListAidReceiptFilter;
   searchQuery: string;
   cursor?: string | null | undefined;
 }): string {
@@ -36,6 +38,9 @@ function buildManagedRegistrationsUrl(params: {
   if (params.ppsFollowUpFilter !== "all") {
     url.searchParams.set("ppsFollowUp", params.ppsFollowUpFilter);
   }
+  if (params.aidReceiptFilter !== "all") {
+    url.searchParams.set("aidReceipt", params.aidReceiptFilter);
+  }
   if (params.searchQuery.trim().length >= 2) {
     url.searchParams.set("q", params.searchQuery.trim());
   }
@@ -47,7 +52,7 @@ function buildManagedRegistrationsUrl(params: {
 
 type InitialState = Pick<
   ManagedListUrlState,
-  "statusFilter" | "medicalCertificateFilter" | "ppsFollowUpFilter"
+  "statusFilter" | "medicalCertificateFilter" | "ppsFollowUpFilter" | "aidReceiptFilter"
 >;
 
 export function useManagedRegistrations(initial?: InitialState) {
@@ -60,6 +65,9 @@ export function useManagedRegistrations(initial?: InitialState) {
     );
   const [ppsFollowUpFilter, setPpsFollowUpFilter] =
     useState<ManagedListPpsFollowUpFilter>(initial?.ppsFollowUpFilter ?? "all");
+  const [aidReceiptFilter, setAidReceiptFilter] = useState<ManagedListAidReceiptFilter>(
+    initial?.aidReceiptFilter ?? "all"
+  );
   const [searchInput, setSearchInput] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [registrations, setRegistrations] = useState<RegistrationSummary[]>([]);
@@ -89,6 +97,7 @@ export function useManagedRegistrations(initial?: InitialState) {
       status: ManagedListStatusFilter;
       medical: ManagedListMedicalCertificateFilter;
       pps: ManagedListPpsFollowUpFilter;
+      aidReceipt: ManagedListAidReceiptFilter;
       query: string;
     }) => {
       const requestId = ++requestIdRef.current;
@@ -105,6 +114,7 @@ export function useManagedRegistrations(initial?: InitialState) {
             statusFilter: options.status,
             medicalCertificateFilter: options.medical,
             ppsFollowUpFilter: options.pps,
+            aidReceiptFilter: options.aidReceipt,
             searchQuery: options.query,
             cursor: options.cursor,
           }),
@@ -156,9 +166,10 @@ export function useManagedRegistrations(initial?: InitialState) {
       status: statusFilter,
       medical: medicalCertificateFilter,
       pps: ppsFollowUpFilter,
+      aidReceipt: aidReceiptFilter,
       query: searchQuery,
     });
-  }, [fetchPage, medicalCertificateFilter, ppsFollowUpFilter, searchQuery, statusFilter]);
+  }, [aidReceiptFilter, fetchPage, medicalCertificateFilter, ppsFollowUpFilter, searchQuery, statusFilter]);
 
   useEffect(() => {
     void fetchPage({
@@ -166,9 +177,10 @@ export function useManagedRegistrations(initial?: InitialState) {
       status: statusFilter,
       medical: medicalCertificateFilter,
       pps: ppsFollowUpFilter,
+      aidReceipt: aidReceiptFilter,
       query: searchQuery,
     });
-  }, [fetchPage, medicalCertificateFilter, ppsFollowUpFilter, searchQuery, statusFilter]);
+  }, [aidReceiptFilter, fetchPage, medicalCertificateFilter, ppsFollowUpFilter, searchQuery, statusFilter]);
 
   const loadMore = useCallback(async () => {
     if (!pageInfo.hasNextPage || !pageInfo.nextCursor || loadingMore || loadingList) {
@@ -180,9 +192,11 @@ export function useManagedRegistrations(initial?: InitialState) {
       status: statusFilter,
       medical: medicalCertificateFilter,
       pps: ppsFollowUpFilter,
+      aidReceipt: aidReceiptFilter,
       query: searchQuery,
     });
   }, [
+    aidReceiptFilter,
     fetchPage,
     loadingList,
     loadingMore,
@@ -212,6 +226,8 @@ export function useManagedRegistrations(initial?: InitialState) {
     setMedicalCertificateFilter,
     ppsFollowUpFilter,
     setPpsFollowUpFilter,
+    aidReceiptFilter,
+    setAidReceiptFilter,
     searchInput,
     setSearchInput,
     searchQuery,

--- a/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
+++ b/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
 import { calculatePaymentSummary } from "@/lib/club-registration/payment/calculate-payment-summary";
 import { normalizePaymentAidList } from "@/lib/club-registration/payment/payment-draft-helpers";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
 import type { Representative } from "@/lib/club-registration/schema";
 import type { PpsFollowUpState } from "@/lib/club-registration/pps-follow-up";
 import { buildPricingContext, calculateQuote, resolveDonationPricing } from "@/lib/pricing";
@@ -362,8 +363,8 @@ export function useMembershipRequestDetail(
   const requestPayment = async () => {
     if (!registrationId || !form) return;
     const amountCents = parseAmountCents(form.amountEuros);
-    if (!amountCents || amountCents <= 0) {
-      setError("Indiquez un montant strictement positif avant de demander le paiement.");
+    if (amountCents === null || amountCents < 0) {
+      setError("Indiquez un montant avant de demander le paiement.");
       return;
     }
 
@@ -390,7 +391,13 @@ export function useMembershipRequestDetail(
       if (!res.ok || json.error) {
         throw new Error(json.error || "Impossible d'envoyer la demande de paiement.");
       }
-      if (json.manualFollowUp === true) {
+      if (json.zeroDue === true) {
+        setSuccess(
+          typeof json.message === "string"
+            ? json.message
+            : "Aucun paiement n'est dû pour ce dossier."
+        );
+      } else if (json.manualFollowUp === true) {
         setSuccess(
           typeof json.message === "string"
             ? json.message
@@ -437,6 +444,13 @@ export function useMembershipRequestDetail(
     });
   }, []);
 
+  const applyPaymentAids = useCallback((aids: PaymentAid[]) => {
+    setForm((current) => (current ? { ...current, paymentAids: aids } : current));
+    setSelected((current) =>
+      current?.payment ? { ...current, payment: { ...current.payment, aids } } : current
+    );
+  }, []);
+
   return {
     config,
     registrationId,
@@ -458,6 +472,7 @@ export function useMembershipRequestDetail(
     amountDiffersFromQuote,
     fetchDetail,
     applyPpsFollowUp,
+    applyPaymentAids,
     updateField,
     updateReductionTypes,
     patchFfttFields,

--- a/src/components/club-registration/secretariat/PaymentDeclaredAidsTable.tsx
+++ b/src/components/club-registration/secretariat/PaymentDeclaredAidsTable.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  Alert,
+  Snackbar,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import {
+  isCollectableAid,
+  markAidReceived,
+  markAidUnreceived,
+} from "@/lib/club-registration/payment/aid-receipt";
+import type { PaymentAid } from "@/lib/club-registration/payment/types";
+import { formatCentsAsEuros } from "@/lib/pricing";
+import { SecretariatAidReceiptCheckbox } from "./SecretariatAidReceiptCheckbox";
+
+type Props = {
+  registrationId: string;
+  aids: PaymentAid[];
+  onAidsChange: (aids: PaymentAid[]) => void;
+};
+
+type AidReceiptFeedback = {
+  severity: "success" | "error";
+  message: string;
+};
+
+async function patchPaymentAids(registrationId: string, paymentAids: PaymentAid[]) {
+  const res = await fetch(
+    `/api/club/registration?id=${encodeURIComponent(registrationId)}`,
+    {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        paymentAids: paymentAids.map((aid) => ({
+          type: aid.type,
+          label: aid.label,
+          amountCents: aid.amountCents,
+          ...(aid.reference ? { reference: aid.reference } : {}),
+          ...(aid.note ? { note: aid.note } : {}),
+          ...(aid.received === true ? { received: true } : { received: false }),
+        })),
+      }),
+    }
+  );
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.error) {
+    throw new Error(json.error || "Impossible de mettre à jour la réception de l'aide.");
+  }
+}
+
+function nextAidsAfterReceiptToggle(
+  aids: PaymentAid[],
+  aid: PaymentAid,
+  received: boolean
+): PaymentAid[] {
+  return aids.map((item) => {
+    if (item.type !== aid.type) return item;
+    return received
+      ? markAidReceived(item, { uid: "pending", at: new Date().toISOString() })
+      : markAidUnreceived(item);
+  });
+}
+
+export function PaymentDeclaredAidsTable({ registrationId, aids, onAidsChange }: Props) {
+  const requestIdRef = useRef(0);
+  const aidsRef = useRef(aids);
+  aidsRef.current = aids;
+  const [feedback, setFeedback] = useState<AidReceiptFeedback | null>(null);
+
+  const toggleReceived = async (aid: PaymentAid, received: boolean) => {
+    const previousAids = aidsRef.current;
+    const nextAids = nextAidsAfterReceiptToggle(previousAids, aid, received);
+    const requestId = ++requestIdRef.current;
+    aidsRef.current = nextAids;
+    onAidsChange(nextAids);
+    try {
+      await patchPaymentAids(registrationId, nextAids);
+      if (requestId !== requestIdRef.current) return;
+      setFeedback({
+        severity: "success",
+        message: received
+          ? `${aid.label} : réception enregistrée.`
+          : `${aid.label} : réception annulée.`,
+      });
+    } catch (error) {
+      if (requestId !== requestIdRef.current) return;
+      aidsRef.current = previousAids;
+      onAidsChange(previousAids);
+      setFeedback({
+        severity: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Impossible de mettre à jour la réception de l'aide.",
+      });
+    }
+  };
+
+  return (
+    <>
+      <Typography variant="subtitle2" fontWeight={600}>
+        Aides déclarées
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Cochez « Aide reçue » ici : la case se met à jour tout de suite, sans recharger
+        le dossier. Un message confirme l&apos;enregistrement.
+      </Typography>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Aide</TableCell>
+            <TableCell align="right">Montant</TableCell>
+            <TableCell>Référence / note</TableCell>
+            <TableCell>Réception</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {aids.map((aid) => (
+            <TableRow key={aid.type}>
+              <TableCell>{aid.label}</TableCell>
+              <TableCell align="right">{formatCentsAsEuros(aid.amountCents)}</TableCell>
+              <TableCell>{[aid.reference, aid.note].filter(Boolean).join(" — ") || "—"}</TableCell>
+              <TableCell>
+                {isCollectableAid(aid) ? (
+                  <SecretariatAidReceiptCheckbox
+                    checked={aid.received === true}
+                    onChange={(nextReceived) => void toggleReceived(aid, nextReceived)}
+                  />
+                ) : (
+                  "—"
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {feedback ? (
+        <Snackbar
+          open
+          autoHideDuration={feedback.severity === "success" ? 4000 : 8000}
+          onClose={() => setFeedback(null)}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        >
+          <Alert
+            severity={feedback.severity}
+            variant="filled"
+            onClose={() => setFeedback(null)}
+          >
+            {feedback.message}
+          </Alert>
+        </Snackbar>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/club-registration/secretariat/PaymentTrackingSection.tsx
+++ b/src/components/club-registration/secretariat/PaymentTrackingSection.tsx
@@ -25,11 +25,13 @@ import type { ExpectedPayment, RegistrationPayment } from "@/lib/club-registrati
 import { formatCentsAsEuros } from "@/lib/pricing";
 import { AddManualPaymentDialog } from "./AddManualPaymentDialog";
 import { MarkExpectedPaymentReceivedDialog } from "./MarkExpectedPaymentReceivedDialog";
+import { PaymentDeclaredAidsTable } from "./PaymentDeclaredAidsTable";
 
 type Props = {
   registrationId: string;
   payment: RegistrationPayment;
   onRefresh: () => Promise<void>;
+  onAidsChange: (aids: RegistrationPayment["aids"]) => void;
 };
 
 async function postPaymentAction(
@@ -59,6 +61,7 @@ export function PaymentTrackingSection({
   registrationId,
   payment,
   onRefresh,
+  onAidsChange,
 }: Props) {
   const [manualOpen, setManualOpen] = useState(false);
   const [receiveExpected, setReceiveExpected] = useState<ExpectedPayment | null>(null);
@@ -157,33 +160,11 @@ export function PaymentTrackingSection({
       ) : null}
 
       {payment.aids.length > 0 ? (
-        <>
-          <Typography variant="subtitle2" fontWeight={600}>
-            Aides déclarées
-          </Typography>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Aide</TableCell>
-                <TableCell align="right">Montant</TableCell>
-                <TableCell>Référence / note</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {payment.aids.map((aid) => (
-                <TableRow key={aid.type}>
-                  <TableCell>{aid.label}</TableCell>
-                  <TableCell align="right">
-                    {formatCentsAsEuros(aid.amountCents)}
-                  </TableCell>
-                  <TableCell>
-                    {[aid.reference, aid.note].filter(Boolean).join(" — ") || "—"}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </>
+        <PaymentDeclaredAidsTable
+          registrationId={registrationId}
+          aids={payment.aids}
+          onAidsChange={onAidsChange}
+        />
       ) : null}
 
       {payment.expectedPayments.length > 0 ? (

--- a/src/components/club-registration/secretariat/SecretariatAidAmountFields.tsx
+++ b/src/components/club-registration/secretariat/SecretariatAidAmountFields.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Alert, Box, Button, Stack, Typography } from "@mui/material";
+import { Alert, Box, Button, Chip, Stack, Typography } from "@mui/material";
 import {
   findAidRuleById,
   getAidRuleFixedAmountCents,
@@ -14,6 +14,7 @@ import {
   normalizePaymentAidList,
   upsertPaymentAid,
 } from "@/lib/club-registration/payment/payment-draft-helpers";
+import { isCollectableAid, pickAidReceiptFields } from "@/lib/club-registration/payment/aid-receipt";
 import type { PaymentAid } from "@/lib/club-registration/payment/types";
 import { getReductionReferenceCode } from "@/lib/club-registration/reduction-reference-codes";
 import { SecretariatExceptionalDiscountFields } from "./SecretariatExceptionalDiscountFields";
@@ -34,6 +35,21 @@ const AID_AMOUNT_FIELD_SX = {
 function aidMaxAmountHelperText(ruleMaxCents: number | undefined): string | undefined {
   if (ruleMaxCents === undefined) return undefined;
   return `Montant maximum : ${formatCentsAsEuros(ruleMaxCents)}`;
+}
+
+function AidReceiptStatusChip({ aid }: { aid: PaymentAid | undefined }) {
+  if (!aid || !isCollectableAid(aid)) {
+    return null;
+  }
+  const received = aid.received === true;
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      color={received ? "success" : "warning"}
+      label={received ? "Reçue" : "En attente de réception"}
+    />
+  );
 }
 
 function FixedAidAmountRow({
@@ -102,6 +118,7 @@ export function SecretariatAidAmountFields({
           amountCents,
           ...(reference ? { reference } : {}),
           ...(existing?.note ? { note: existing.note } : {}),
+          ...(existing ? pickAidReceiptFields(existing) : {}),
         },
         { retainZero: true }
       )
@@ -118,7 +135,8 @@ export function SecretariatAidAmountFields({
             </Typography>
             <Typography variant="body2" color="text.secondary">
               Ajustez le montant déclaré pour chaque aide cochée. Ces montants sont déduits du
-              reste à payer estimé.
+              reste à payer estimé. Pour cocher qu&apos;une aide a bien été reçue, utilisez le
+              suivi du paiement plus bas (enregistrement immédiat).
             </Typography>
             <Stack spacing={2}>
               {selectedRules.map((rule) => {
@@ -128,29 +146,33 @@ export function SecretariatAidAmountFields({
 
                 if (fixedAmountCents !== undefined) {
                   return (
-                    <FixedAidAmountRow
-                      key={rule.id}
-                      ruleId={rule.id}
-                      ruleLabel={rule.label}
-                      fixedAmountCents={fixedAmountCents}
-                      dossierAmountCents={aid?.amountCents ?? 0}
-                      onApplyFixedAmount={() => updateAidAmount(rule.id, fixedAmountCents)}
-                    />
+                    <Stack key={rule.id} spacing={0.75}>
+                      <FixedAidAmountRow
+                        ruleId={rule.id}
+                        ruleLabel={rule.label}
+                        fixedAmountCents={fixedAmountCents}
+                        dossierAmountCents={aid?.amountCents ?? 0}
+                        onApplyFixedAmount={() => updateAidAmount(rule.id, fixedAmountCents)}
+                      />
+                      <AidReceiptStatusChip aid={aid} />
+                    </Stack>
                   );
                 }
 
                 const maxHelperText = aidMaxAmountHelperText(maxAmountCents);
                 return (
-                  <AidEuroAmountField
-                    key={rule.id}
-                    label={`Montant (${rule.label})`}
-                    amountCents={aid?.amountCents ?? 0}
-                    onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
-                    required
-                    sx={AID_AMOUNT_FIELD_SX}
-                    dataField={`paymentAid.${rule.id}`}
-                    {...(maxHelperText ? { helperText: maxHelperText } : {})}
-                  />
+                  <Stack key={rule.id} spacing={0.75}>
+                    <AidEuroAmountField
+                      label={`Montant (${rule.label})`}
+                      amountCents={aid?.amountCents ?? 0}
+                      onCommitCents={(cents) => updateAidAmount(rule.id, cents)}
+                      required
+                      sx={AID_AMOUNT_FIELD_SX}
+                      dataField={`paymentAid.${rule.id}`}
+                      {...(maxHelperText ? { helperText: maxHelperText } : {})}
+                    />
+                    <AidReceiptStatusChip aid={aid} />
+                  </Stack>
                 );
               })}
             </Stack>

--- a/src/components/club-registration/secretariat/SecretariatAidReceiptCheckbox.tsx
+++ b/src/components/club-registration/secretariat/SecretariatAidReceiptCheckbox.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Checkbox, FormControlLabel } from "@mui/material";
+
+type Props = {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (received: boolean) => void;
+  label?: string;
+};
+
+export function SecretariatAidReceiptCheckbox({
+  checked,
+  disabled = false,
+  onChange,
+  label = "Aide reçue",
+}: Props) {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+        />
+      }
+      label={label}
+    />
+  );
+}

--- a/src/components/club-registration/spreadsheet/RegistrationsSpreadsheetClient.tsx
+++ b/src/components/club-registration/spreadsheet/RegistrationsSpreadsheetClient.tsx
@@ -86,6 +86,7 @@ export function RegistrationsSpreadsheetClient() {
     applySavedView,
     toggleRegistrationStatusFilter,
     togglePaymentStatusFilter,
+    toggleAidReceiptFilter,
     clearAllFilters,
   } = useSpreadsheetFilterState(preferences, savePreferences, urlBootstrap);
 
@@ -153,10 +154,13 @@ export function RegistrationsSpreadsheetClient() {
     quickFilters,
   ]);
 
-  const summaryStats = useMemo(
-    () => computeSpreadsheetSummaryStats(displayedRows),
-    [displayedRows]
-  );
+  const summaryStats = useMemo(() => {
+    const corpusStats = computeSpreadsheetSummaryStats(registrations);
+    return {
+      ...corpusStats,
+      displayedCount: displayedRows.length,
+    };
+  }, [displayedRows.length, registrations]);
 
   const treatQueueHref = buildManagedTreatQueueHref();
   const treatQueueLabel =
@@ -286,6 +290,7 @@ export function RegistrationsSpreadsheetClient() {
             onSelectSavedView={(viewId) => void applySavedView(viewId)}
             onToggleRegistrationStatus={toggleRegistrationStatusFilter}
             onTogglePaymentStatus={togglePaymentStatusFilter}
+            onToggleAidReceiptStatus={toggleAidReceiptFilter}
             loading={loading}
             tableDensity={tableDensity}
             onTableDensityChange={(density) => void handleTableDensityChange(density)}

--- a/src/components/club-registration/spreadsheet/SpreadsheetQuickFilterChips.tsx
+++ b/src/components/club-registration/spreadsheet/SpreadsheetQuickFilterChips.tsx
@@ -4,8 +4,10 @@ import { Box } from "@mui/material";
 import type { PaymentStatusId } from "@/lib/club-registration/payment-constants";
 import type { RegistrationStatus } from "@/lib/club-registration/registration-status";
 import {
+  SPREADSHEET_AID_RECEIPT_CHIP_OPTIONS,
   SPREADSHEET_PAYMENT_STATUS_CHIP_OPTIONS,
   SPREADSHEET_REGISTRATION_STATUS_CHIP_OPTIONS,
+  type AidReceiptFilterStatus,
   type SpreadsheetQuickFilters,
 } from "@/lib/club-registration/spreadsheet/quick-filters";
 import { FilterChipGroup } from "./SpreadsheetFilterChipGroup";
@@ -14,18 +16,20 @@ type Props = {
   quickFilters: SpreadsheetQuickFilters;
   onToggleRegistrationStatus: (status: RegistrationStatus) => void;
   onTogglePaymentStatus: (status: PaymentStatusId) => void;
+  onToggleAidReceiptStatus: (status: AidReceiptFilterStatus) => void;
 };
 
 export function SpreadsheetQuickFilterChips({
   quickFilters,
   onToggleRegistrationStatus,
   onTogglePaymentStatus,
+  onToggleAidReceiptStatus,
 }: Props) {
   return (
     <Box
       sx={{
         display: "grid",
-        gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+        gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", lg: "1fr 1fr 1fr" },
         columnGap: { xs: 0, sm: 2.5, xl: 3 },
         rowGap: 1.25,
       }}
@@ -41,6 +45,12 @@ export function SpreadsheetQuickFilterChips({
         options={SPREADSHEET_PAYMENT_STATUS_CHIP_OPTIONS}
         activeValues={quickFilters.paymentStatuses}
         onToggle={onTogglePaymentStatus}
+      />
+      <FilterChipGroup
+        title="Aides"
+        options={SPREADSHEET_AID_RECEIPT_CHIP_OPTIONS}
+        activeValues={quickFilters.aidReceiptStatuses ?? []}
+        onToggle={onToggleAidReceiptStatus}
       />
     </Box>
   );

--- a/src/components/club-registration/spreadsheet/SpreadsheetSummaryBar.tsx
+++ b/src/components/club-registration/spreadsheet/SpreadsheetSummaryBar.tsx
@@ -4,12 +4,13 @@ import { Chip, Stack, Typography } from "@mui/material";
 import type { SpreadsheetSummaryStats } from "@/lib/club-registration/spreadsheet/quick-filters";
 import type { SpreadsheetSavedViewId } from "@/lib/club-registration/spreadsheet/quick-filters";
 
-type SummaryChipKey = "displayed" | "actionable" | "certificate" | "payment";
+type SummaryChipKey = "displayed" | "actionable" | "certificate" | "payment" | "aids";
 
 const VIEW_BY_CHIP: Partial<Record<SummaryChipKey, SpreadsheetSavedViewId>> = {
   actionable: "to_review",
   certificate: "missing_certificate",
   payment: "payment_pending",
+  aids: "pending_aid_receipt",
 };
 
 type Props = {
@@ -54,6 +55,15 @@ export function SpreadsheetSummaryBar({ stats, onApplySavedView, attached = fals
       label: `${stats.paymentPendingCount} paiement en cours`,
       color: "info",
       show: stats.paymentPendingCount > 0,
+      clickable: true,
+    },
+    {
+      key: "aids",
+      label: `${stats.pendingAidReceiptCount} aide${
+        stats.pendingAidReceiptCount > 1 ? "s" : ""
+      } en attente`,
+      color: "warning",
+      show: stats.pendingAidReceiptCount > 0,
       clickable: true,
     },
   ].filter((part) => part.show) as {

--- a/src/components/club-registration/spreadsheet/SpreadsheetToolbar.tsx
+++ b/src/components/club-registration/spreadsheet/SpreadsheetToolbar.tsx
@@ -20,7 +20,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import ViewColumnIcon from "@mui/icons-material/ViewColumn";
 import type { PaymentStatusId } from "@/lib/club-registration/payment-constants";
 import type { RegistrationStatus } from "@/lib/club-registration/registration-status";
-import type { SpreadsheetQuickFilters, SpreadsheetSavedViewId } from "@/lib/club-registration/spreadsheet/quick-filters";
+import type { SpreadsheetQuickFilters, SpreadsheetSavedViewId, AidReceiptFilterStatus } from "@/lib/club-registration/spreadsheet/quick-filters";
 import type { SpreadsheetTableDensity } from "@/lib/club-registration/spreadsheet/preferences";
 import { FilterCard } from "@/components/ui";
 import { SpreadsheetQuickFilterChips } from "./SpreadsheetQuickFilterChips";
@@ -48,6 +48,7 @@ type Props = {
   onSelectSavedView: (viewId: SpreadsheetSavedViewId) => void;
   onToggleRegistrationStatus: (status: RegistrationStatus) => void;
   onTogglePaymentStatus: (status: PaymentStatusId) => void;
+  onToggleAidReceiptStatus: (status: AidReceiptFilterStatus) => void;
   loading: boolean;
   tableDensity?: SpreadsheetTableDensity;
   onTableDensityChange?: (density: SpreadsheetTableDensity) => void;
@@ -75,6 +76,7 @@ export function SpreadsheetToolbar({
   onSelectSavedView,
   onToggleRegistrationStatus,
   onTogglePaymentStatus,
+  onToggleAidReceiptStatus,
   loading,
   tableDensity = "comfortable",
   onTableDensityChange,
@@ -201,6 +203,7 @@ export function SpreadsheetToolbar({
             quickFilters={quickFilters}
             onToggleRegistrationStatus={onToggleRegistrationStatus}
             onTogglePaymentStatus={onTogglePaymentStatus}
+            onToggleAidReceiptStatus={onToggleAidReceiptStatus}
           />
           {hasActiveFilters ? (
             <Button

--- a/src/components/club-registration/spreadsheet/useSpreadsheetFilterState.ts
+++ b/src/components/club-registration/spreadsheet/useSpreadsheetFilterState.ts
@@ -7,7 +7,9 @@ import type { RegistrationsSpreadsheetPreferences } from "@/lib/club-registratio
 import {
   EMPTY_SPREADSHEET_QUICK_FILTERS,
   getSpreadsheetSavedView,
+  normalizeSpreadsheetQuickFilters,
   resolveActiveSavedViewId,
+  type AidReceiptFilterStatus,
   type SpreadsheetQuickFilters,
   type SpreadsheetSavedViewId,
 } from "@/lib/club-registration/spreadsheet/quick-filters";
@@ -16,11 +18,7 @@ import type { SpreadsheetColumnFilters } from "@/lib/club-registration/spreadshe
 type SavePreferences = (next: RegistrationsSpreadsheetPreferences) => Promise<void>;
 
 function cloneQuickFilters(filters: SpreadsheetQuickFilters): SpreadsheetQuickFilters {
-  return {
-    registrationStatuses: [...filters.registrationStatuses],
-    paymentStatuses: [...filters.paymentStatuses],
-    medicalCertificateStatuses: [...filters.medicalCertificateStatuses],
-  };
+  return normalizeSpreadsheetQuickFilters(filters);
 }
 
 export function useSpreadsheetFilterState(
@@ -83,7 +81,9 @@ export function useSpreadsheetFilterState(
   const updateQuickFilters = useCallback(
     (updater: (current: SpreadsheetQuickFilters) => SpreadsheetQuickFilters) => {
       setQuickFilters((current) => {
-        const next = updater(current);
+        const next = normalizeSpreadsheetQuickFilters(
+          updater(normalizeSpreadsheetQuickFilters(current))
+        );
         const resolvedViewId = resolveActiveSavedViewId(next);
         setActiveViewId(resolvedViewId);
         void persistActiveView(resolvedViewId);
@@ -117,6 +117,21 @@ export function useSpreadsheetFilterState(
           paymentStatuses: selected
             ? current.paymentStatuses.filter((value) => value !== status)
             : [...current.paymentStatuses, status],
+        };
+      });
+    },
+    [updateQuickFilters]
+  );
+
+  const toggleAidReceiptFilter = useCallback(
+    (status: AidReceiptFilterStatus) => {
+      updateQuickFilters((current) => {
+        const selected = current.aidReceiptStatuses.includes(status);
+        return {
+          ...current,
+          aidReceiptStatuses: selected
+            ? current.aidReceiptStatuses.filter((value) => value !== status)
+            : [...current.aidReceiptStatuses, status],
         };
       });
     },
@@ -168,6 +183,7 @@ export function useSpreadsheetFilterState(
     applySavedView,
     toggleRegistrationStatusFilter,
     togglePaymentStatusFilter,
+    toggleAidReceiptFilter,
     clearAllFilters,
   };
 }

--- a/src/lib/club-registration/build-manager-registration-aids-patch.test.ts
+++ b/src/lib/club-registration/build-manager-registration-aids-patch.test.ts
@@ -1,4 +1,4 @@
-import { buildManagerRegistrationAidsPatch } from "./build-manager-registration-aids-patch";
+import { buildManagerRegistrationAidsPatch, resolveManagerPaymentAidsUpdate } from "./build-manager-registration-aids-patch";
 import type { RegistrationPayment } from "./payment/types";
 
 describe("buildManagerRegistrationAidsPatch", () => {
@@ -169,5 +169,209 @@ describe("buildManagerRegistrationAidsPatch", () => {
     const payment = patch.payment as RegistrationPayment;
     expect(payment.expectedPayments[0]?.id).toBe("ep_received");
     expect(payment.expectedPayments[0]?.expectedAmountCents).toBe(11_500);
+  });
+
+  it("conserve la réception d'aide et approuve un dossier 0 € encore ouvert", () => {
+    const currentPayment: RegistrationPayment = {
+      totalAmountCents: 5_000,
+      assistanceTotalAmountCents: 5_000,
+      amountToPayCents: 0,
+      aids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 5_000 }],
+      paymentMethod: "card",
+      paymentInstallments: 1,
+      expectedPayments: [],
+      receivedPayments: [],
+      paidAmountCents: 0,
+      remainingAmountCents: 0,
+      paymentStatus: "paid",
+    };
+
+    const patch = buildManagerRegistrationAidsPatch(
+      {
+        reductionTypes: ["pass_sport"],
+        reductionReferenceCodes: {},
+        status: "in_review",
+      },
+      { payment: currentPayment, status: "in_review" },
+      config as never,
+      [
+        {
+          type: "pass_sport",
+          label: "Pass Sport",
+          amountCents: 5_000,
+          received: true,
+          receivedAt: "2026-08-17T10:00:00.000Z",
+          receivedBy: "uid-sec",
+        },
+      ]
+    );
+
+    expect(patch.status).toBe("approved");
+    expect(patch.paymentAids).toEqual([
+      {
+        type: "pass_sport",
+        label: "Pass Sport",
+        amountCents: 5_000,
+        received: true,
+        receivedAt: "2026-08-17T10:00:00.000Z",
+        receivedBy: "uid-sec",
+      },
+    ]);
+    expect(patch.payment).toMatchObject({
+      aids: [
+        {
+          type: "pass_sport",
+          amountCents: 5_000,
+          received: true,
+          receivedBy: "uid-sec",
+        },
+      ],
+    });
+  });
+
+  it("ne change pas le statut d'un dossier déjà payé", () => {
+    const currentPayment: RegistrationPayment = {
+      totalAmountCents: 10_000,
+      assistanceTotalAmountCents: 5_000,
+      amountToPayCents: 5_000,
+      aids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 5_000 }],
+      paymentMethod: "card",
+      paymentInstallments: 1,
+      expectedPayments: [],
+      receivedPayments: [
+        {
+          id: "rp_1",
+          method: "card",
+          label: "Carte",
+          amountCents: 5_000,
+          receivedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+      paidAmountCents: 5_000,
+      remainingAmountCents: 0,
+      paymentStatus: "paid",
+    };
+
+    const patch = buildManagerRegistrationAidsPatch(
+      {
+        reductionTypes: ["pass_sport"],
+        reductionReferenceCodes: {},
+      },
+      { payment: currentPayment, status: "paid" },
+      config as never,
+      [
+        {
+          type: "pass_sport",
+          label: "Pass Sport",
+          amountCents: 5_000,
+          received: true,
+          receivedAt: "2026-08-17T10:00:00.000Z",
+          receivedBy: "uid-sec",
+        },
+      ]
+    );
+
+    expect(patch.status).toBeUndefined();
+  });
+});
+
+describe("resolveManagerPaymentAidsUpdate", () => {
+  const config = {
+    aidRules: [
+      { id: "pass_sport", label: "Pass Sport", effect: { type: "admin_review" as const } },
+    ],
+  } as const;
+
+  it("pose receivedBy depuis l'acteur serveur, pas depuis le client", () => {
+    const result = resolveManagerPaymentAidsUpdate(
+      { reductionTypes: ["pass_sport"] },
+      {
+        reductionTypes: ["pass_sport"],
+        paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 5_000 }],
+      },
+      [
+        {
+          type: "pass_sport",
+          label: "Pass Sport",
+          amountCents: 5_000,
+          received: true,
+        },
+      ],
+      config as never,
+      { uid: "uid-server", at: "2026-08-17T12:00:00.000Z" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.patch.paymentAids).toEqual([
+      {
+        type: "pass_sport",
+        label: "Pass Sport",
+        amountCents: 5_000,
+        received: true,
+        receivedAt: "2026-08-17T12:00:00.000Z",
+        receivedBy: "uid-server",
+      },
+    ]);
+  });
+
+  it("autorise la réception même si un montant déjà enregistré dépasse le plafond actuel", () => {
+    const configWithMax = {
+      aidRules: [
+        { id: "pass_sport", label: "Pass Sport", effect: { type: "admin_review" as const } },
+        {
+          id: "pass_plus",
+          label: "Pass Plus",
+          effect: { type: "admin_review" as const },
+          maxAmountCents: 5_000,
+        },
+      ],
+    } as const;
+
+    const result = resolveManagerPaymentAidsUpdate(
+      { reductionTypes: ["pass_sport", "pass_plus"] },
+      {
+        reductionTypes: ["pass_sport", "pass_plus"],
+        payment: {
+          totalAmountCents: 20_000,
+          assistanceTotalAmountCents: 11_000,
+          amountToPayCents: 9_000,
+          aids: [
+            { type: "pass_sport", label: "Pass Sport", amountCents: 5_000 },
+            { type: "pass_plus", label: "Pass Plus", amountCents: 6_000 },
+          ],
+          paymentMethod: "card",
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 9_000,
+          paymentStatus: "pending_validation",
+        },
+      },
+      [
+        { type: "pass_sport", label: "Pass Sport", amountCents: 5_000, received: true },
+        { type: "pass_plus", label: "Pass Plus", amountCents: 6_000, received: false },
+      ],
+      configWithMax as never,
+      { uid: "uid-server", at: "2026-08-17T12:00:00.000Z" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const patchedAids = result.patch.paymentAids as Array<{
+      type: string;
+      amountCents: number;
+      received?: boolean;
+      receivedBy?: string;
+    }>;
+    expect(patchedAids.find((aid) => aid.type === "pass_sport")).toMatchObject({
+      received: true,
+      receivedBy: "uid-server",
+    });
+    expect(patchedAids.find((aid) => aid.type === "pass_plus")).toMatchObject({
+      amountCents: 6_000,
+    });
+    expect(patchedAids.find((aid) => aid.type === "pass_plus")?.received).toBeUndefined();
   });
 });

--- a/src/lib/club-registration/build-manager-registration-aids-patch.ts
+++ b/src/lib/club-registration/build-manager-registration-aids-patch.ts
@@ -1,5 +1,11 @@
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { z } from "zod";
+import {
+  applyManagerAidReceiptMetadata,
+  getRegistrationPaymentAids,
+  isAidReceiptOnlyChange,
+  resolveApprovedStatusAfterAidReceipt,
+} from "@/lib/club-registration/payment/aid-receipt";
 import { mergePaymentAidsFromDraft } from "@/lib/club-registration/payment/build-payment-from-draft";
 import {
   normalizeRegistrationPayment,
@@ -11,7 +17,7 @@ import {
   regenerateExpectedPayments,
 } from "@/lib/club-registration/payment/payment-mutations";
 import type { PaymentAid, RegistrationPayment } from "@/lib/club-registration/payment/types";
-import { paymentAidPayloadSchema } from "@/lib/club-registration/payment-payload-schema";
+import { managerPaymentAidPayloadSchema } from "@/lib/club-registration/payment-payload-schema";
 import { validateAdminAids } from "@/lib/club-registration/validate-admin-aids";
 import { PRICING_CATALOG_VERSION, type FamilyRegistrationOrder, type PriceQuote } from "@/lib/pricing/types";
 
@@ -28,7 +34,7 @@ const EMPTY_QUOTE: PriceQuote = {
 export function parseManagerPaymentAidsInput(
   raw: unknown
 ): { ok: true; data: PaymentAid[] } | { ok: false; error: string } {
-  const parsed = z.array(paymentAidPayloadSchema).safeParse(raw);
+  const parsed = z.array(managerPaymentAidPayloadSchema).safeParse(raw);
   if (!parsed.success) {
     return { ok: false, error: "Montants d'aides invalides" };
   }
@@ -75,16 +81,22 @@ export function resolveManagerPaymentAidsUpdate(
   mergedData: Record<string, unknown>,
   currentData: Record<string, unknown>,
   rawPaymentAids: unknown,
-  config: RegistrationConfigV1
+  config: RegistrationConfigV1,
+  actor: { uid: string; at: string }
 ): { ok: true; patch: Record<string, unknown> } | { ok: false; error: string } {
   const parsedAids = parseManagerPaymentAidsInput(rawPaymentAids);
   if (!parsedAids.ok) {
     return parsedAids;
   }
 
-  const aidIssue = validateAdminAids(buildAidValidationDraft(mergedData, parsedAids.data), config);
-  if (aidIssue) {
-    return { ok: false, error: aidIssue.message };
+  const previousAids = getRegistrationPaymentAids(currentData);
+  const stampedAids = applyManagerAidReceiptMetadata(parsedAids.data, previousAids, actor);
+
+  if (!isAidReceiptOnlyChange(parsedAids.data, previousAids)) {
+    const aidIssue = validateAdminAids(buildAidValidationDraft(mergedData, stampedAids), config);
+    if (aidIssue) {
+      return { ok: false, error: aidIssue.message };
+    }
   }
 
   return {
@@ -93,7 +105,7 @@ export function resolveManagerPaymentAidsUpdate(
       mergedData,
       currentData,
       config,
-      parsedAids.data
+      stampedAids
     ),
   };
 }
@@ -143,9 +155,18 @@ export function buildManagerRegistrationAidsPatch(
   };
 
   const payment = normalizeRegistrationPayment(currentData);
-  if (payment) {
-    const nextPayment = syncPaymentAfterAidsChange(payment, mergedAids);
+  const nextPayment = payment ? syncPaymentAfterAidsChange(payment, mergedAids) : null;
+  if (nextPayment) {
     Object.assign(patch, paymentToFirestoreUpdate(nextPayment));
+  }
+
+  const approvedStatus = resolveApprovedStatusAfterAidReceipt({
+    currentStatus: currentData.status,
+    aids: mergedAids,
+    amountToPayCents: nextPayment?.amountToPayCents ?? 0,
+  });
+  if (approvedStatus) {
+    patch.status = approvedStatus;
   }
 
   return patch;

--- a/src/lib/club-registration/list-registrations.ts
+++ b/src/lib/club-registration/list-registrations.ts
@@ -12,6 +12,10 @@ import {
 } from "@/lib/club-registration/pps-follow-up";
 import { hasPaymentProofAvailable } from "@/lib/club-registration/payment-proof";
 import {
+  matchesManagedAidReceiptFilter,
+  type ManagedListAidReceiptFilter,
+} from "@/lib/club-registration/payment/aid-receipt";
+import {
   ACTIONABLE_REGISTRATION_STATUSES,
   type ManagedListStatusFilter,
 } from "@/lib/club-registration/registration-status";
@@ -38,6 +42,7 @@ export const LIST_FIELDS = [
   "paymentRequestedAt",
   "paidAt",
   "payment",
+  "paymentAids",
   "pricingQuote",
 ] as const;
 
@@ -231,6 +236,7 @@ export type ListManagedRegistrationsParams = {
   statusFilter: ManagedListStatusFilter;
   medicalCertificateFilter?: ManagedListMedicalCertificateFilter;
   ppsFollowUpFilter?: ManagedListPpsFollowUpFilter;
+  aidReceiptFilter?: ManagedListAidReceiptFilter;
   pageSize: number;
   cursor?: string | null;
   searchQuery?: string | null;
@@ -240,7 +246,13 @@ function needsClientSideFiltering(params: ListManagedRegistrationsParams): boole
   const searchQuery = params.searchQuery?.trim() ?? "";
   const medicalFilter = params.medicalCertificateFilter ?? "all";
   const ppsFilter = params.ppsFollowUpFilter ?? "all";
-  return searchQuery.length >= 2 || medicalFilter !== "all" || ppsFilter !== "all";
+  const aidReceiptFilter = params.aidReceiptFilter ?? "all";
+  return (
+    searchQuery.length >= 2 ||
+    medicalFilter !== "all" ||
+    ppsFilter !== "all" ||
+    aidReceiptFilter !== "all"
+  );
 }
 
 function filterManagedSummaries(
@@ -249,6 +261,7 @@ function filterManagedSummaries(
 ): RegistrationListSummary[] {
   const medicalFilter = params.medicalCertificateFilter ?? "all";
   const ppsFilter = params.ppsFollowUpFilter ?? "all";
+  const aidReceiptFilter = params.aidReceiptFilter ?? "all";
   return summaries.filter((summary) => {
     const declaration =
       typeof summary.medicalCertificateDeclaration === "string"
@@ -263,6 +276,7 @@ function filterManagedSummaries(
       matchesManagedStatusFilter(summary, params.statusFilter) &&
       matchesMedicalCertificateFilter(summary, medicalFilter) &&
       matchesPpsFollowUpFilter(ppsStatus, ppsFilter) &&
+      matchesManagedAidReceiptFilter(summary, aidReceiptFilter) &&
       registrationMatchesSearch(summary, params.searchQuery)
     );
   });

--- a/src/lib/club-registration/managed-list-saved-views.test.ts
+++ b/src/lib/club-registration/managed-list-saved-views.test.ts
@@ -8,10 +8,17 @@ describe("managed-list-saved-views", () => {
     expect(getManagedListFiltersForSavedView("to_review")).toEqual({
       statusFilter: "actionable",
       medicalCertificateFilter: "all",
+      aidReceiptFilter: "all",
     });
     expect(getManagedListFiltersForSavedView("missing_certificate")).toEqual({
       statusFilter: "actionable",
       medicalCertificateFilter: "required_not_received",
+      aidReceiptFilter: "all",
+    });
+    expect(getManagedListFiltersForSavedView("pending_aid_receipt")).toEqual({
+      statusFilter: "all",
+      medicalCertificateFilter: "all",
+      aidReceiptFilter: "pending",
     });
   });
 
@@ -21,6 +28,10 @@ describe("managed-list-saved-views", () => {
     ).toBe("missing_certificate");
     expect(resolveManagedListSavedViewFromFilters("payment_requested", "all")).toBe(
       "payment_pending"
+    );
+    expect(resolveManagedListSavedViewFromFilters("all", "all")).toBe("all");
+    expect(resolveManagedListSavedViewFromFilters("all", "all", "pending")).toBe(
+      "pending_aid_receipt"
     );
   });
 });

--- a/src/lib/club-registration/managed-list-saved-views.ts
+++ b/src/lib/club-registration/managed-list-saved-views.ts
@@ -1,4 +1,5 @@
 import type { ManagedListMedicalCertificateFilter } from "@/lib/club-registration/medical-certificate";
+import type { ManagedListAidReceiptFilter } from "@/lib/club-registration/payment/aid-receipt";
 import type { ManagedListStatusFilter } from "@/lib/club-registration/registration-status";
 import {
   SPREADSHEET_SAVED_VIEWS,
@@ -9,19 +10,34 @@ import {
 export type ManagedListSavedViewFilters = {
   statusFilter: ManagedListStatusFilter;
   medicalCertificateFilter: ManagedListMedicalCertificateFilter;
+  aidReceiptFilter: ManagedListAidReceiptFilter;
 };
 
 const MANAGED_LIST_SAVED_VIEW_FILTERS: Record<
   SpreadsheetSavedViewId,
   ManagedListSavedViewFilters
 > = {
-  all: { statusFilter: "all", medicalCertificateFilter: "all" },
-  to_review: { statusFilter: "actionable", medicalCertificateFilter: "all" },
+  all: { statusFilter: "all", medicalCertificateFilter: "all", aidReceiptFilter: "all" },
+  to_review: {
+    statusFilter: "actionable",
+    medicalCertificateFilter: "all",
+    aidReceiptFilter: "all",
+  },
   missing_certificate: {
     statusFilter: "actionable",
     medicalCertificateFilter: "required_not_received",
+    aidReceiptFilter: "all",
   },
-  payment_pending: { statusFilter: "payment_requested", medicalCertificateFilter: "all" },
+  payment_pending: {
+    statusFilter: "payment_requested",
+    medicalCertificateFilter: "all",
+    aidReceiptFilter: "all",
+  },
+  pending_aid_receipt: {
+    statusFilter: "all",
+    medicalCertificateFilter: "all",
+    aidReceiptFilter: "pending",
+  },
 };
 
 export function resolveManagedListSavedViewId(
@@ -41,13 +57,15 @@ export function getManagedListFiltersForSavedView(
 
 export function resolveManagedListSavedViewFromFilters(
   statusFilter: ManagedListStatusFilter,
-  medicalCertificateFilter: ManagedListMedicalCertificateFilter
+  medicalCertificateFilter: ManagedListMedicalCertificateFilter,
+  aidReceiptFilter: ManagedListAidReceiptFilter = "all"
 ): SpreadsheetSavedViewId | null {
   for (const view of SPREADSHEET_SAVED_VIEWS) {
     const filters = MANAGED_LIST_SAVED_VIEW_FILTERS[view.id];
     if (
       filters.statusFilter === statusFilter &&
-      filters.medicalCertificateFilter === medicalCertificateFilter
+      filters.medicalCertificateFilter === medicalCertificateFilter &&
+      filters.aidReceiptFilter === aidReceiptFilter
     ) {
       return view.id;
     }

--- a/src/lib/club-registration/managed-list-url-state.test.ts
+++ b/src/lib/club-registration/managed-list-url-state.test.ts
@@ -12,6 +12,7 @@ describe("managed-list-url-state", () => {
       statusFilter: "actionable",
       medicalCertificateFilter: "all",
       ppsFollowUpFilter: "all",
+      aidReceiptFilter: "all",
       selectedId: "reg-1",
     });
   });
@@ -22,6 +23,17 @@ describe("managed-list-url-state", () => {
       statusFilter: "all",
       medicalCertificateFilter: "all",
       ppsFollowUpFilter: "expected",
+      aidReceiptFilter: "all",
+      selectedId: null,
+    });
+  });
+
+  it("parses pending aid receipt saved view", () => {
+    expect(parseManagedListUrlState(new URLSearchParams("vue=pending_aid_receipt"))).toEqual({
+      statusFilter: "all",
+      medicalCertificateFilter: "all",
+      ppsFollowUpFilter: "all",
+      aidReceiptFilter: "pending",
       selectedId: null,
     });
   });
@@ -32,9 +44,22 @@ describe("managed-list-url-state", () => {
         statusFilter: "actionable",
         medicalCertificateFilter: "all",
         ppsFollowUpFilter: "all",
+        aidReceiptFilter: "all",
         selectedId: "reg-1",
       })
     ).toBe("vue=to_review&id=reg-1");
+  });
+
+  it("builds pending aid receipt view param", () => {
+    expect(
+      buildManagedListQueryString({
+        statusFilter: "all",
+        medicalCertificateFilter: "all",
+        ppsFollowUpFilter: "all",
+        aidReceiptFilter: "pending",
+        selectedId: null,
+      })
+    ).toBe("vue=pending_aid_receipt");
   });
 
   it("keeps pps filter alongside saved view", () => {
@@ -43,6 +68,7 @@ describe("managed-list-url-state", () => {
         statusFilter: "actionable",
         medicalCertificateFilter: "all",
         ppsFollowUpFilter: "ok",
+        aidReceiptFilter: "all",
         selectedId: null,
       })
     ).toBe("vue=to_review&pps=ok");
@@ -61,6 +87,7 @@ describe("managed-list-url-state", () => {
           statusFilter: "actionable",
           medicalCertificateFilter: "all",
           ppsFollowUpFilter: "all",
+          aidReceiptFilter: "all",
           selectedId: "reg-1",
         },
         parseManagedListUrlState(new URLSearchParams("status=actionable&id=reg-1"))

--- a/src/lib/club-registration/managed-list-url-state.ts
+++ b/src/lib/club-registration/managed-list-url-state.ts
@@ -8,6 +8,10 @@ import {
   type ManagedListMedicalCertificateFilter,
 } from "@/lib/club-registration/medical-certificate";
 import {
+  resolveManagedListAidReceiptFilter,
+  type ManagedListAidReceiptFilter,
+} from "@/lib/club-registration/payment/aid-receipt";
+import {
   resolveManagedListPpsFollowUpFilter,
   type ManagedListPpsFollowUpFilter,
 } from "@/lib/club-registration/pps-follow-up";
@@ -20,8 +24,17 @@ export type ManagedListUrlState = {
   statusFilter: ManagedListStatusFilter;
   medicalCertificateFilter: ManagedListMedicalCertificateFilter;
   ppsFollowUpFilter: ManagedListPpsFollowUpFilter;
+  aidReceiptFilter: ManagedListAidReceiptFilter;
   selectedId: string | null;
 };
+
+function resolveSavedViewIdFromState(input: ManagedListUrlState) {
+  return resolveManagedListSavedViewFromFilters(
+    input.statusFilter,
+    input.medicalCertificateFilter,
+    input.aidReceiptFilter
+  );
+}
 
 export function parseManagedListUrlState(
   searchParams: Pick<URLSearchParams, "get">
@@ -36,6 +49,7 @@ export function parseManagedListUrlState(
       statusFilter: filters.statusFilter,
       medicalCertificateFilter: filters.medicalCertificateFilter,
       ppsFollowUpFilter,
+      aidReceiptFilter: filters.aidReceiptFilter,
       selectedId: searchParams.get("id"),
     };
   }
@@ -49,15 +63,13 @@ export function parseManagedListUrlState(
     statusFilter,
     medicalCertificateFilter,
     ppsFollowUpFilter,
+    aidReceiptFilter: resolveManagedListAidReceiptFilter(searchParams.get("aides")),
     selectedId: searchParams.get("id"),
   };
 }
 
 export function normalizeManagedListUrlState(input: ManagedListUrlState): ManagedListUrlState {
-  const matchedViewId = resolveManagedListSavedViewFromFilters(
-    input.statusFilter,
-    input.medicalCertificateFilter
-  );
+  const matchedViewId = resolveSavedViewIdFromState(input);
 
   if (matchedViewId) {
     const filters = getManagedListFiltersForSavedView(matchedViewId);
@@ -65,6 +77,7 @@ export function normalizeManagedListUrlState(input: ManagedListUrlState): Manage
       statusFilter: filters.statusFilter,
       medicalCertificateFilter: filters.medicalCertificateFilter,
       ppsFollowUpFilter: input.ppsFollowUpFilter,
+      aidReceiptFilter: filters.aidReceiptFilter,
       selectedId: input.selectedId,
     };
   }
@@ -73,6 +86,7 @@ export function normalizeManagedListUrlState(input: ManagedListUrlState): Manage
     statusFilter: input.statusFilter,
     medicalCertificateFilter: input.medicalCertificateFilter,
     ppsFollowUpFilter: input.ppsFollowUpFilter,
+    aidReceiptFilter: input.aidReceiptFilter,
     selectedId: input.selectedId,
   };
 }
@@ -89,16 +103,14 @@ export function managedListUrlStatesEqual(
     normalizedLeft.medicalCertificateFilter ===
       normalizedRight.medicalCertificateFilter &&
     normalizedLeft.ppsFollowUpFilter === normalizedRight.ppsFollowUpFilter &&
+    normalizedLeft.aidReceiptFilter === normalizedRight.aidReceiptFilter &&
     (normalizedLeft.selectedId ?? null) === (normalizedRight.selectedId ?? null)
   );
 }
 
 export function buildManagedListQueryString(input: ManagedListUrlState): string {
   const params = new URLSearchParams();
-  const matchedViewId = resolveManagedListSavedViewFromFilters(
-    input.statusFilter,
-    input.medicalCertificateFilter
-  );
+  const matchedViewId = resolveSavedViewIdFromState(input);
 
   if (matchedViewId) {
     params.set("vue", matchedViewId);
@@ -106,6 +118,9 @@ export function buildManagedListQueryString(input: ManagedListUrlState): string 
     params.set("status", input.statusFilter);
     if (input.medicalCertificateFilter !== "all") {
       params.set("certificat", input.medicalCertificateFilter);
+    }
+    if (input.aidReceiptFilter !== "all") {
+      params.set("aides", input.aidReceiptFilter);
     }
   }
 

--- a/src/lib/club-registration/patch-manager-registration.ts
+++ b/src/lib/club-registration/patch-manager-registration.ts
@@ -148,7 +148,8 @@ export async function patchManagerRegistration(
 
   const currentData = snap.data() ?? {};
   const currentStatus = currentData.status;
-  const statusPatch = currentStatus === "submitted" ? { status: "in_review" } : {};
+  const statusPatch =
+    currentStatus === "submitted" ? { status: "in_review" as const } : {};
 
   if (
     updates.medicalCertificateDeclaration !== undefined ||
@@ -205,7 +206,8 @@ export async function patchManagerRegistration(
       mergedForPricing,
       currentData,
       updates.paymentAids,
-      config
+      config,
+      { uid: decoded.uid, at: new Date().toISOString() }
     );
     if (!aidsUpdate.ok) {
       return jsonNoStore({ error: aidsUpdate.error }, { status: 400 });
@@ -217,7 +219,7 @@ export async function patchManagerRegistration(
     {
       ...updates,
       ...pricingPatch,
-      ...statusPatch,
+      ...(updates.status !== undefined ? {} : statusPatch),
       reviewedBy: decoded.uid,
       reviewedAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),

--- a/src/lib/club-registration/payment-payload-schema.test.ts
+++ b/src/lib/club-registration/payment-payload-schema.test.ts
@@ -1,0 +1,31 @@
+import { managerPaymentAidPayloadSchema, paymentAidPayloadSchema } from "./payment-payload-schema";
+
+describe("paymentAidPayloadSchema", () => {
+  it("ignore received à la soumission famille", () => {
+    const parsed = paymentAidPayloadSchema.parse({
+      type: "pass_sport",
+      label: "Pass Sport",
+      amountCents: 5_000,
+      received: true,
+      receivedAt: "2026-08-01T00:00:00.000Z",
+      receivedBy: "uid-family",
+    });
+    expect(parsed).toEqual({
+      type: "pass_sport",
+      label: "Pass Sport",
+      amountCents: 5_000,
+    });
+  });
+
+  it("accepte received côté secrétariat sans receivedAt/receivedBy", () => {
+    const parsed = managerPaymentAidPayloadSchema.parse({
+      type: "pass_sport",
+      label: "Pass Sport",
+      amountCents: 5_000,
+      received: true,
+      receivedBy: "uid-spoof",
+    });
+    expect(parsed.received).toBe(true);
+    expect("receivedBy" in parsed).toBe(false);
+  });
+});

--- a/src/lib/club-registration/payment-payload-schema.ts
+++ b/src/lib/club-registration/payment-payload-schema.ts
@@ -16,6 +16,11 @@ export const paymentAidPayloadSchema = z.object({
   note: z.string().trim().max(PAYMENT_AID_NOTE_MAX_LENGTH).optional(),
 });
 
+/** Schéma secrétariat : accepte `received`, jamais `receivedAt` / `receivedBy` (posés côté serveur). */
+export const managerPaymentAidPayloadSchema = paymentAidPayloadSchema.extend({
+  received: z.boolean().optional(),
+});
+
 export const paymentPayloadFieldsSchema = {
   paymentMethod: z.enum(PAYMENT_METHOD_IDS),
   paymentInstallments: z

--- a/src/lib/club-registration/payment/aid-receipt.test.ts
+++ b/src/lib/club-registration/payment/aid-receipt.test.ts
@@ -1,0 +1,190 @@
+import {
+  applyManagerAidReceiptMetadata,
+  getRegistrationPaymentAids,
+  hasPendingAidReceipt,
+  isAidReceiptPending,
+  isCollectableAid,
+  isAidReceiptOnlyChange,
+  markAidReceived,
+  matchesManagedAidReceiptFilter,
+  resolveApprovedStatusAfterAidReceipt,
+  resolveManagedListAidReceiptFilter,
+  resolveZeroDueDossierStatus,
+  sanitizePaymentAidsForFamilySubmit,
+  ZERO_DUE_APPROVED_MESSAGE,
+  ZERO_DUE_PENDING_AID_MESSAGE,
+} from "./aid-receipt";
+import type { PaymentAid } from "./types";
+
+const passSport = (overrides: Partial<PaymentAid> = {}): PaymentAid => ({
+  type: "pass_sport",
+  label: "Pass Sport",
+  amountCents: 5_000,
+  ...overrides,
+});
+
+const exceptional = (overrides: Partial<PaymentAid> = {}): PaymentAid => ({
+  type: "other",
+  label: "Remise exceptionnelle",
+  amountCents: 2_000,
+  note: "Geste",
+  ...overrides,
+});
+
+describe("aid-receipt", () => {
+  it("ignore la remise exceptionnelle et les montants à 0", () => {
+    expect(isCollectableAid(passSport())).toBe(true);
+    expect(isCollectableAid(exceptional())).toBe(false);
+    expect(isCollectableAid(passSport({ amountCents: 0 }))).toBe(false);
+  });
+
+  it("traite received absent comme en attente", () => {
+    expect(isAidReceiptPending(passSport())).toBe(true);
+    expect(isAidReceiptPending(passSport({ received: false }))).toBe(true);
+    expect(isAidReceiptPending(passSport({ received: true }))).toBe(false);
+    expect(isAidReceiptPending(exceptional())).toBe(false);
+  });
+
+  it("détecte une aide collectable en attente dans une liste", () => {
+    expect(hasPendingAidReceipt([passSport(), exceptional()])).toBe(true);
+    expect(hasPendingAidReceipt([passSport({ received: true }), exceptional()])).toBe(false);
+    expect(hasPendingAidReceipt([exceptional()])).toBe(false);
+  });
+
+  it("filtre la liste secrétariat sur les aides en attente", () => {
+    expect(resolveManagedListAidReceiptFilter(null)).toBe("all");
+    expect(resolveManagedListAidReceiptFilter("pending")).toBe("pending");
+    expect(
+      matchesManagedAidReceiptFilter(
+        { paymentAids: [passSport()] },
+        "pending"
+      )
+    ).toBe(true);
+    expect(
+      matchesManagedAidReceiptFilter(
+        { paymentAids: [passSport({ received: true })] },
+        "pending"
+      )
+    ).toBe(false);
+    expect(
+      matchesManagedAidReceiptFilter({ paymentAids: [passSport()] }, "all")
+    ).toBe(true);
+  });
+
+  it("retire received* à la soumission famille", () => {
+    const sanitized = sanitizePaymentAidsForFamilySubmit([
+      passSport({ received: true, receivedAt: "2026-08-01T00:00:00.000Z", receivedBy: "uid-1" }),
+    ]);
+    expect(sanitized[0]).toEqual({
+      type: "pass_sport",
+      label: "Pass Sport",
+      amountCents: 5_000,
+    });
+  });
+
+  it("pose receivedAt/receivedBy côté serveur et les conserve si déjà reçue", () => {
+    const previous = [
+      markAidReceived(passSport(), { uid: "secretary-1", at: "2026-08-01T10:00:00.000Z" }),
+    ];
+    const stamped = applyManagerAidReceiptMetadata(
+      [passSport({ received: true })],
+      previous,
+      { uid: "secretary-2", at: "2026-08-17T10:00:00.000Z" }
+    );
+    expect(stamped[0]).toMatchObject({
+      received: true,
+      receivedBy: "secretary-1",
+      receivedAt: "2026-08-01T10:00:00.000Z",
+    });
+  });
+
+  it("efface la réception si on décoche", () => {
+    const previous = [markAidReceived(passSport(), { uid: "sec", at: "2026-08-01T00:00:00.000Z" })];
+    const stamped = applyManagerAidReceiptMetadata(
+      [passSport({ received: false })],
+      previous,
+      { uid: "sec", at: "2026-08-17T00:00:00.000Z" }
+    );
+    expect(stamped[0]?.received).toBeUndefined();
+    expect(stamped[0]?.receivedAt).toBeUndefined();
+    expect(stamped[0]?.receivedBy).toBeUndefined();
+  });
+
+  it("ne ferme pas un dossier 0 € tant qu'une aide est en attente", () => {
+    expect(resolveZeroDueDossierStatus([passSport()])).toEqual({
+      status: "in_review",
+      message: ZERO_DUE_PENDING_AID_MESSAGE,
+    });
+    expect(resolveZeroDueDossierStatus([passSport({ received: true })])).toEqual({
+      status: "approved",
+      message: ZERO_DUE_APPROVED_MESSAGE,
+    });
+  });
+
+  it("approuve à la dernière réception si reste 0 et statut encore ouvert", () => {
+    const received = [passSport({ received: true })];
+    expect(
+      resolveApprovedStatusAfterAidReceipt({
+        currentStatus: "in_review",
+        aids: received,
+        amountToPayCents: 0,
+      })
+    ).toBe("approved");
+    expect(
+      resolveApprovedStatusAfterAidReceipt({
+        currentStatus: "submitted",
+        aids: received,
+        amountToPayCents: 0,
+      })
+    ).toBe("approved");
+    expect(
+      resolveApprovedStatusAfterAidReceipt({
+        currentStatus: "paid",
+        aids: received,
+        amountToPayCents: 0,
+      })
+    ).toBeNull();
+    expect(
+      resolveApprovedStatusAfterAidReceipt({
+        currentStatus: "in_review",
+        aids: [passSport()],
+        amountToPayCents: 0,
+      })
+    ).toBeNull();
+    expect(
+      resolveApprovedStatusAfterAidReceipt({
+        currentStatus: "in_review",
+        aids: received,
+        amountToPayCents: 1_000,
+      })
+    ).toBeNull();
+  });
+
+  it("lit les aides depuis paymentAids ou payment.aids", () => {
+    expect(
+      getRegistrationPaymentAids({
+        paymentAids: [passSport()],
+      })
+    ).toEqual([passSport()]);
+    expect(
+      getRegistrationPaymentAids({
+        payment: { aids: [passSport({ received: true })] },
+      })[0]?.received
+    ).toBe(true);
+  });
+
+  it("détecte un changement limité à la réception", () => {
+    expect(
+      isAidReceiptOnlyChange(
+        [passSport({ received: true }), { type: "pass_plus", label: "Pass Plus", amountCents: 6_000 }],
+        [passSport(), { type: "pass_plus", label: "Pass Plus", amountCents: 6_000 }]
+      )
+    ).toBe(true);
+    expect(
+      isAidReceiptOnlyChange(
+        [passSport({ amountCents: 4_000, received: true })],
+        [passSport()]
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/club-registration/payment/aid-receipt.ts
+++ b/src/lib/club-registration/payment/aid-receipt.ts
@@ -1,0 +1,166 @@
+import { isExceptionalDiscountAidType } from "./exceptional-discount";
+import { normalizePaymentAidList } from "./payment-draft-helpers";
+import type { PaymentAid } from "./types";
+
+export const ZERO_DUE_APPROVED_MESSAGE = "Aucun paiement n'est dû pour ce dossier.";
+export const ZERO_DUE_PENDING_AID_MESSAGE =
+  "Aucun paiement n'est dû. Le dossier reste ouvert en attente de réception des aides.";
+
+export type AidReceiptActor = {
+  uid: string;
+  at: string;
+};
+
+export function isCollectableAid(aid: PaymentAid): boolean {
+  return aid.amountCents > 0 && !isExceptionalDiscountAidType(aid.type);
+}
+
+export function isAidReceiptPending(aid: PaymentAid): boolean {
+  return isCollectableAid(aid) && aid.received !== true;
+}
+
+export function hasPendingAidReceipt(aids: PaymentAid[]): boolean {
+  return aids.some(isAidReceiptPending);
+}
+
+export function pickAidReceiptFields(
+  aid: PaymentAid
+): Pick<PaymentAid, "received" | "receivedAt" | "receivedBy"> {
+  const fields: Pick<PaymentAid, "received" | "receivedAt" | "receivedBy"> = {};
+  if (aid.received === true) {
+    fields.received = true;
+    if (aid.receivedAt) fields.receivedAt = aid.receivedAt;
+    if (aid.receivedBy) fields.receivedBy = aid.receivedBy;
+  } else if (aid.received === false) {
+    fields.received = false;
+  }
+  return fields;
+}
+
+export function markAidReceived(aid: PaymentAid, actor: AidReceiptActor): PaymentAid {
+  return {
+    ...aid,
+    received: true,
+    receivedAt: actor.at,
+    receivedBy: actor.uid,
+  };
+}
+
+export function markAidUnreceived(aid: PaymentAid): PaymentAid {
+  const { received: _received, receivedAt: _receivedAt, receivedBy: _receivedBy, ...rest } = aid;
+  void _received;
+  void _receivedAt;
+  void _receivedBy;
+  return rest;
+}
+
+export function sanitizePaymentAidsForFamilySubmit(
+  aids: Array<{
+    type: string;
+    label: string;
+    amountCents: number;
+    reference?: string | undefined;
+    note?: string | undefined;
+    received?: boolean | undefined;
+    receivedAt?: string | undefined;
+    receivedBy?: string | undefined;
+  }>
+): PaymentAid[] {
+  return normalizePaymentAidList(aids).map(markAidUnreceived);
+}
+
+export function applyManagerAidReceiptMetadata(
+  incoming: PaymentAid[],
+  previous: PaymentAid[],
+  actor: AidReceiptActor
+): PaymentAid[] {
+  return incoming.map((aid) => {
+    if (!isCollectableAid(aid)) {
+      return markAidUnreceived(aid);
+    }
+    if (aid.received !== true) {
+      return markAidUnreceived(aid);
+    }
+    const prev = previous.find((item) => item.type === aid.type);
+    if (prev?.received === true && prev.receivedAt && prev.receivedBy) {
+      return markAidReceived(aid, { uid: prev.receivedBy, at: prev.receivedAt });
+    }
+    return markAidReceived(aid, actor);
+  });
+}
+
+function aidAmountSnapshotKey(aid: PaymentAid): string {
+  return [aid.type, String(aid.amountCents), aid.note ?? ""].join("\u0000");
+}
+
+/** True si seuls les flags de réception changent (montants / types / notes identiques). */
+export function isAidReceiptOnlyChange(incoming: PaymentAid[], previous: PaymentAid[]): boolean {
+  if (incoming.length === 0 || incoming.length !== previous.length) {
+    return false;
+  }
+  const previousKeys = previous.map(aidAmountSnapshotKey).sort();
+  const incomingKeys = incoming.map(aidAmountSnapshotKey).sort();
+  return previousKeys.every((key, index) => key === incomingKeys[index]);
+}
+
+export function resolveZeroDueDossierStatus(aids: PaymentAid[]): {
+  status: "approved" | "in_review";
+  message: string;
+} {
+  if (hasPendingAidReceipt(aids)) {
+    return { status: "in_review", message: ZERO_DUE_PENDING_AID_MESSAGE };
+  }
+  return { status: "approved", message: ZERO_DUE_APPROVED_MESSAGE };
+}
+
+export function resolveApprovedStatusAfterAidReceipt(params: {
+  currentStatus: unknown;
+  aids: PaymentAid[];
+  amountToPayCents: number;
+}): "approved" | null {
+  if (params.currentStatus !== "in_review" && params.currentStatus !== "submitted") {
+    return null;
+  }
+  if (params.amountToPayCents > 0) {
+    return null;
+  }
+  if (hasPendingAidReceipt(params.aids)) {
+    return null;
+  }
+  return "approved";
+}
+
+export function getRegistrationPaymentAids(record: Record<string, unknown>): PaymentAid[] {
+  const paymentAids = record.paymentAids;
+  if (Array.isArray(paymentAids) && paymentAids.length > 0) {
+    return normalizePaymentAidList(paymentAids);
+  }
+  const payment = record.payment;
+  if (
+    payment &&
+    typeof payment === "object" &&
+    Array.isArray((payment as { aids?: unknown }).aids) &&
+    (payment as { aids: unknown[] }).aids.length > 0
+  ) {
+    return normalizePaymentAidList((payment as { aids: PaymentAid[] }).aids);
+  }
+  return [];
+}
+
+export type ManagedListAidReceiptFilter = "all" | "pending";
+
+export function resolveManagedListAidReceiptFilter(
+  value: string | null | undefined
+): ManagedListAidReceiptFilter {
+  return value === "pending" ? "pending" : "all";
+}
+
+export function matchesManagedAidReceiptFilter(
+  record: Record<string, unknown>,
+  filter: ManagedListAidReceiptFilter
+): boolean {
+  if (filter === "all") {
+    return true;
+  }
+  return hasPendingAidReceipt(getRegistrationPaymentAids(record));
+}

--- a/src/lib/club-registration/payment/index.ts
+++ b/src/lib/club-registration/payment/index.ts
@@ -49,3 +49,16 @@ export {
   isExpectedPaymentStatusId,
   isReceivedMethodIdSafe,
 } from "./normalize-payment";
+
+export {
+  isCollectableAid,
+  isAidReceiptPending,
+  hasPendingAidReceipt,
+  markAidReceived,
+  markAidUnreceived,
+  getRegistrationPaymentAids,
+  resolveManagedListAidReceiptFilter,
+  matchesManagedAidReceiptFilter,
+  resolveZeroDueDossierStatus,
+  resolveApprovedStatusAfterAidReceipt,
+} from "./aid-receipt";

--- a/src/lib/club-registration/payment/payment-draft-helpers.test.ts
+++ b/src/lib/club-registration/payment/payment-draft-helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  normalizePaymentAidList,
   sanitizeEurosMonetaryInput,
   upsertPaymentAid,
 } from "./payment-draft-helpers";
@@ -51,5 +52,37 @@ describe("upsertPaymentAid retainZero", () => {
       { retainZero: true }
     );
     expect(next[0]?.note).toBe("Geste ");
+  });
+
+  it("conserve received* au normalize et à l'upsert de montant", () => {
+    const normalized = normalizePaymentAidList([
+      {
+        type: "pass_sport",
+        label: "Pass Sport",
+        amountCents: 5_000,
+        received: true,
+        receivedAt: "2026-08-01T00:00:00.000Z",
+        receivedBy: "uid-sec",
+      },
+    ]);
+    expect(normalized[0]).toMatchObject({
+      received: true,
+      receivedAt: "2026-08-01T00:00:00.000Z",
+      receivedBy: "uid-sec",
+    });
+
+    const updated = upsertPaymentAid(normalized, {
+      type: "pass_sport",
+      label: "Pass Sport",
+      amountCents: 7_000,
+      received: true,
+      receivedAt: "2026-08-01T00:00:00.000Z",
+      receivedBy: "uid-sec",
+    });
+    expect(updated[0]).toMatchObject({
+      amountCents: 7_000,
+      received: true,
+      receivedBy: "uid-sec",
+    });
   });
 });

--- a/src/lib/club-registration/payment/payment-draft-helpers.ts
+++ b/src/lib/club-registration/payment/payment-draft-helpers.ts
@@ -1,6 +1,27 @@
 import { EXCEPTIONAL_DISCOUNT_AID_TYPE } from "./exceptional-discount";
 import type { PaymentAid } from "./types";
 
+function assignAidReceiptFields(
+  target: PaymentAid,
+  source: {
+    received?: boolean | undefined;
+    receivedAt?: string | undefined;
+    receivedBy?: string | undefined;
+  }
+): void {
+  if (source.received === true) {
+    target.received = true;
+    if (typeof source.receivedAt === "string" && source.receivedAt.length > 0) {
+      target.receivedAt = source.receivedAt;
+    }
+    if (typeof source.receivedBy === "string" && source.receivedBy.length > 0) {
+      target.receivedBy = source.receivedBy;
+    }
+  } else if (source.received === false) {
+    target.received = false;
+  }
+}
+
 export function normalizePaymentAidList(
   aids: Array<{
     type: string;
@@ -8,6 +29,9 @@ export function normalizePaymentAidList(
     amountCents: number;
     reference?: string | undefined;
     note?: string | undefined;
+    received?: boolean | undefined;
+    receivedAt?: string | undefined;
+    receivedBy?: string | undefined;
   }>
 ): PaymentAid[] {
   return aids.map((aid) => {
@@ -18,6 +42,7 @@ export function normalizePaymentAidList(
     };
     if (aid.reference) normalized.reference = aid.reference;
     if (aid.note) normalized.note = aid.note;
+    assignAidReceiptFields(normalized, aid);
     return normalized;
   });
 }
@@ -93,6 +118,7 @@ export function upsertPaymentAid(
     if (patch.note != null && patch.note.length > 0) {
       next.note = patch.note;
     }
+    assignAidReceiptFields(next, patch);
     return [...without, next];
   }
   return without;

--- a/src/lib/club-registration/payment/types.ts
+++ b/src/lib/club-registration/payment/types.ts
@@ -12,6 +12,10 @@ export type PaymentAid = {
   amountCents: number;
   reference?: string;
   note?: string;
+  /** Aide collectable effectivement reçue par le club (Pass Sport, Labaz, etc.). */
+  received?: boolean;
+  receivedAt?: string;
+  receivedBy?: string;
 };
 
 export type ExpectedPayment = {

--- a/src/lib/club-registration/persist-registration-on-submit.ts
+++ b/src/lib/club-registration/persist-registration-on-submit.ts
@@ -6,6 +6,7 @@ import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types"
 import { calculateQuoteWithConfig } from "@/lib/club-registration-config/pricing-resolve";
 import { buildPricingContext } from "@/lib/pricing/build-context";
 import type { ClubRegistrationPayload } from "./build-payload-schema";
+import { sanitizePaymentAidsForFamilySubmit } from "./payment/aid-receipt";
 import { buildPaymentFromDraft } from "./payment/build-payment-from-draft";
 import { paymentToFirestoreUpdate } from "./payment/normalize-payment";
 
@@ -51,13 +52,7 @@ export function buildRegistrationSubmitDocument(params: {
     reductionReferenceCodes: payload.reductionReferenceCodes,
     paymentMethod: payload.paymentMethod,
     paymentInstallments: payload.paymentInstallments,
-    paymentAids: payload.paymentAids.map((aid) => ({
-      type: aid.type,
-      label: aid.label,
-      amountCents: aid.amountCents,
-      ...(aid.reference ? { reference: aid.reference } : {}),
-      ...(aid.note ? { note: aid.note } : {}),
-    })),
+    paymentAids: sanitizePaymentAidsForFamilySubmit(payload.paymentAids),
     holidayVoucherAmountCents: payload.holidayVoucherAmountCents ?? null,
     remainingPaymentMethod: payload.remainingPaymentMethod ?? "",
     paymentNote: payload.paymentNote ?? "",

--- a/src/lib/club-registration/spreadsheet/format-cell-value.test.ts
+++ b/src/lib/club-registration/spreadsheet/format-cell-value.test.ts
@@ -131,6 +131,21 @@ describe("format complex field helpers", () => {
       formatPaymentAidsForSpreadsheet([
         { type: "pass_sport", label: "Pass Sport", amountCents: 5000, reference: "REF1" },
       ])
-    ).toContain("REF1");
+    ).toContain("en attente");
+    expect(
+      formatPaymentAidsForSpreadsheet([
+        {
+          type: "pass_sport",
+          label: "Pass Sport",
+          amountCents: 5000,
+          received: true,
+        },
+      ])
+    ).toContain("reçue");
+    expect(
+      formatPaymentAidsForSpreadsheet([
+        { type: "other", label: "Remise exceptionnelle", amountCents: 1000, note: "Geste" },
+      ])
+    ).not.toContain("en attente");
   });
 });

--- a/src/lib/club-registration/spreadsheet/format-cell-value.ts
+++ b/src/lib/club-registration/spreadsheet/format-cell-value.ts
@@ -25,6 +25,7 @@ import {
   REGISTRATION_STATUS_LABELS,
   type RegistrationStatus,
 } from "@/lib/club-registration/registration-status";
+import { getRegistrationPaymentAids } from "@/lib/club-registration/payment/aid-receipt";
 import type { SpreadsheetColumnId } from "./column-ids";
 import type { RegistrationClientRecord } from "@/lib/club-registration/map-registration-doc-to-client";
 import {
@@ -318,7 +319,7 @@ export function formatSpreadsheetCellValue(
     case "paymentInstallments":
       return formatPaymentInstallmentsForSpreadsheet(value);
     case "paymentAids":
-      return formatPaymentAidsForSpreadsheet(value);
+      return formatPaymentAidsForSpreadsheet(getRegistrationPaymentAids(row));
     case "pricingQuoteStatus":
       return typeof value === "string"
         ? (PRICING_QUOTE_STATUS_LABELS[value] ?? value)

--- a/src/lib/club-registration/spreadsheet/format-complex-field-values.ts
+++ b/src/lib/club-registration/spreadsheet/format-complex-field-values.ts
@@ -1,4 +1,5 @@
 import type { PriceQuote } from "@/lib/pricing/types";
+import { isCollectableAid } from "@/lib/club-registration/payment/aid-receipt";
 import type { PaymentAid } from "@/lib/club-registration/payment/types";
 import type { StripeCheckoutLineItem } from "@/lib/pricing/stripe-checkout-lines";
 import { formatLastNameForDisplay } from "@/lib/shared/person-name-format";
@@ -174,7 +175,12 @@ export function formatPaymentAidsForSpreadsheet(value: unknown): string {
           : "";
       const note =
         typeof aid.note === "string" && aid.note.trim().length > 0 ? ` — ${aid.note.trim()}` : "";
-      return [label, amount, reference, note].filter(Boolean).join("") || label;
+      const receipt = isCollectableAid(aid)
+        ? aid.received === true
+          ? " — reçue"
+          : " — en attente"
+        : "";
+      return [label, amount, reference, note, receipt].filter(Boolean).join("") || label;
     })
     .filter(Boolean)
     .join(" ; ");

--- a/src/lib/club-registration/spreadsheet/quick-filters.test.ts
+++ b/src/lib/club-registration/spreadsheet/quick-filters.test.ts
@@ -23,6 +23,12 @@ describe("spreadsheet quick filters", () => {
       paymentStatus: "paid",
       medicalCertificateStatus: "validated",
     },
+    {
+      id: "c",
+      status: "paid",
+      paymentStatus: "paid",
+      paymentAids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 5000 }],
+    },
   ];
 
   it("filtre les dossiers à valider", () => {
@@ -31,17 +37,34 @@ describe("spreadsheet quick filters", () => {
     expect(filtered.map((row) => row.id)).toEqual(["a"]);
   });
 
-  it("calcule la synthèse sur les lignes affichées", () => {
+  it("calcule la synthèse globale y compris les aides en attente", () => {
     const stats = computeSpreadsheetSummaryStats(rows);
-    expect(stats.displayedCount).toBe(2);
+    expect(stats.displayedCount).toBe(3);
     expect(stats.actionableCount).toBe(1);
     expect(stats.missingCertificateCount).toBe(1);
     expect(stats.paymentPendingCount).toBe(1);
+    expect(stats.pendingAidReceiptCount).toBe(1);
+  });
+
+  it("filtre les aides en attente de réception y compris dossiers payés", () => {
+    const view = getSpreadsheetSavedView("pending_aid_receipt");
+    const filtered = filterSpreadsheetRowsByQuickFilters(rows, view.quickFilters);
+    expect(filtered.map((row) => row.id)).toEqual(["c"]);
+    expect(resolveActiveSavedViewId(view.quickFilters)).toBe("pending_aid_receipt");
   });
 
   it("résout la vue active depuis les filtres rapides", () => {
     const view = getSpreadsheetSavedView("missing_certificate");
     expect(resolveActiveSavedViewId(view.quickFilters)).toBe("missing_certificate");
     expect(quickFiltersMatchSavedView(view.quickFilters, "missing_certificate")).toBe(true);
+  });
+
+  it("tolère un objet de filtres sans aidReceiptStatuses", () => {
+    const legacy = {
+      registrationStatuses: [],
+      paymentStatuses: [],
+      medicalCertificateStatuses: [],
+    } as Parameters<typeof resolveActiveSavedViewId>[0];
+    expect(resolveActiveSavedViewId(legacy)).toBe("all");
   });
 });

--- a/src/lib/club-registration/spreadsheet/quick-filters.ts
+++ b/src/lib/club-registration/spreadsheet/quick-filters.ts
@@ -4,6 +4,10 @@ import {
   type MedicalCertificateStatus,
 } from "@/lib/club-registration/medical-certificate";
 import {
+  getRegistrationPaymentAids,
+  hasPendingAidReceipt,
+} from "@/lib/club-registration/payment/aid-receipt";
+import {
   ACTIONABLE_REGISTRATION_STATUSES,
   isRegistrationStatus,
   REGISTRATION_STATUS_LABELS,
@@ -16,23 +20,40 @@ import {
 } from "@/lib/club-registration/payment-constants";
 import { resolveRegistrationPaymentStatus } from "@/lib/club-registration/resolve-registration-payment-status";
 
+export type AidReceiptFilterStatus = "pending";
+
 export type SpreadsheetQuickFilters = {
   registrationStatuses: RegistrationStatus[];
   paymentStatuses: PaymentStatusId[];
   medicalCertificateStatuses: MedicalCertificateStatus[];
+  aidReceiptStatuses: AidReceiptFilterStatus[];
 };
 
 export const EMPTY_SPREADSHEET_QUICK_FILTERS: SpreadsheetQuickFilters = {
   registrationStatuses: [],
   paymentStatuses: [],
   medicalCertificateStatuses: [],
+  aidReceiptStatuses: [],
 };
+
+/** Complète les tableaux manquants (état React / vues antérieures au champ aides). */
+export function normalizeSpreadsheetQuickFilters(
+  filters: Partial<SpreadsheetQuickFilters> | null | undefined
+): SpreadsheetQuickFilters {
+  return {
+    registrationStatuses: [...(filters?.registrationStatuses ?? [])],
+    paymentStatuses: [...(filters?.paymentStatuses ?? [])],
+    medicalCertificateStatuses: [...(filters?.medicalCertificateStatuses ?? [])],
+    aidReceiptStatuses: [...(filters?.aidReceiptStatuses ?? [])],
+  };
+}
 
 export type SpreadsheetSavedViewId =
   | "all"
   | "to_review"
   | "missing_certificate"
-  | "payment_pending";
+  | "payment_pending"
+  | "pending_aid_receipt";
 
 export type SpreadsheetSavedView = {
   id: SpreadsheetSavedViewId;
@@ -57,17 +78,15 @@ export const SPREADSHEET_SAVED_VIEWS: SpreadsheetSavedView[] = [
     id: "to_review",
     label: "À valider",
     quickFilters: {
+      ...EMPTY_SPREADSHEET_QUICK_FILTERS,
       registrationStatuses: [...ACTIONABLE_REGISTRATION_STATUSES],
-      paymentStatuses: [],
-      medicalCertificateStatuses: [],
     },
   },
   {
     id: "missing_certificate",
     label: "Certificat manquant",
     quickFilters: {
-      registrationStatuses: [],
-      paymentStatuses: [],
+      ...EMPTY_SPREADSHEET_QUICK_FILTERS,
       medicalCertificateStatuses: ["required_not_received"],
     },
   },
@@ -75,9 +94,16 @@ export const SPREADSHEET_SAVED_VIEWS: SpreadsheetSavedView[] = [
     id: "payment_pending",
     label: "Paiement en attente",
     quickFilters: {
-      registrationStatuses: [],
+      ...EMPTY_SPREADSHEET_QUICK_FILTERS,
       paymentStatuses: [...PAYMENT_PENDING_STATUSES],
-      medicalCertificateStatuses: [],
+    },
+  },
+  {
+    id: "pending_aid_receipt",
+    label: "Aides en attente",
+    quickFilters: {
+      ...EMPTY_SPREADSHEET_QUICK_FILTERS,
+      aidReceiptStatuses: ["pending"],
     },
   },
 ];
@@ -122,11 +148,17 @@ export function getRowMedicalCertificateStatus(
   return summaryMedicalCertificateStatus(row);
 }
 
+export function rowHasPendingAidReceipt(row: RegistrationClientRecord): boolean {
+  return hasPendingAidReceipt(getRegistrationPaymentAids(row));
+}
+
 export function isQuickFiltersEmpty(quickFilters: SpreadsheetQuickFilters): boolean {
+  const normalized = normalizeSpreadsheetQuickFilters(quickFilters);
   return (
-    quickFilters.registrationStatuses.length === 0 &&
-    quickFilters.paymentStatuses.length === 0 &&
-    quickFilters.medicalCertificateStatuses.length === 0
+    normalized.registrationStatuses.length === 0 &&
+    normalized.paymentStatuses.length === 0 &&
+    normalized.medicalCertificateStatuses.length === 0 &&
+    normalized.aidReceiptStatuses.length === 0
   );
 }
 
@@ -135,13 +167,15 @@ export function quickFiltersMatchSavedView(
   viewId: SpreadsheetSavedViewId
 ): boolean {
   const view = getSpreadsheetSavedView(viewId);
+  const normalized = normalizeSpreadsheetQuickFilters(quickFilters);
   return (
-    arraysEqual(quickFilters.registrationStatuses, view.quickFilters.registrationStatuses) &&
-    arraysEqual(quickFilters.paymentStatuses, view.quickFilters.paymentStatuses) &&
+    arraysEqual(normalized.registrationStatuses, view.quickFilters.registrationStatuses) &&
+    arraysEqual(normalized.paymentStatuses, view.quickFilters.paymentStatuses) &&
     arraysEqual(
-      quickFilters.medicalCertificateStatuses,
+      normalized.medicalCertificateStatuses,
       view.quickFilters.medicalCertificateStatuses
-    )
+    ) &&
+    arraysEqual(normalized.aidReceiptStatuses, view.quickFilters.aidReceiptStatuses)
   );
 }
 
@@ -164,30 +198,35 @@ export function filterSpreadsheetRowsByQuickFilters(
   rows: RegistrationClientRecord[],
   quickFilters: SpreadsheetQuickFilters
 ): RegistrationClientRecord[] {
-  if (isQuickFiltersEmpty(quickFilters)) {
+  const normalized = normalizeSpreadsheetQuickFilters(quickFilters);
+  if (isQuickFiltersEmpty(normalized)) {
     return rows;
   }
 
   return rows.filter((row) => {
-    if (quickFilters.registrationStatuses.length > 0) {
+    if (normalized.registrationStatuses.length > 0) {
       const status = getRowRegistrationStatus(row);
-      if (!status || !quickFilters.registrationStatuses.includes(status)) {
+      if (!status || !normalized.registrationStatuses.includes(status)) {
         return false;
       }
     }
 
-    if (quickFilters.paymentStatuses.length > 0) {
+    if (normalized.paymentStatuses.length > 0) {
       const paymentStatus = getRowPaymentStatus(row);
-      if (!paymentStatus || !quickFilters.paymentStatuses.includes(paymentStatus)) {
+      if (!paymentStatus || !normalized.paymentStatuses.includes(paymentStatus)) {
         return false;
       }
     }
 
-    if (quickFilters.medicalCertificateStatuses.length > 0) {
+    if (normalized.medicalCertificateStatuses.length > 0) {
       const medicalStatus = getRowMedicalCertificateStatus(row);
-      if (!quickFilters.medicalCertificateStatuses.includes(medicalStatus)) {
+      if (!normalized.medicalCertificateStatuses.includes(medicalStatus)) {
         return false;
       }
+    }
+
+    if (normalized.aidReceiptStatuses.includes("pending") && !rowHasPendingAidReceipt(row)) {
+      return false;
     }
 
     return true;
@@ -199,6 +238,7 @@ export type SpreadsheetSummaryStats = {
   actionableCount: number;
   missingCertificateCount: number;
   paymentPendingCount: number;
+  pendingAidReceiptCount: number;
 };
 
 export function computeSpreadsheetSummaryStats(
@@ -207,6 +247,7 @@ export function computeSpreadsheetSummaryStats(
   let actionableCount = 0;
   let missingCertificateCount = 0;
   let paymentPendingCount = 0;
+  let pendingAidReceiptCount = 0;
 
   for (const row of rows) {
     const registrationStatus = getRowRegistrationStatus(row);
@@ -222,6 +263,10 @@ export function computeSpreadsheetSummaryStats(
     if (paymentStatus && PAYMENT_PENDING_STATUSES.includes(paymentStatus)) {
       paymentPendingCount += 1;
     }
+
+    if (rowHasPendingAidReceipt(row)) {
+      pendingAidReceiptCount += 1;
+    }
   }
 
   return {
@@ -229,6 +274,7 @@ export function computeSpreadsheetSummaryStats(
     actionableCount,
     missingCertificateCount,
     paymentPendingCount,
+    pendingAidReceiptCount,
   };
 }
 
@@ -243,6 +289,11 @@ export const SPREADSHEET_PAYMENT_STATUS_CHIP_OPTIONS = PAYMENT_PENDING_STATUSES.
   value,
   label: PAYMENT_STATUS_LABELS[value],
 }));
+
+export const SPREADSHEET_AID_RECEIPT_CHIP_OPTIONS: {
+  value: AidReceiptFilterStatus;
+  label: string;
+}[] = [{ value: "pending", label: "En attente de réception" }];
 
 function arraysEqual<T>(left: readonly T[], right: readonly T[]): boolean {
   if (left.length !== right.length) return false;

--- a/src/lib/club-registration/spreadsheet/row-processing.test.ts
+++ b/src/lib/club-registration/spreadsheet/row-processing.test.ts
@@ -3,6 +3,7 @@ import type { RegistrationClientRecord } from "@/lib/club-registration/map-regis
 import {
   applySpreadsheetFilters,
   filterSpreadsheetRowsByGlobalSearch,
+  hasActiveQuickFilters,
 } from "./row-processing";
 
 function row(partial: Partial<RegistrationClientRecord> & { id: string }): RegistrationClientRecord {
@@ -42,5 +43,24 @@ describe("spreadsheet row filters", () => {
       config: null,
     });
     expect(filtered).toEqual([rows[1]]);
+  });
+
+  it("tolère un filtre rapide sans aidReceiptStatuses (état antérieur)", () => {
+    const legacyFilters = {
+      registrationStatuses: [],
+      paymentStatuses: [],
+      medicalCertificateStatuses: [],
+    } as Parameters<typeof hasActiveQuickFilters>[0];
+
+    expect(hasActiveQuickFilters(legacyFilters)).toBe(false);
+    expect(
+      applySpreadsheetFilters(rows, {
+        globalSearchQuery: "",
+        columnFilters: {},
+        visibleColumnIds: ["firstName"],
+        config: null,
+        quickFilters: legacyFilters,
+      })
+    ).toEqual(rows);
   });
 });

--- a/src/lib/club-registration/spreadsheet/row-processing.ts
+++ b/src/lib/club-registration/spreadsheet/row-processing.ts
@@ -4,6 +4,7 @@ import type { SpreadsheetColumnId } from "@/lib/club-registration/spreadsheet/co
 import {
   EMPTY_SPREADSHEET_QUICK_FILTERS,
   filterSpreadsheetRowsByQuickFilters,
+  isQuickFiltersEmpty,
   type SpreadsheetQuickFilters,
 } from "@/lib/club-registration/spreadsheet/quick-filters";
 import {
@@ -76,11 +77,7 @@ export function filterSpreadsheetRowsByColumnFilters(
 }
 
 export function hasActiveQuickFilters(quickFilters: SpreadsheetQuickFilters): boolean {
-  return (
-    quickFilters.registrationStatuses.length > 0 ||
-    quickFilters.paymentStatuses.length > 0 ||
-    quickFilters.medicalCertificateStatuses.length > 0
-  );
+  return !isQuickFiltersEmpty(quickFilters);
 }
 
 export function applySpreadsheetFilters(

--- a/src/lib/club-registration/spreadsheet/spreadsheet-url-state.test.ts
+++ b/src/lib/club-registration/spreadsheet/spreadsheet-url-state.test.ts
@@ -29,4 +29,14 @@ describe("spreadsheet url state", () => {
       "/club/adhesions-tableau?vue=missing_certificate&q=Martin&tri=submittedAt&ordre=desc&dossier=id-1"
     );
   });
+
+  it("conserve la vue aides en attente dans l’URL du tableau", () => {
+    const params = new URLSearchParams("vue=pending_aid_receipt");
+    expect(parseSpreadsheetUrlState(params)).toEqual({
+      viewId: "pending_aid_receipt",
+    });
+    expect(
+      buildSpreadsheetPathWithParams({ viewId: "pending_aid_receipt" })
+    ).toBe("/club/adhesions-tableau?vue=pending_aid_receipt");
+  });
 });


### PR DESCRIPTION
## Summary
- Le secrétariat peut cocher « Aide reçue » immédiatement (PATCH local, toast succès/erreur, sans recharger tout le dossier).
- Un dossier à 0 € reste en revue tant qu’une aide collectable n’est pas reçue ; la dernière réception peut l’approuver.
- Vue « Aides en attente » sur la file demandes d’adhésion (`?vue=pending_aid_receipt`) et sur le tableau.

## Test plan
- [ ] Dossier avec Pass Sport / Pass Plus : cocher et décocher « Aide reçue » sans reload, message succès ; simuler une erreur réseau pour le revert.
- [ ] Dossier 0 € avec aide en attente : reste `in_review` ; cocher la dernière aide → `approved` si reste dû 0 €.
- [ ] Page demandes-adhesion : bouton « Aides en attente » filtre la liste (URL `vue=pending_aid_receipt`), les autres vues restent sur cette page.
- [ ] Tableau adhésions : même vue et pastille de synthèse filtrent les aides non reçues, y compris dossiers déjà payés.


Made with [Cursor](https://cursor.com)