### PR TITLE
fix(club-registration): valider un dossier déjà réglé sans renvoyer de lien

### DIFF
--- a/src/app/api/club/registration/[id]/request-payment/route.ts
+++ b/src/app/api/club/registration/[id]/request-payment/route.ts
@@ -6,7 +6,7 @@ import { jsonNoStore } from "@/lib/http/cache-headers";
 import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
 import { hasAnyRole, resolveRole, USER_ROLES } from "@/lib/auth/roles";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
-import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
 import {
   createStripePaymentForRegistration,
   getAppBaseUrl,
@@ -31,6 +31,12 @@ import {
   recalculatePaymentForRequest,
   validateRegistrationStripeCheckout,
 } from "@/lib/club-registration/request-payment-checkout";
+import {
+  buildPaidDossierValidationPatch,
+  isRegistrationPaymentSettled,
+  resolveSettledRequestPaymentAction,
+} from "@/lib/club-registration/resolve-settled-request-payment";
+import { dispatchPaymentConfirmedEmail } from "@/lib/email/dispatch-payment-confirmed-email";
 import { buildMesInscriptionsUrl } from "@/lib/club-registration/mes-inscriptions-url";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import type { PriceQuote } from "@/lib/pricing/types";
@@ -78,27 +84,8 @@ export async function POST(
     }
 
     const data = snap.data() ?? {};
-    if (isRegistrationPaidRecord(data)) {
-      return jsonNoStore(
-        {
-          error:
-            "Ce dossier est déjà réglé (paiement enregistré). Impossible de renvoyer un lien de paiement.",
-        },
-        { status: 409 }
-      );
-    }
-
     const isResend = data.status === "payment_requested";
     const requestedAmount = body.amountCents ?? data.paymentAmountCents;
-
-    const paymentEmails = resolveRegistrationPaymentRecipientEmails(data);
-    const paymentEmail = paymentEmails[0] ?? null;
-    if (!paymentEmail) {
-      return jsonNoStore(
-        { error: "Aucune adresse e-mail exploitable pour envoyer la demande de paiement." },
-        { status: 400 }
-      );
-    }
 
     const adherentName =
       formatPersonDisplayName(
@@ -128,6 +115,8 @@ export async function POST(
       quote?.totalCents ??
       (typeof requestedAmount === "number" ? requestedAmount : 0);
 
+    // Une remise à 0 € met paymentStatus à "paid" : traiter le zéro dû avant
+    // le garde-fou « déjà réglé », sinon la validation est bloquée.
     if (amountToPayCents <= 0) {
       const zeroDue = resolveZeroDueDossierStatus(
         payment?.aids ?? getRegistrationPaymentAids(data)
@@ -150,6 +139,72 @@ export async function POST(
           message: zeroDue.message,
         },
         { status: 200 }
+      );
+    }
+
+    if (isRegistrationPaymentSettled(data as Record<string, unknown>, payment)) {
+      const settledAction = resolveSettledRequestPaymentAction(data.status);
+      if (settledAction.kind === "reject") {
+        return jsonNoStore({ error: settledAction.error }, { status: 409 });
+      }
+      if (settledAction.kind === "already_finalized") {
+        return jsonNoStore(
+          {
+            success: true,
+            alreadySettled: true,
+            message: settledAction.message,
+          },
+          { status: 200 }
+        );
+      }
+
+      await docRef.set(
+        {
+          ...buildPaidDossierValidationPatch(payment),
+          ...(data.paidAt == null ? { paidAt: FieldValue.serverTimestamp() } : {}),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+
+      logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_UPDATED, decoded.uid, {
+        resource: "clubRegistration",
+        resourceId: id,
+        details: { action: "validate_already_paid" },
+        success: true,
+      });
+
+      const paidAmountCents = payment?.paidAmountCents ?? 0;
+      if (paidAmountCents > 0) {
+        try {
+          await dispatchPaymentConfirmedEmail({
+            registrationId: id,
+            data,
+            amountCents: paidAmountCents,
+            source: "secretariat",
+            req,
+          });
+        } catch (emailError) {
+          console.error("[api/club/registration/request-payment] confirmation email", emailError);
+        }
+      }
+
+      return jsonNoStore(
+        {
+          success: true,
+          alreadySettled: true,
+          message: settledAction.message,
+        },
+        { status: 200 }
+      );
+    }
+
+    const paymentEmails = resolveRegistrationPaymentRecipientEmails(data);
+    const paymentEmail = paymentEmails[0] ?? null;
+    if (!paymentEmail) {
+      return jsonNoStore(
+        { error: "Aucune adresse e-mail exploitable pour envoyer la demande de paiement." },
+        { status: 400 }
       );
     }
 

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFooter.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFooter.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { SecretariatPaymentNotesSection } from "../secretariat/SecretariatPaymentNotesSection";
+import { isRegistrationPaymentSettled } from "@/lib/club-registration/resolve-settled-request-payment";
+import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
+import { DeleteRegistrationSection } from "./DeleteRegistrationSection";
+import type { MembershipRequestDetailState } from "./useMembershipRequestDetail";
+import type { MembershipListReloadFn } from "./types";
+
+type Props = {
+  detail: MembershipRequestDetailState;
+  onListReload?: MembershipListReloadFn | undefined;
+  onDeleted?: (() => void | Promise<void>) | undefined;
+};
+
+export function MembershipRequestDetailFooter({
+  detail,
+  onListReload,
+  onDeleted,
+}: Props) {
+  const {
+    registrationId,
+    selected,
+    form,
+    selectedPayment,
+    saving,
+    requestingPayment,
+    persistingQuote,
+    updateField,
+    save,
+    requestPayment,
+  } = detail;
+
+  if (!selected || !form) return null;
+
+  return (
+    <>
+      <SecretariatPaymentNotesSection
+        amountEuros={form.amountEuros}
+        reviewNotes={form.reviewNotes}
+        onAmountEurosChange={(value) => updateField("amountEuros", value)}
+        onReviewNotesChange={(value) => updateField("reviewNotes", value)}
+        registrationStatus={selected.status ?? null}
+        paymentRequestedAt={selected.paymentRequestedAt ?? null}
+        paymentAmountCents={selected.paymentAmountCents ?? null}
+        paymentEmailSentTo={selected.paymentEmailSentTo ?? null}
+        paymentMethod={selectedPayment?.paymentMethod}
+        paymentSettled={isRegistrationPaymentSettled(
+          {
+            status: selected.status,
+            paymentStatus: selected.paymentStatus,
+            paidAt: selected.paidAt,
+          },
+          selectedPayment
+        )}
+        saving={saving}
+        requestingPayment={requestingPayment}
+        persistingQuote={persistingQuote}
+        onSave={() => void save()}
+        onRequestPayment={requestPayment}
+      />
+
+      {registrationId ? (
+        <DeleteRegistrationSection
+          registrationId={registrationId}
+          firstName={form.firstName}
+          lastName={form.lastName}
+          adherentDisplayName={formatPersonDisplayName(form.firstName, form.lastName)}
+          status={selected.status ?? null}
+          disabled={saving || requestingPayment || persistingQuote}
+          onDeleted={async () => {
+            await onListReload?.({ advance: "always" });
+            await onDeleted?.();
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
@@ -21,7 +21,6 @@ import { RegistrationMultiSelectField } from "../RegistrationMultiSelectField";
 import type { RegistrationDraft } from "../registration-defaults";
 import { PaymentTrackingSection } from "../secretariat/PaymentTrackingSection";
 import { SecretariatAidAmountFields } from "../secretariat/SecretariatAidAmountFields";
-import { SecretariatPaymentNotesSection } from "../secretariat/SecretariatPaymentNotesSection";
 import { RegistrationMedicalDossierDetail } from "./RegistrationSupplementarySections";
 import { DetailSectionTitle } from "./DetailSectionTitle";
 import {
@@ -31,8 +30,7 @@ import {
   MEDICAL_OPTIONS,
 } from "./membership-request-detail-shared";
 import { MembershipRequestDonationSection } from "./MembershipRequestDonationSection";
-import { DeleteRegistrationSection } from "./DeleteRegistrationSection";
-import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
+import { MembershipRequestDetailFooter } from "./MembershipRequestDetailFooter";
 import type { MembershipRequestDetailState } from "./useMembershipRequestDetail";
 import type { EditableRegistration, MembershipListReloadFn } from "./types";
 
@@ -67,8 +65,6 @@ export function MembershipRequestDetailFormSecondary({
     updateMedicalDeclaration,
     applyCalculatedAmount,
     persistQuote,
-    save,
-    requestPayment,
   } = detail;
 
   if (!selected || !form) return null;
@@ -363,37 +359,11 @@ export function MembershipRequestDetailFormSecondary({
         />
       ) : null}
 
-      <SecretariatPaymentNotesSection
-        amountEuros={form.amountEuros}
-        reviewNotes={form.reviewNotes}
-        onAmountEurosChange={(value) => updateField("amountEuros", value)}
-        onReviewNotesChange={(value) => updateField("reviewNotes", value)}
-        registrationStatus={selected.status ?? null}
-        paymentRequestedAt={selected.paymentRequestedAt ?? null}
-        paymentAmountCents={selected.paymentAmountCents ?? null}
-        paymentEmailSentTo={selected.paymentEmailSentTo ?? null}
-        paymentMethod={selectedPayment?.paymentMethod}
-        saving={saving}
-        requestingPayment={requestingPayment}
-        persistingQuote={persistingQuote}
-        onSave={() => void save()}
-        onRequestPayment={requestPayment}
+      <MembershipRequestDetailFooter
+        detail={detail}
+        onListReload={onListReload}
+        onDeleted={onDeleted}
       />
-
-      {registrationId ? (
-        <DeleteRegistrationSection
-          registrationId={registrationId}
-          firstName={form.firstName}
-          lastName={form.lastName}
-          adherentDisplayName={formatPersonDisplayName(form.firstName, form.lastName)}
-          status={selected.status ?? null}
-          disabled={saving || requestingPayment || persistingQuote}
-          onDeleted={async () => {
-            await onListReload?.({ advance: "always" });
-            await onDeleted?.();
-          }}
-        />
-      ) : null}
     </Stack>
   );
 }

--- a/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
+++ b/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
@@ -391,11 +391,13 @@ export function useMembershipRequestDetail(
       if (!res.ok || json.error) {
         throw new Error(json.error || "Impossible d'envoyer la demande de paiement.");
       }
-      if (json.zeroDue === true) {
+      if (json.zeroDue === true || json.alreadySettled === true) {
         setSuccess(
           typeof json.message === "string"
             ? json.message
-            : "Aucun paiement n'est dû pour ce dossier."
+            : json.alreadySettled === true
+              ? "Dossier validé. Le paiement était déjà enregistré."
+              : "Aucun paiement n'est dû pour ce dossier."
         );
       } else if (json.manualFollowUp === true) {
         setSuccess(

--- a/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
+++ b/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
@@ -17,13 +17,10 @@ import {
 } from "@mui/icons-material";
 import {
   BNPL_SECRETARIAT_ALERT,
-  BNPL_SECRETARIAT_PAYMENT_TOOLTIP,
   CHECKOUT_LINK_VALIDITY_NOTICE,
-  SECRETARIAT_INITIAL_PAYMENT_BUTTON,
-  SECRETARIAT_RESEND_PAYMENT_BUTTON,
-  SECRETARIAT_RESEND_PAYMENT_TOOLTIP,
   SECRETARIAT_SELF_SERVICE_HINT,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
+import { resolveSecretariatPaymentCta } from "@/lib/club-registration/payment/secretariat-payment-action";
 import {
   PAYMENT_METHOD_LABELS,
   type PaymentMethodId,
@@ -39,6 +36,7 @@ type Props = {
   paymentAmountCents?: number | null;
   paymentEmailSentTo?: string | null | undefined;
   paymentMethod?: PaymentMethodId | null | undefined;
+  paymentSettled?: boolean;
   saving: boolean;
   requestingPayment: boolean;
   persistingQuote: boolean;
@@ -79,27 +77,19 @@ export function SecretariatPaymentNotesSection({
   paymentAmountCents,
   paymentEmailSentTo,
   paymentMethod,
+  paymentSettled = false,
   saving,
   requestingPayment,
   persistingQuote,
   onSave,
   onRequestPayment,
 }: Props) {
-  const canSendStripeEmail = paymentMethod === "card";
-  const isPaid = registrationStatus === "paid";
-  const isPaymentResend = registrationStatus === "payment_requested" && !isPaid;
-  const paymentButtonLabel = isPaymentResend
-    ? canSendStripeEmail
-      ? SECRETARIAT_RESEND_PAYMENT_BUTTON
-      : "Renvoyer les instructions de règlement"
-    : SECRETARIAT_INITIAL_PAYMENT_BUTTON;
-  const paymentTooltip = isPaymentResend
-    ? canSendStripeEmail
-      ? SECRETARIAT_RESEND_PAYMENT_TOOLTIP
-      : "Renvoie l'e-mail d'instructions de règlement au contact du dossier."
-    : canSendStripeEmail
-      ? BNPL_SECRETARIAT_PAYMENT_TOOLTIP
-      : "Enregistre le dossier puis bascule en suivi adapté : pas de lien de paiement automatique pour ce mode de règlement.";
+  const paymentCta = resolveSecretariatPaymentCta({
+    registrationStatus,
+    paymentSettled,
+    paymentMethod,
+  });
+  const isPaymentResend = paymentCta.visible && paymentCta.kind === "resend";
   const requestedAtLabel = formatPaymentRequestedAt(paymentRequestedAt);
   const formattedAmount = formatAmountCents(paymentAmountCents);
 
@@ -109,7 +99,8 @@ export function SecretariatPaymentNotesSection({
         Paiement et notes internes
       </Typography>
 
-      {paymentMethod === "card" ? (
+      {paymentMethod === "card" &&
+      !(paymentCta.visible && paymentCta.kind === "validate_settled") ? (
         <Alert severity="info" variant="outlined">
           Mode <strong>carte bancaire</strong> : un lien Stripe Checkout sera envoyé par
           e-mail. {BNPL_SECRETARIAT_ALERT} {CHECKOUT_LINK_VALIDITY_NOTICE}{" "}
@@ -154,7 +145,12 @@ export function SecretariatPaymentNotesSection({
         </Grid>
       </Grid>
 
-      {isPaymentResend && canSendStripeEmail ? (
+      {paymentCta.visible && paymentCta.kind === "validate_settled" ? (
+        <Alert severity="success" variant="outlined">
+          Le règlement est déjà enregistré. Vous pouvez valider le dossier sans renvoyer de
+          lien de paiement.
+        </Alert>
+      ) : isPaymentResend && paymentMethod === "card" ? (
         <Alert severity="warning" variant="outlined">
           Paiement en attente
           {requestedAtLabel ? ` depuis le ${requestedAtLabel}` : ""}
@@ -189,9 +185,9 @@ export function SecretariatPaymentNotesSection({
             </Button>
           </span>
         </Tooltip>
-        {isPaid ? null : (
+        {paymentCta.visible ? (
           <Tooltip
-            title={paymentTooltip}
+            title={paymentCta.tooltip}
             slotProps={{ popper: { sx: { maxWidth: 340 } } }}
             {...tooltipEnterProps}
           >
@@ -203,11 +199,15 @@ export function SecretariatPaymentNotesSection({
                 onClick={() => void onRequestPayment()}
                 disabled={saving || requestingPayment || persistingQuote}
               >
-                {requestingPayment ? "Envoi..." : paymentButtonLabel}
+                {requestingPayment
+                  ? paymentCta.kind === "validate_settled"
+                    ? "Validation..."
+                    : "Envoi..."
+                  : paymentCta.label}
               </Button>
             </span>
           </Tooltip>
-        )}
+        ) : null}
       </Stack>
     </>
   );

--- a/src/lib/club-registration/payment/bnpl-checkout-copy.ts
+++ b/src/lib/club-registration/payment/bnpl-checkout-copy.ts
@@ -88,6 +88,13 @@ export const ADHERENT_PAYMENT_PENDING_ALERT =
 /** Bouton secrétariat — premier envoi. */
 export const SECRETARIAT_INITIAL_PAYMENT_BUTTON = "Valider et demander le paiement";
 
+/** Bouton secrétariat — validation après paiement déjà enregistré. */
+export const SECRETARIAT_VALIDATE_SETTLED_BUTTON = "Valider le dossier";
+
+/** Tooltip secrétariat — validation après paiement déjà enregistré. */
+export const SECRETARIAT_VALIDATE_SETTLED_TOOLTIP =
+  "Valide le dossier sans envoyer de lien de paiement, car le règlement est déjà enregistré.";
+
 /** Bouton secrétariat — renvoi lien. */
 export const SECRETARIAT_RESEND_PAYMENT_BUTTON = "Renvoyer le lien de paiement";
 

--- a/src/lib/club-registration/payment/secretariat-payment-action.test.ts
+++ b/src/lib/club-registration/payment/secretariat-payment-action.test.ts
@@ -1,0 +1,66 @@
+import {
+  SECRETARIAT_INITIAL_PAYMENT_BUTTON,
+  SECRETARIAT_RESEND_PAYMENT_BUTTON,
+  SECRETARIAT_VALIDATE_SETTLED_BUTTON,
+  SECRETARIAT_VALIDATE_SETTLED_TOOLTIP,
+} from "./bnpl-checkout-copy";
+import { resolveSecretariatPaymentCta } from "./secretariat-payment-action";
+
+describe("resolveSecretariatPaymentCta", () => {
+  it("propose de valider sans lien si le paiement est déjà enregistré", () => {
+    expect(
+      resolveSecretariatPaymentCta({
+        registrationStatus: "in_review",
+        paymentSettled: true,
+        paymentMethod: "card",
+      })
+    ).toEqual({
+      visible: true,
+      label: SECRETARIAT_VALIDATE_SETTLED_BUTTON,
+      tooltip: SECRETARIAT_VALIDATE_SETTLED_TOOLTIP,
+      kind: "validate_settled",
+    });
+  });
+
+  it("masque l'action une fois le dossier clos", () => {
+    expect(
+      resolveSecretariatPaymentCta({
+        registrationStatus: "paid",
+        paymentSettled: true,
+        paymentMethod: "card",
+      })
+    ).toEqual({ visible: false });
+    expect(
+      resolveSecretariatPaymentCta({
+        registrationStatus: "approved",
+        paymentSettled: true,
+        paymentMethod: "cheque",
+      })
+    ).toEqual({ visible: false });
+  });
+
+  it("conserve la demande de paiement et le renvoi de lien", () => {
+    expect(
+      resolveSecretariatPaymentCta({
+        registrationStatus: "submitted",
+        paymentSettled: false,
+        paymentMethod: "card",
+      })
+    ).toMatchObject({
+      visible: true,
+      label: SECRETARIAT_INITIAL_PAYMENT_BUTTON,
+      kind: "request",
+    });
+    expect(
+      resolveSecretariatPaymentCta({
+        registrationStatus: "payment_requested",
+        paymentSettled: false,
+        paymentMethod: "card",
+      })
+    ).toMatchObject({
+      visible: true,
+      label: SECRETARIAT_RESEND_PAYMENT_BUTTON,
+      kind: "resend",
+    });
+  });
+});

--- a/src/lib/club-registration/payment/secretariat-payment-action.ts
+++ b/src/lib/club-registration/payment/secretariat-payment-action.ts
@@ -1,0 +1,62 @@
+import type { PaymentMethodId } from "@/lib/club-registration/payment-constants";
+import {
+  BNPL_SECRETARIAT_PAYMENT_TOOLTIP,
+  SECRETARIAT_INITIAL_PAYMENT_BUTTON,
+  SECRETARIAT_RESEND_PAYMENT_BUTTON,
+  SECRETARIAT_RESEND_PAYMENT_TOOLTIP,
+  SECRETARIAT_VALIDATE_SETTLED_BUTTON,
+  SECRETARIAT_VALIDATE_SETTLED_TOOLTIP,
+} from "./bnpl-checkout-copy";
+
+export type SecretariatPaymentCta =
+  | { visible: false }
+  | {
+      visible: true;
+      label: string;
+      tooltip: string;
+      kind: "request" | "resend" | "validate_settled";
+    };
+
+export function resolveSecretariatPaymentCta(params: {
+  registrationStatus?: string | null | undefined;
+  paymentSettled: boolean;
+  paymentMethod?: PaymentMethodId | null | undefined;
+}): SecretariatPaymentCta {
+  const status = params.registrationStatus ?? null;
+  if (status === "paid" || status === "approved") {
+    return { visible: false };
+  }
+
+  const canSendStripeEmail = params.paymentMethod === "card";
+
+  if (params.paymentSettled) {
+    return {
+      visible: true,
+      label: SECRETARIAT_VALIDATE_SETTLED_BUTTON,
+      tooltip: SECRETARIAT_VALIDATE_SETTLED_TOOLTIP,
+      kind: "validate_settled",
+    };
+  }
+
+  if (status === "payment_requested") {
+    return {
+      visible: true,
+      label: canSendStripeEmail
+        ? SECRETARIAT_RESEND_PAYMENT_BUTTON
+        : "Renvoyer les instructions de règlement",
+      tooltip: canSendStripeEmail
+        ? SECRETARIAT_RESEND_PAYMENT_TOOLTIP
+        : "Renvoie l'e-mail d'instructions de règlement au contact du dossier.",
+      kind: "resend",
+    };
+  }
+
+  return {
+    visible: true,
+    label: SECRETARIAT_INITIAL_PAYMENT_BUTTON,
+    tooltip: canSendStripeEmail
+      ? BNPL_SECRETARIAT_PAYMENT_TOOLTIP
+      : "Enregistre le dossier puis bascule en suivi adapté : pas de lien de paiement automatique pour ce mode de règlement.",
+    kind: "request",
+  };
+}

--- a/src/lib/club-registration/resolve-settled-request-payment.test.ts
+++ b/src/lib/club-registration/resolve-settled-request-payment.test.ts
@@ -1,0 +1,126 @@
+import {
+  ALREADY_FINALIZED_NO_LINK_MESSAGE,
+  ALREADY_PAID_RESEND_ERROR,
+  VALIDATED_ALREADY_PAID_MESSAGE,
+  buildPaidDossierValidationPatch,
+  isRegistrationPaymentSettled,
+  resolveSettledRequestPaymentAction,
+} from "./resolve-settled-request-payment";
+import type { RegistrationPayment } from "./payment/types";
+
+const paidPayment = (
+  overrides: Partial<RegistrationPayment> = {}
+): RegistrationPayment => ({
+  totalAmountCents: 20_000,
+  assistanceTotalAmountCents: 5_000,
+  amountToPayCents: 15_000,
+  aids: [],
+  paymentMethod: "cheque",
+  paymentInstallments: 1,
+  expectedPayments: [],
+  receivedPayments: [
+    {
+      id: "rp-1",
+      method: "cheque",
+      label: "Chèque",
+      amountCents: 15_000,
+      receivedAt: "2026-08-17T10:00:00.000Z",
+    },
+  ],
+  paidAmountCents: 15_000,
+  remainingAmountCents: 0,
+  paymentStatus: "paid",
+  ...overrides,
+});
+
+describe("isRegistrationPaymentSettled", () => {
+  it("détecte un paiement enregistré même si le dossier n'est pas encore payé", () => {
+    expect(
+      isRegistrationPaymentSettled(
+        { status: "in_review", paymentStatus: "paid" },
+        paidPayment()
+      )
+    ).toBe(true);
+  });
+
+  it("détecte un solde soldé via l'objet payment imbriqué", () => {
+    expect(
+      isRegistrationPaymentSettled({ status: "submitted", paymentStatus: "pending" }, paidPayment())
+    ).toBe(true);
+  });
+
+  it("détecte une remise qui solde le dossier sans encaissement", () => {
+    expect(
+      isRegistrationPaymentSettled(
+        { status: "in_review", paymentStatus: "paid" },
+        paidPayment({
+          assistanceTotalAmountCents: 20_000,
+          amountToPayCents: 0,
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 0,
+          paymentStatus: "paid",
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("laisse ouverts les dossiers encore dus", () => {
+    expect(
+      isRegistrationPaymentSettled(
+        { status: "in_review", paymentStatus: "pending" },
+        paidPayment({
+          paidAmountCents: 5_000,
+          remainingAmountCents: 10_000,
+          paymentStatus: "partially_paid",
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("resolveSettledRequestPaymentAction", () => {
+  it("finalise un dossier encore ouvert", () => {
+    expect(resolveSettledRequestPaymentAction("in_review")).toEqual({
+      kind: "finalize_paid",
+      message: VALIDATED_ALREADY_PAID_MESSAGE,
+    });
+    expect(resolveSettledRequestPaymentAction("submitted")).toEqual({
+      kind: "finalize_paid",
+      message: VALIDATED_ALREADY_PAID_MESSAGE,
+    });
+    expect(resolveSettledRequestPaymentAction("payment_requested")).toEqual({
+      kind: "finalize_paid",
+      message: VALIDATED_ALREADY_PAID_MESSAGE,
+    });
+  });
+
+  it("reste idempotent si le dossier est déjà clos", () => {
+    expect(resolveSettledRequestPaymentAction("paid")).toEqual({
+      kind: "already_finalized",
+      message: ALREADY_FINALIZED_NO_LINK_MESSAGE,
+    });
+    expect(resolveSettledRequestPaymentAction("approved")).toEqual({
+      kind: "already_finalized",
+      message: ALREADY_FINALIZED_NO_LINK_MESSAGE,
+    });
+  });
+
+  it("refuse de valider un dossier rejeté", () => {
+    expect(resolveSettledRequestPaymentAction("rejected")).toEqual({
+      kind: "reject",
+      error: ALREADY_PAID_RESEND_ERROR,
+    });
+  });
+});
+
+describe("buildPaidDossierValidationPatch", () => {
+  it("passe le dossier en payé en conservant le suivi de paiement", () => {
+    const payment = paidPayment();
+    expect(buildPaidDossierValidationPatch(payment)).toMatchObject({
+      status: "paid",
+      paymentStatus: "paid",
+      payment,
+    });
+  });
+});

--- a/src/lib/club-registration/resolve-settled-request-payment.ts
+++ b/src/lib/club-registration/resolve-settled-request-payment.ts
@@ -1,0 +1,54 @@
+import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
+import { paymentToFirestoreUpdate } from "@/lib/club-registration/payment/normalize-payment";
+import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+
+export const ALREADY_PAID_RESEND_ERROR =
+  "Ce dossier est déjà réglé (paiement enregistré). Impossible de renvoyer un lien de paiement.";
+
+export const ALREADY_FINALIZED_NO_LINK_MESSAGE =
+  "Dossier déjà réglé. Aucun lien de paiement n'a été renvoyé.";
+
+export const VALIDATED_ALREADY_PAID_MESSAGE =
+  "Dossier validé. Le paiement était déjà enregistré, aucun lien de paiement n'a été envoyé.";
+
+export function isRegistrationPaymentSettled(
+  data: Record<string, unknown>,
+  payment?: Pick<
+    RegistrationPayment,
+    "paymentStatus" | "remainingAmountCents" | "paidAmountCents"
+  > | null
+): boolean {
+  if (isRegistrationPaidRecord(data)) {
+    return true;
+  }
+  if (payment?.paymentStatus === "paid") {
+    return true;
+  }
+  return (payment?.paidAmountCents ?? 0) > 0 && (payment?.remainingAmountCents ?? 1) <= 0;
+}
+
+export type SettledRequestPaymentAction =
+  | { kind: "already_finalized"; message: string }
+  | { kind: "finalize_paid"; message: string }
+  | { kind: "reject"; error: string };
+
+export function resolveSettledRequestPaymentAction(
+  dossierStatus: unknown
+): SettledRequestPaymentAction {
+  if (dossierStatus === "rejected") {
+    return { kind: "reject", error: ALREADY_PAID_RESEND_ERROR };
+  }
+  if (dossierStatus === "paid" || dossierStatus === "approved") {
+    return { kind: "already_finalized", message: ALREADY_FINALIZED_NO_LINK_MESSAGE };
+  }
+  return { kind: "finalize_paid", message: VALIDATED_ALREADY_PAID_MESSAGE };
+}
+
+export function buildPaidDossierValidationPatch(
+  payment: RegistrationPayment | null
+): Record<string, unknown> {
+  return {
+    status: "paid",
+    ...(payment ? paymentToFirestoreUpdate(payment) : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- Un dossier déjà soldé (remise + paiement enregistré) peut être validé sans renvoyer un lien de paiement.
- Le bouton secrétariat devient « Valider le dossier » au lieu de bloquer avec l’erreur 409.
- Une remise à 0 € redevient validable (le statut de suivi « payé » ne court-circuite plus l’approbation).

## Test plan
- [ ] Dossier en relecture, reste dû 0 € après encaissement : le bouton affiche « Valider le dossier », la validation passe le statut à `paid` sans e-mail de lien Stripe.
- [ ] Dossier avec remise exceptionnelle qui solde tout : « Valider et demander le paiement » approuve sans 409.
- [ ] Dossier non soldé : le flux actuel (lien Stripe / instructions) est inchangé.
- [ ] Dossier déjà `paid` / `approved` : le bouton de demande de paiement n’apparaît plus.


Made with [Cursor](https://cursor.com)