### PR TITLE
release: mode de règlement comme intention

### DIFF
--- a/scripts/repair-registration-payment-status.ts
+++ b/scripts/repair-registration-payment-status.ts
@@ -29,6 +29,7 @@ import {
   paymentToFirestoreUpdate,
 } from "../src/lib/club-registration/payment/normalize-payment";
 import { markPaymentFullyPaid } from "../src/lib/club-registration/payment/payment-mutations";
+import { receivedMethodFromPlanned } from "../src/lib/club-registration/payment/received-method-from-planned";
 import { needsRegistrationPaymentStatusRepair } from "../src/lib/club-registration/repair-registration-payment-status";
 import { resolveRegistrationPaymentStatus } from "../src/lib/club-registration/resolve-registration-payment-status";
 import { formatPersonDisplayName } from "../src/lib/shared/person-name-format";
@@ -191,7 +192,11 @@ function formatPaidAt(value: unknown): string {
 function buildRepairPatch(data: DocumentData): Record<string, unknown> {
   const payment = normalizeRegistrationPayment(data);
   const nextPayment = payment
-    ? markPaymentFullyPaid(payment, { recordedBy: "repair-script" })
+    ? markPaymentFullyPaid(payment, {
+        method: receivedMethodFromPlanned(payment.paymentMethod),
+        recordedBy: "repair-script",
+        note: "Réparation de statut — moyen repris du mode prévu",
+      })
     : null;
 
   return {

--- a/src/app/api/club/registration/[id]/checkout/route.ts
+++ b/src/app/api/club/registration/[id]/checkout/route.ts
@@ -26,6 +26,7 @@ import {
   canSelfServiceCheckout,
   resolveSelfServicePayableCents,
 } from "@/lib/club-registration/self-service-checkout";
+import { resolveCheckoutChargeAmounts } from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import type { PriceQuote } from "@/lib/pricing/types";
 
@@ -123,10 +124,12 @@ export async function POST(
       invoiceTotalCents
     );
 
-    const amountToPayCents =
-      payment?.amountToPayCents ?? resolveSelfServicePayableCents(data);
+    const charge = resolveCheckoutChargeAmounts(
+      payment,
+      resolveSelfServicePayableCents(data)
+    );
 
-    if (amountToPayCents <= 0) {
+    if (charge.remainingPayableCents <= 0) {
       return jsonNoStore({ error: "Aucun montant à régler pour ce dossier." }, { status: 400 });
     }
 
@@ -136,7 +139,9 @@ export async function POST(
       donationPricing,
       pricingConfig,
       payment,
-      amountToPayCents,
+      amountToPayCents: charge.amountToPayCents,
+      alreadyPaidCents: charge.alreadyPaidCents,
+      remainingPayableCents: charge.remainingPayableCents,
       paymentEmail,
       adherentName,
       successUrl,
@@ -164,7 +169,7 @@ export async function POST(
       resource: "clubRegistration",
       resourceId: id,
       details: {
-        amountCents: amountToPayCents,
+        amountCents: charge.remainingPayableCents,
         stripeCheckoutSessionId: checkoutResult.result.session.id,
         selfService: true,
       },

--- a/src/app/api/club/registration/[id]/payment/expected/[expectedId]/receive/route.ts
+++ b/src/app/api/club/registration/[id]/payment/expected/[expectedId]/receive/route.ts
@@ -6,11 +6,9 @@ import { getFirestoreAdmin } from "@/lib/firebase-admin";
 import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
 import { requireRegistrationManager } from "@/lib/club-registration/payment/api-auth";
-import {
-  normalizeRegistrationPayment,
-  paymentToFirestoreUpdate,
-} from "@/lib/club-registration/payment/normalize-payment";
+import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
 import { markExpectedPaymentReceived } from "@/lib/club-registration/payment/payment-mutations";
+import { paymentWriteWithSettlement } from "@/lib/club-registration/payment/settlement-firestore";
 import { normalizePaymentReference } from "@/lib/club-registration/payment/payment-reference";
 
 const COLLECTION = "clubRegistrations";
@@ -81,7 +79,7 @@ export async function POST(
 
     await docRef.set(
       {
-        ...paymentToFirestoreUpdate(next),
+        ...paymentWriteWithSettlement(next),
         updatedAt: FieldValue.serverTimestamp(),
       },
       { merge: true }

--- a/src/app/api/club/registration/[id]/payment/mark-paid/route.ts
+++ b/src/app/api/club/registration/[id]/payment/mark-paid/route.ts
@@ -7,6 +7,7 @@ import { validateOrigin } from "@/lib/auth/csrf-utils";
 import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
 import { requireRegistrationManager } from "@/lib/club-registration/payment/api-auth";
 import {
+  isReceivedMethodIdSafe,
   normalizeRegistrationPayment,
   paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
@@ -30,7 +31,10 @@ export async function POST(
     }
 
     const { id } = await context.params;
-    const body = ((await req.json().catch(() => ({}))) ?? {}) as { note?: string };
+    const body = ((await req.json().catch(() => ({}))) ?? {}) as {
+      note?: string;
+      method?: string;
+    };
 
     const db = getFirestoreAdmin();
     const docRef = db.collection(COLLECTION).doc(id);
@@ -45,9 +49,17 @@ export async function POST(
       return jsonNoStore({ error: "Aucune donnée de paiement sur ce dossier" }, { status: 400 });
     }
 
+    if (!isReceivedMethodIdSafe(body.method)) {
+      return jsonNoStore(
+        { error: "Indiquez le moyen d'encaissement réellement reçu." },
+        { status: 400 }
+      );
+    }
+
     const alreadyPaid = data.status === "paid" || payment.paymentStatus === "paid";
 
     const next = markPaymentFullyPaid(payment, {
+      method: body.method,
       recordedBy: auth.uid,
       ...(typeof body.note === "string" && body.note.trim()
         ? { note: body.note.trim() }

--- a/src/app/api/club/registration/[id]/payment/received/route.ts
+++ b/src/app/api/club/registration/[id]/payment/received/route.ts
@@ -9,9 +9,9 @@ import { requireRegistrationManager } from "@/lib/club-registration/payment/api-
 import {
   isReceivedMethodIdSafe,
   normalizeRegistrationPayment,
-  paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
 import { addManualReceivedPayment } from "@/lib/club-registration/payment/payment-mutations";
+import { paymentWriteWithSettlement } from "@/lib/club-registration/payment/settlement-firestore";
 import { normalizePaymentReference } from "@/lib/club-registration/payment/payment-reference";
 
 const COLLECTION = "clubRegistrations";
@@ -79,7 +79,7 @@ export async function POST(
 
     await docRef.set(
       {
-        ...paymentToFirestoreUpdate(next),
+        ...paymentWriteWithSettlement(next),
         updatedAt: FieldValue.serverTimestamp(),
       },
       { merge: true }

--- a/src/app/api/club/registration/[id]/request-payment/route.ts
+++ b/src/app/api/club/registration/[id]/request-payment/route.ts
@@ -16,6 +16,7 @@ import {
   paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
 import { recalculateRegistrationPayment } from "@/lib/club-registration/payment/payment-mutations";
+import { resolveCheckoutChargeAmounts } from "@/lib/club-registration/payment/resolve-remaining-payable";
 import {
   calculateQuoteForRecord,
   resolveRegistrationConfigForRecord,
@@ -67,6 +68,7 @@ export async function POST(
     const { id } = await context.params;
     const body = ((await req.json().catch(() => ({}))) ?? {}) as {
       amountCents?: number;
+      channel?: "stripe" | "instructions";
     };
 
     const db = getFirestoreAdmin();
@@ -128,10 +130,12 @@ export async function POST(
       invoiceTotalCents
     );
 
-    const amountToPayCents =
-      payment?.amountToPayCents ??
-      quote?.totalCents ??
-      (typeof requestedAmount === "number" ? requestedAmount : 0);
+    const charge = resolveCheckoutChargeAmounts(
+      payment,
+      quote?.totalCents ?? (typeof requestedAmount === "number" ? requestedAmount : 0)
+    );
+    const amountToPayCents = charge.amountToPayCents;
+    const payableCents = charge.remainingPayableCents;
 
     if (amountToPayCents <= 0) {
       const zeroPayment = payment
@@ -154,6 +158,16 @@ export async function POST(
       );
     }
 
+    if (payableCents <= 0) {
+      return jsonNoStore(
+        {
+          error:
+            "Ce dossier est déjà réglé (paiement enregistré). Impossible de renvoyer un lien de paiement.",
+        },
+        { status: 409 }
+      );
+    }
+
     if (requestedAmount !== amountToPayCents) {
       return jsonNoStore(
         {
@@ -166,13 +180,14 @@ export async function POST(
     }
 
     const paymentMethod = payment?.paymentMethod ?? "card";
-    const stripeCapability = await createStripePaymentForRegistration({
-      registrationId: id,
-      amountToPayCents,
-      paymentMethod,
-    });
+    const channel =
+      body.channel === "stripe" || body.channel === "instructions"
+        ? body.channel
+        : paymentMethod === "card"
+          ? "stripe"
+          : "instructions";
 
-    if (!stripeCapability.supported) {
+    if (channel === "instructions") {
       const manualResult = await processManualPaymentFollowUp({
         docRef,
         registrationId: id,
@@ -180,6 +195,7 @@ export async function POST(
         quote,
         donationPricing,
         amountToPayCents,
+        payableCents,
         paymentMethod,
         paymentEmails,
         adherentName,
@@ -202,12 +218,27 @@ export async function POST(
       );
     }
 
+    const stripeCapability = await createStripePaymentForRegistration({
+      registrationId: id,
+      amountToPayCents: payableCents,
+      paymentMethod,
+    });
+
+    if (!stripeCapability.supported) {
+      return jsonNoStore(
+        { error: stripeCapability.reason ?? "Paiement en ligne indisponible." },
+        { status: 400 }
+      );
+    }
+
     const checkoutValidation = validateRegistrationStripeCheckout({
       quote,
       donationPricing,
       pricingConfig,
       payment,
       amountToPayCents,
+      alreadyPaidCents: charge.alreadyPaidCents,
+      remainingPayableCents: payableCents,
     });
     if (!checkoutValidation.ok) {
       return jsonNoStore(checkoutValidation.body, { status: checkoutValidation.status });
@@ -220,6 +251,7 @@ export async function POST(
       quote,
       donationPricing,
       amountToPayCents,
+      payableCents,
       paymentEmails,
       adherentName,
       baseUrl,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -6,14 +6,9 @@ import { getFirestoreAdmin } from "@/lib/firebase-admin";
 import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
 import { dispatchPaymentConfirmedEmail } from "@/lib/email/dispatch-payment-confirmed-email";
 import { verifyStripeWebhookSignature } from "@/lib/club-registration/stripe";
-import {
-  normalizeRegistrationPayment,
-  paymentToFirestoreUpdate,
-} from "@/lib/club-registration/payment/normalize-payment";
-import {
-  addManualReceivedPayment,
-  markPaymentFullyPaid,
-} from "@/lib/club-registration/payment/payment-mutations";
+import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import { applyStripeCheckoutPaid } from "@/lib/club-registration/payment/apply-stripe-checkout-paid";
+import { paymentWriteWithSettlement } from "@/lib/club-registration/payment/settlement-firestore";
 
 type StripeWebhookEvent = {
   id: string;
@@ -31,20 +26,6 @@ type StripeWebhookEvent = {
 };
 
 const STRIPE_PAID_CHECKOUT_STATUSES = new Set(["paid", "no_payment_required"]);
-
-function resolveStripeCheckoutPaidAmountCents(
-  session: NonNullable<StripeWebhookEvent["data"]>["object"],
-  existing: Record<string, unknown>,
-  basePaymentAmountToPayCents: number | null
-): number {
-  if (typeof session?.amount_total === "number" && session.amount_total > 0) {
-    return session.amount_total;
-  }
-  if (typeof existing.paymentAmountCents === "number" && existing.paymentAmountCents > 0) {
-    return existing.paymentAmountCents;
-  }
-  return basePaymentAmountToPayCents ?? 0;
-}
 
 export async function POST(req: Request) {
   try {
@@ -77,49 +58,62 @@ export async function POST(req: Request) {
 
     const db = getFirestoreAdmin();
     const docRef = db.collection("clubRegistrations").doc(registrationId);
-    const snap = await docRef.get();
-    const existing = snap.data() ?? {};
-    if (existing.status === "paid") {
+
+    const applied = await db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      const existing = snap.data() ?? {};
+      const amountTotal =
+        typeof session?.amount_total === "number" ? session.amount_total : undefined;
+      const existingStatus = typeof existing.status === "string" ? existing.status : undefined;
+      const result = applyStripeCheckoutPaid({
+        payment: normalizeRegistrationPayment(existing),
+        ...(existingStatus ? { existingStatus } : {}),
+        ...(session?.id ? { sessionId: session.id } : {}),
+        ...(amountTotal != null ? { amountTotal } : {}),
+      });
+
+      if (result.duplicate) {
+        return { ...result, existing, amountCents: amountTotal ?? 0 };
+      }
+
+      if (result.ignored) {
+        return { ...result, existing, amountCents: 0 };
+      }
+
+      const paymentUpdate = result.payment
+        ? paymentWriteWithSettlement(result.payment)
+        : result.markRegistrationPaid
+          ? { paymentStatus: "paid", status: "paid", paidAt: FieldValue.serverTimestamp() }
+          : {};
+
+      tx.set(
+        docRef,
+        {
+          ...paymentUpdate,
+          ...(result.markRegistrationPaid
+            ? { status: "paid", paidAt: FieldValue.serverTimestamp() }
+            : {}),
+          stripeCheckoutSessionId: session?.id ?? null,
+          stripeInvoiceId: session?.invoice ?? null,
+          stripePaymentUrl: null,
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+
+      return {
+        ...result,
+        existing,
+        amountCents: amountTotal && amountTotal > 0 ? amountTotal : 0,
+      };
+    });
+
+    if (applied.duplicate) {
       return jsonNoStore({ received: true, duplicate: true }, { status: 200 });
     }
-
-    const basePayment = normalizeRegistrationPayment(existing);
-    const amountCents = resolveStripeCheckoutPaidAmountCents(
-      session,
-      existing,
-      basePayment?.amountToPayCents ?? null
-    );
-
-    let payment = basePayment;
-    if (payment) {
-      if (amountCents > 0) {
-        payment = addManualReceivedPayment(payment, {
-          method: "card",
-          label: "Paiement Stripe",
-          amountCents,
-          receivedAt: new Date().toISOString(),
-          recordedBy: "stripe",
-          ...(session?.id ? { note: `Checkout ${session.id}` } : {}),
-        });
-      }
-      payment = markPaymentFullyPaid(payment, {
-        recordedBy: "stripe",
-        ...(session?.id ? { note: `Checkout ${session.id}` } : {}),
-      });
+    if (applied.ignored) {
+      return jsonNoStore({ received: true, ignored: applied.ignored }, { status: 200 });
     }
-
-    await docRef.set(
-      {
-        status: "paid",
-        stripeCheckoutSessionId: session?.id ?? null,
-        stripeInvoiceId: session?.invoice ?? null,
-        stripePaymentUrl: null,
-        paidAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-        ...(payment ? paymentToFirestoreUpdate(payment) : { paymentStatus: "paid" }),
-      },
-      { merge: true }
-    );
 
     logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_PAYMENT_CONFIRMED, "stripe", {
       resource: "clubRegistration",
@@ -127,21 +121,23 @@ export async function POST(req: Request) {
       details: {
         eventId: event.id,
         checkoutSessionId: session?.id,
+        amountCents: applied.amountCents,
+        settled: applied.markRegistrationPaid,
         donationCents: session?.metadata?.donationCents,
         donationDiscountCents: session?.metadata?.donationDiscountCents,
       },
       success: true,
     });
 
-    if (amountCents > 0) {
+    if (applied.amountCents > 0 && applied.markRegistrationPaid) {
       try {
         await dispatchPaymentConfirmedEmail({
           registrationId,
           data: {
-            ...existing,
-            stripeInvoiceId: session?.invoice ?? existing.stripeInvoiceId,
+            ...applied.existing,
+            stripeInvoiceId: session?.invoice ?? applied.existing.stripeInvoiceId,
           },
-          amountCents,
+          amountCents: applied.amountCents,
           source: "stripe",
         });
       } catch (emailError) {

--- a/src/components/club-registration/MesInscriptionRegistrationCard.tsx
+++ b/src/components/club-registration/MesInscriptionRegistrationCard.tsx
@@ -18,8 +18,8 @@ import { MEDICAL_CERTIFICATE_STATUS_LABELS } from "@/lib/club-registration/medic
 import { MesInscriptionPayOnlineButton } from "@/components/club-registration/MesInscriptionPayOnlineButton";
 import {
   findMesInscriptionSectionLabel,
-  formatMesInscriptionAmount,
   formatMesInscriptionDate,
+  formatMesInscriptionPayableAmount,
   isMesInscriptionPaid,
   MES_INSCRIPTION_MEDICAL_COLOR,
   MES_INSCRIPTION_ROLE_LABEL,
@@ -100,8 +100,8 @@ export const MesInscriptionRegistrationCard = forwardRef<HTMLDivElement, Props>(
               {r.status === "payment_requested" ? (
                 <Typography variant="caption" color="secondary.main" fontWeight={700}>
                   Paiement attendu
-                  {formatMesInscriptionAmount(r.paymentAmountCents)
-                    ? ` : ${formatMesInscriptionAmount(r.paymentAmountCents)}`
+                  {formatMesInscriptionPayableAmount(r)
+                    ? ` : ${formatMesInscriptionPayableAmount(r)}`
                     : ""}
                 </Typography>
               ) : null}

--- a/src/components/club-registration/PaymentStep.tsx
+++ b/src/components/club-registration/PaymentStep.tsx
@@ -76,9 +76,9 @@ export function PaymentStep({ draft, onChange }: Props) {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Indiquez comment vous souhaitez régler votre inscription. Les montants
-        d&apos;aides ont été saisis à l&apos;étape dossier administratif ; le
-        secrétariat vérifiera votre dossier avant validation définitive.
+        Les montants d&apos;aides ont été saisis à l&apos;étape dossier
+        administratif ; le secrétariat vérifiera votre dossier avant validation
+        définitive.
       </Typography>
 
       {!quote ? (
@@ -139,10 +139,11 @@ export function PaymentStep({ draft, onChange }: Props) {
 
       <Stack spacing={1.5}>
         <Typography variant="subtitle1" component="h3" sx={{ fontWeight: 700 }}>
-          Mode de paiement
+          Mode de règlement prévu
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          Comment souhaitez-vous régler le reste à payer ?
+          Indiquez comment vous prévoyez de régler votre adhésion. Ce choix
+          pourra évoluer par la suite.
         </Typography>
         <FormControl component="fieldset" data-field="paymentMethod">
           <RadioGroup

--- a/src/components/club-registration/RecapPaymentBlock.tsx
+++ b/src/components/club-registration/RecapPaymentBlock.tsx
@@ -55,7 +55,7 @@ export function buildRecapPaymentFields(
         : "—",
     },
     {
-      label: "Mode de paiement",
+      label: "Mode de règlement prévu",
       value:
         draft.paymentMethod !== ""
           ? PAYMENT_METHOD_LABELS[draft.paymentMethod]

--- a/src/components/club-registration/membership-requests/MembershipRequestCardQuickActions.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestCardQuickActions.tsx
@@ -75,7 +75,10 @@ export function MembershipRequestCardQuickActions({
     }
   };
 
-  const requestPayment = async (busy: BusyAction) => {
+  const requestPayment = async (
+    busy: BusyAction,
+    channel?: "stripe" | "instructions"
+  ) => {
     const amountCents = resolveQuickPaymentAmountCents(registration);
     if (!amountCents || amountCents <= 0) {
       return;
@@ -90,7 +93,10 @@ export function MembershipRequestCardQuickActions({
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ amountCents }),
+          body: JSON.stringify({
+            amountCents,
+            ...(channel ? { channel } : {}),
+          }),
         }
       );
       const json = await res.json().catch(() => ({}));
@@ -174,7 +180,7 @@ export function MembershipRequestCardQuickActions({
               )
             }
             disabled={busyAction !== null}
-            onClick={() => void requestPayment("resend")}
+            onClick={() => void requestPayment("resend", "stripe")}
           >
             {SECRETARIAT_QUICK_RESEND_PAYMENT_LABEL}
           </Button>

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFooter.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFooter.tsx
@@ -42,7 +42,9 @@ export function MembershipRequestDetailFooter({
         onReviewNotesChange={(value) => updateField("reviewNotes", value)}
         registrationStatus={selected.status ?? null}
         paymentRequestedAt={selected.paymentRequestedAt ?? null}
-        paymentAmountCents={selected.paymentAmountCents ?? null}
+        paymentAmountCents={
+          selectedPayment?.amountToPayCents ?? selected.paymentAmountCents ?? null
+        }
         paymentEmailSentTo={selected.paymentEmailSentTo ?? null}
         paymentMethod={selectedPayment?.paymentMethod}
         remainingAmountCents={selectedPayment?.remainingAmountCents ?? null}

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFormSecondary.tsx
@@ -371,13 +371,13 @@ export function MembershipRequestDetailFormSecondary({
         paymentAmountCents={selected.paymentAmountCents ?? null}
         paymentEmailSentTo={selected.paymentEmailSentTo ?? null}
         paymentMethod={selectedPayment?.paymentMethod}
+        remainingAmountCents={selectedPayment?.remainingAmountCents ?? null}
         saving={saving}
         requestingPayment={requestingPayment}
         persistingQuote={persistingQuote}
-        onSave={async () => {
-          await save();
-        }}
+        onSave={() => void save()}
         onRequestPayment={requestPayment}
+        onRequestOnlinePayment={() => requestPayment("stripe")}
       />
 
       {registrationId ? (

--- a/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
+++ b/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
@@ -359,7 +359,7 @@ export function useMembershipRequestDetail(
     }
   };
 
-  const requestPayment = async () => {
+  const requestPayment = async (channel?: "stripe" | "instructions") => {
     if (!registrationId || !form) return;
     const amountCents = parseAmountCents(form.amountEuros);
     if (!amountCents || amountCents <= 0) {
@@ -383,7 +383,10 @@ export function useMembershipRequestDetail(
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ amountCents }),
+          body: JSON.stringify({
+            amountCents,
+            ...(channel ? { channel } : {}),
+          }),
         }
       );
       const json = await res.json().catch(() => ({}));

--- a/src/components/club-registration/mes-inscriptions-shared.ts
+++ b/src/components/club-registration/mes-inscriptions-shared.ts
@@ -69,6 +69,16 @@ export function formatMesInscriptionAmount(cents: number | undefined): string | 
   }).format(cents / 100);
 }
 
+export function formatMesInscriptionPayableAmount(
+  registration: MesInscriptionSummary
+): string | null {
+  const remaining = registration.payment?.remainingAmountCents;
+  if (typeof remaining === "number") {
+    return formatMesInscriptionAmount(remaining);
+  }
+  return formatMesInscriptionAmount(registration.paymentAmountCents);
+}
+
 export function formatMesInscriptionDate(iso: string | null | undefined): string {
   if (!iso) return "—";
   try {

--- a/src/components/club-registration/secretariat/AddManualPaymentDialog.tsx
+++ b/src/components/club-registration/secretariat/AddManualPaymentDialog.tsx
@@ -38,6 +38,8 @@ type Props = {
   suggestedAmountCents?: number;
   /** Reste dû actuel — sert à détecter un trop-perçu (si fourni). */
   remainingAmountCents?: number | null;
+  /** Moyen proposé, sans contrainte — l'utilisateur peut le changer. */
+  defaultMethod?: ReceivedPaymentMethodId;
   onSubmit: (input: {
     method: ReceivedPaymentMethodId;
     label: string;
@@ -54,6 +56,7 @@ export function AddManualPaymentDialog({
   onClose,
   suggestedAmountCents = 0,
   remainingAmountCents = null,
+  defaultMethod = "cheque",
   onSubmit,
 }: Props) {
   const [method, setMethod] = useState<ReceivedPaymentMethodId>("cheque");
@@ -72,7 +75,7 @@ export function AddManualPaymentDialog({
     if (!open) {
       return;
     }
-    setMethod("cheque");
+    setMethod(defaultMethod);
     setLabel("");
     setAmountEuros(
       suggestedAmountCents > 0 ? centsToEurosInput(suggestedAmountCents) : ""
@@ -82,7 +85,7 @@ export function AddManualPaymentDialog({
     setNote("");
     setConfirmOverpayment(false);
     setAmountError(null);
-  }, [open, suggestedAmountCents]);
+  }, [open, suggestedAmountCents, defaultMethod]);
 
   const amountCents = eurosInputToCents(amountEuros);
   const isOverpayment =

--- a/src/components/club-registration/secretariat/PaymentSummaryCard.tsx
+++ b/src/components/club-registration/secretariat/PaymentSummaryCard.tsx
@@ -35,7 +35,7 @@ export function PaymentSummaryCard({ payment }: Props) {
         <Chip
           size="small"
           variant="outlined"
-          label={PAYMENT_METHOD_LABELS[payment.paymentMethod]}
+          label={`Prévu : ${PAYMENT_METHOD_LABELS[payment.paymentMethod]}`}
         />
         {(payment.paymentMethod === "cheque") &&
         payment.paymentInstallments > 1 ? (

--- a/src/components/club-registration/secretariat/PaymentTrackingSection.tsx
+++ b/src/components/club-registration/secretariat/PaymentTrackingSection.tsx
@@ -22,6 +22,7 @@ import {
   REMAINING_PAYMENT_METHOD_LABELS,
 } from "@/lib/club-registration/payment-constants";
 import { receivedMethodFromPlanned } from "@/lib/club-registration/payment/received-method-from-planned";
+import { resolveExpectedLineReceivedCents } from "@/lib/club-registration/payment/expected-line-received";
 import type { ExpectedPayment, RegistrationPayment } from "@/lib/club-registration/payment/types";
 import { formatCentsAsEuros } from "@/lib/pricing";
 import { AddManualPaymentDialog } from "./AddManualPaymentDialog";
@@ -177,57 +178,71 @@ export function PaymentTrackingSection({
             <TableHead>
               <TableRow>
                 <TableCell>Libellé</TableCell>
-                <TableCell align="right">Montant</TableCell>
+                <TableCell align="right">Prévu</TableCell>
+                <TableCell align="right">Reçu</TableCell>
                 <TableCell>Statut</TableCell>
                 <TableCell align="right">Actions</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {payment.expectedPayments.map((line) => (
-                <TableRow key={line.id}>
-                  <TableCell>{line.label}</TableCell>
-                  <TableCell align="right">
-                    {formatCentsAsEuros(line.expectedAmountCents)}
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      size="small"
-                      label={
-                        line.status === "received"
-                          ? "Reçu"
-                          : line.status === "cancelled"
-                            ? "Annulé"
-                            : "Attendu"
-                      }
-                      color={
-                        line.status === "received"
-                          ? "success"
-                          : line.status === "cancelled"
-                            ? "default"
-                            : "warning"
-                      }
-                    />
-                  </TableCell>
-                  <TableCell align="right">
-                    {line.status === "expected" ? (
-                      <Tooltip
-                        title="À utiliser dès que cette échéance est bien arrivée sur le compte du club (hors lien de paiement envoyé par l’application, si vous n’en utilisez pas)."
-                        slotProps={{ popper: { sx: { maxWidth: 320 } } }}
-                        enterDelay={400}
-                      >
-                        <Button
-                          size="small"
-                          onClick={() => setReceiveExpected(line)}
+              {payment.expectedPayments.map((line) => {
+                const receivedCents = resolveExpectedLineReceivedCents(
+                  line,
+                  payment.receivedPayments
+                );
+                return (
+                  <TableRow key={line.id}>
+                    <TableCell>{line.label}</TableCell>
+                    <TableCell align="right">
+                      {formatCentsAsEuros(line.expectedAmountCents)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {receivedCents != null ? formatCentsAsEuros(receivedCents) : "—"}
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        label={
+                          line.status === "received"
+                            ? "Reçu"
+                            : line.status === "cancelled"
+                              ? "Annulé"
+                              : "Attendu"
+                        }
+                        color={
+                          line.status === "received"
+                            ? "success"
+                            : line.status === "cancelled"
+                              ? "default"
+                              : "warning"
+                        }
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      {line.status === "expected" ? (
+                        <Tooltip
+                          title="À utiliser dès que cette échéance est bien arrivée sur le compte du club (hors lien de paiement envoyé par l’application, si vous n’en utilisez pas)."
+                          slotProps={{ popper: { sx: { maxWidth: 320 } } }}
+                          enterDelay={400}
                         >
-                          Marquer reçu
-                        </Button>
-                      </Tooltip>
-                    ) : null}
-                  </TableCell>
-                </TableRow>
-              ))}
+                          <Button
+                            size="small"
+                            onClick={() => setReceiveExpected(line)}
+                          >
+                            Marquer reçu
+                          </Button>
+                        </Tooltip>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
+          <Typography variant="caption" color="text.secondary">
+            « Prévu » est le plan d&apos;origine ; « Reçu » reprend l&apos;encaissement
+            réellement enregistré. Le solde restant ci-dessus fait foi.
+          </Typography>
         </>
       ) : null}
 

--- a/src/components/club-registration/secretariat/PaymentTrackingSection.tsx
+++ b/src/components/club-registration/secretariat/PaymentTrackingSection.tsx
@@ -21,6 +21,7 @@ import {
   PAYMENT_STATUS_LABELS,
   REMAINING_PAYMENT_METHOD_LABELS,
 } from "@/lib/club-registration/payment-constants";
+import { receivedMethodFromPlanned } from "@/lib/club-registration/payment/received-method-from-planned";
 import type { ExpectedPayment, RegistrationPayment } from "@/lib/club-registration/payment/types";
 import { formatCentsAsEuros } from "@/lib/pricing";
 import { AddManualPaymentDialog } from "./AddManualPaymentDialog";
@@ -72,17 +73,17 @@ export function PaymentTrackingSection({
         value: formatCentsAsEuros(payment.assistanceTotalAmountCents),
       },
       {
-        label: "Reste à payer (initial)",
+        label: "Montant à régler",
         value: formatCentsAsEuros(payment.amountToPayCents),
       },
-      { label: "Montant déjà reçu", value: formatCentsAsEuros(payment.paidAmountCents) },
-      { label: "Reste dû", value: formatCentsAsEuros(payment.remainingAmountCents) },
+      { label: "Montant encaissé", value: formatCentsAsEuros(payment.paidAmountCents) },
+      { label: "Solde restant", value: formatCentsAsEuros(payment.remainingAmountCents) },
       {
         label: "Statut",
         value: PAYMENT_STATUS_LABELS[payment.paymentStatus],
       },
       {
-        label: "Mode choisi",
+        label: "Mode prévu",
         value: PAYMENT_METHOD_LABELS[payment.paymentMethod],
       },
       ...(payment.paymentMethod === "cheque"
@@ -189,7 +190,7 @@ export function PaymentTrackingSection({
       {payment.expectedPayments.length > 0 ? (
         <>
           <Typography variant="subtitle2" fontWeight={600}>
-            Paiements attendus
+            Règlement prévu
           </Typography>
           <Table size="small">
             <TableHead>
@@ -253,7 +254,7 @@ export function PaymentTrackingSection({
         <>
           <Divider />
           <Typography variant="subtitle2" fontWeight={600}>
-            Paiements reçus
+            Encaissements reçus
           </Typography>
           <Table size="small">
             <TableHead>
@@ -293,18 +294,16 @@ export function PaymentTrackingSection({
           </Button>
         </Tooltip>
         <Tooltip
-          title="Raccourci quand tout est réglé d’un coup, sans cocher chaque ligne. À utiliser avec prudence (contrôle trésorerie)."
+          title="Ouvre le formulaire d’encaissement, prérempli avec le solde restant. Choisissez le moyen réellement reçu."
           slotProps={{ popper: { sx: { maxWidth: 300 } } }}
           enterDelay={400}
         >
           <Button
             variant="outlined"
             color="success"
-            onClick={() =>
-              void runAction(() => postPaymentAction(registrationId, "/mark-paid", {}))
-            }
+            onClick={() => setManualOpen(true)}
           >
-            Tout est payé (raccourci)
+            Tout est payé
           </Button>
         </Tooltip>
         <Tooltip
@@ -330,6 +329,7 @@ export function PaymentTrackingSection({
         open={manualOpen}
         suggestedAmountCents={payment.remainingAmountCents}
         remainingAmountCents={payment.remainingAmountCents}
+        defaultMethod={receivedMethodFromPlanned(payment.paymentMethod)}
         onClose={() => setManualOpen(false)}
         onSubmit={async (input) => {
           await runAction(() =>

--- a/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
+++ b/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
@@ -23,6 +23,8 @@ import {
   SECRETARIAT_RESEND_PAYMENT_BUTTON,
   SECRETARIAT_RESEND_PAYMENT_TOOLTIP,
   SECRETARIAT_SELF_SERVICE_HINT,
+  SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON,
+  SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import {
   PAYMENT_METHOD_LABELS,
@@ -39,11 +41,13 @@ type Props = {
   paymentAmountCents?: number | null;
   paymentEmailSentTo?: string | null | undefined;
   paymentMethod?: PaymentMethodId | null | undefined;
+  remainingAmountCents?: number | null;
   saving: boolean;
   requestingPayment: boolean;
   persistingQuote: boolean;
   onSave: () => void | Promise<void>;
   onRequestPayment: () => void | Promise<void>;
+  onRequestOnlinePayment?: () => void | Promise<void>;
 };
 
 const tooltipEnterProps = { enterDelay: 400, enterNextDelay: 400 } as const;
@@ -79,14 +83,22 @@ export function SecretariatPaymentNotesSection({
   paymentAmountCents,
   paymentEmailSentTo,
   paymentMethod,
+  remainingAmountCents = null,
   saving,
   requestingPayment,
   persistingQuote,
   onSave,
   onRequestPayment,
+  onRequestOnlinePayment,
 }: Props) {
   const canSendStripeEmail = paymentMethod === "card";
   const isPaid = registrationStatus === "paid";
+  const remaining = remainingAmountCents ?? null;
+  const canOfferOnlineLink =
+    !isPaid &&
+    Boolean(onRequestOnlinePayment) &&
+    !canSendStripeEmail &&
+    (remaining == null || remaining > 0);
   const isPaymentResend = registrationStatus === "payment_requested" && !isPaid;
   const paymentButtonLabel = isPaymentResend
     ? canSendStripeEmail
@@ -111,16 +123,17 @@ export function SecretariatPaymentNotesSection({
 
       {paymentMethod === "card" ? (
         <Alert severity="info" variant="outlined">
-          Mode <strong>carte bancaire</strong> : un lien Stripe Checkout sera envoyé par
-          e-mail. {BNPL_SECRETARIAT_ALERT} {CHECKOUT_LINK_VALIDITY_NOTICE}{" "}
+          Mode prévu <strong>carte bancaire</strong> : un lien Stripe Checkout sera
+          envoyé par e-mail. {BNPL_SECRETARIAT_ALERT} {CHECKOUT_LINK_VALIDITY_NOTICE}{" "}
           {SECRETARIAT_SELF_SERVICE_HINT}
         </Alert>
       ) : null}
 
       {paymentMethod && paymentMethod !== "card" ? (
         <Alert severity="info" variant="outlined">
-          Mode <strong>{PAYMENT_METHOD_LABELS[paymentMethod]}</strong> : aucun lien Stripe
-          ne sera envoyé. Utilisez le tableau de suivi pour noter les encaissements reçus.
+          Mode prévu <strong>{PAYMENT_METHOD_LABELS[paymentMethod]}</strong> : les
+          instructions de règlement suivent cette intention. Vous pouvez aussi envoyer
+          un lien de paiement en ligne si l&apos;adhérent règle finalement par carte.
         </Alert>
       ) : null}
 
@@ -138,7 +151,11 @@ export function SecretariatPaymentNotesSection({
                 </InputAdornment>
               ),
             }}
-            helperText="Doit correspondre au reste dû après aides (voir tarification). C’est ce montant qui figurera sur la demande de paiement ou sur vos relances."
+            helperText={
+              remaining != null && remaining !== paymentAmountCents
+                ? `Net après aides. Le solde réellement demandé sera ${formatAmountCents(remaining)}.`
+                : "Doit correspondre au net après aides (voir tarification)."
+            }
           />
         </Grid>
         <Grid size={{ xs: 12 }}>
@@ -190,23 +207,44 @@ export function SecretariatPaymentNotesSection({
           </span>
         </Tooltip>
         {isPaid ? null : (
-          <Tooltip
-            title={paymentTooltip}
-            slotProps={{ popper: { sx: { maxWidth: 340 } } }}
-            {...tooltipEnterProps}
-          >
-            <span>
-              <Button
-                variant="contained"
-                color="secondary"
-                startIcon={<MarkEmailReadIcon />}
-                onClick={() => void onRequestPayment()}
-                disabled={saving || requestingPayment || persistingQuote}
+          <>
+            {canOfferOnlineLink ? (
+              <Tooltip
+                title={SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP}
+                slotProps={{ popper: { sx: { maxWidth: 340 } } }}
+                {...tooltipEnterProps}
               >
-                {requestingPayment ? "Envoi..." : paymentButtonLabel}
-              </Button>
-            </span>
-          </Tooltip>
+                <span>
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    startIcon={<MarkEmailReadIcon />}
+                    onClick={() => void onRequestOnlinePayment?.()}
+                    disabled={saving || requestingPayment || persistingQuote}
+                  >
+                    {SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON}
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : null}
+            <Tooltip
+              title={paymentTooltip}
+              slotProps={{ popper: { sx: { maxWidth: 340 } } }}
+              {...tooltipEnterProps}
+            >
+              <span>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  startIcon={<MarkEmailReadIcon />}
+                  onClick={() => void onRequestPayment()}
+                  disabled={saving || requestingPayment || persistingQuote}
+                >
+                  {requestingPayment ? "Envoi..." : paymentButtonLabel}
+                </Button>
+              </span>
+            </Tooltip>
+          </>
         )}
       </Stack>
     </>

--- a/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
+++ b/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
@@ -23,6 +23,7 @@ import {
   SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import { resolveSecretariatPaymentCta } from "@/lib/club-registration/payment/secretariat-payment-action";
+import { centsToEurosInput } from "@/lib/club-registration/payment/payment-draft-helpers";
 import {
   PAYMENT_METHOD_LABELS,
   type PaymentMethodId,
@@ -71,6 +72,11 @@ function formatAmountCents(cents: number | null | undefined): string | null {
   }).format(cents / 100);
 }
 
+function withRemainingAmount(label: string, remainingCents: number | null): string {
+  const formatted = formatAmountCents(remainingCents);
+  return formatted ? `${label} (${formatted})` : label;
+}
+
 export function SecretariatPaymentNotesSection({
   amountEuros,
   reviewNotes,
@@ -104,7 +110,15 @@ export function SecretariatPaymentNotesSection({
     paymentMethod !== "card" &&
     (remaining == null || remaining > 0);
   const requestedAtLabel = formatPaymentRequestedAt(paymentRequestedAt);
-  const formattedAmount = formatAmountCents(paymentAmountCents);
+  const remainingLabel = formatAmountCents(remaining);
+  const netLabel = formatAmountCents(paymentAmountCents);
+  const alreadyPaidCents =
+    remaining != null && paymentAmountCents != null && remaining < paymentAmountCents
+      ? paymentAmountCents - remaining
+      : null;
+  const hasPartialReceipt = alreadyPaidCents != null && alreadyPaidCents > 0;
+  const chargeButtonLabel =
+    remaining != null && remaining > 0 ? remaining : null;
 
   return (
     <>
@@ -132,7 +146,7 @@ export function SecretariatPaymentNotesSection({
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, sm: 6 }}>
           <TextField
-            label="Montant total à demander à l’adhérent"
+            label="Montant net après aides"
             value={amountEuros}
             onChange={(e) => onAmountEurosChange(e.target.value)}
             fullWidth
@@ -143,13 +157,31 @@ export function SecretariatPaymentNotesSection({
                 </InputAdornment>
               ),
             }}
-            helperText={
-              remaining != null && remaining !== paymentAmountCents
-                ? `Net après aides. Le solde réellement demandé sera ${formatAmountCents(remaining)}.`
-                : "Doit correspondre au net après aides (voir tarification)."
-            }
+            helperText="Total de l’adhésion (hors déjà encaissé). Doit correspondre au devis."
           />
         </Grid>
+        {remaining != null ? (
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <TextField
+              label="Solde qui sera demandé maintenant"
+              value={centsToEurosInput(remaining)}
+              fullWidth
+              InputProps={{
+                readOnly: true,
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <EuroIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+              helperText={
+                hasPartialReceipt
+                  ? `${formatAmountCents(alreadyPaidCents)} déjà encaissé. C’est ce solde que le lien Stripe demandera.`
+                  : "Montant du lien de paiement et des instructions."
+              }
+            />
+          </Grid>
+        ) : null}
         <Grid size={{ xs: 12 }}>
           <TextField
             label="Notes internes (non visibles par l’adhérent)"
@@ -172,7 +204,7 @@ export function SecretariatPaymentNotesSection({
         <Alert severity="warning" variant="outlined">
           Paiement en attente
           {requestedAtLabel ? ` depuis le ${requestedAtLabel}` : ""}
-          {formattedAmount ? ` — montant : ${formattedAmount}` : ""}.
+          {remainingLabel ? ` — solde demandé : ${remainingLabel}` : ""}.
           {paymentEmailSentTo ? (
             <>
               {" "}
@@ -183,6 +215,13 @@ export function SecretariatPaymentNotesSection({
       ) : paymentEmailSentTo ? (
         <Alert severity="info">
           Dernière demande de paiement par e-mail envoyée à {paymentEmailSentTo}.
+        </Alert>
+      ) : null}
+
+      {hasPartialReceipt && remainingLabel && netLabel && paymentCta.visible ? (
+        <Alert severity="warning" variant="outlined">
+          Un encaissement est déjà enregistré. Le lien de paiement demandera{" "}
+          <strong>{remainingLabel}</strong>, pas {netLabel}.
         </Alert>
       ) : null}
 
@@ -205,7 +244,11 @@ export function SecretariatPaymentNotesSection({
         </Tooltip>
         {canOfferOnlineLink ? (
           <Tooltip
-            title={SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP}
+            title={
+              remainingLabel
+                ? `Envoie un e-mail invitant l'adhérent à régler ${remainingLabel} par carte (Stripe), pas le montant net initial.`
+                : SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP
+            }
             slotProps={{ popper: { sx: { maxWidth: 340 } } }}
             {...tooltipEnterProps}
           >
@@ -217,7 +260,10 @@ export function SecretariatPaymentNotesSection({
                 onClick={() => void onRequestOnlinePayment?.()}
                 disabled={saving || requestingPayment || persistingQuote}
               >
-                {SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON}
+                {withRemainingAmount(
+                  SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON,
+                  chargeButtonLabel
+                )}
               </Button>
             </span>
           </Tooltip>
@@ -240,7 +286,9 @@ export function SecretariatPaymentNotesSection({
                   ? paymentCta.kind === "validate_settled"
                     ? "Validation..."
                     : "Envoi..."
-                  : paymentCta.label}
+                  : paymentCta.kind === "validate_settled"
+                    ? paymentCta.label
+                    : withRemainingAmount(paymentCta.label, chargeButtonLabel)}
               </Button>
             </span>
           </Tooltip>

--- a/src/lib/club-registration/membership-requests/registration-card-quick-actions.test.ts
+++ b/src/lib/club-registration/membership-requests/registration-card-quick-actions.test.ts
@@ -73,9 +73,25 @@ describe("registration-card-quick-actions", () => {
     ).toBe(true);
     expect(
       canQuickResendPaymentLink(
-        baseSummary({ status: "in_review", paymentAmountCents: 22_400 })
+        baseSummary({
+          status: "payment_requested",
+          paymentAmountCents: 22_400,
+          payment: {
+            paymentMethod: "cheque",
+            amountToPayCents: 22_400,
+            totalAmountCents: 22_400,
+            assistanceTotalAmountCents: 0,
+            aids: [],
+            paymentInstallments: 1,
+            expectedPayments: [],
+            receivedPayments: [],
+            paidAmountCents: 0,
+            remainingAmountCents: 22_400,
+            paymentStatus: "waiting_payment",
+          },
+        })
       )
-    ).toBe(false);
+    ).toBe(true);
     expect(
       canQuickResendPaymentLink(
         baseSummary({

--- a/src/lib/club-registration/membership-requests/registration-card-quick-actions.ts
+++ b/src/lib/club-registration/membership-requests/registration-card-quick-actions.ts
@@ -56,7 +56,7 @@ export function canQuickResendPaymentLink(registration: RegistrationSummary): bo
   const payment =
     registration.payment ??
     normalizeRegistrationPayment(registration as unknown as Record<string, unknown>);
-  if (payment?.paymentMethod !== "card") {
+  if (payment && payment.remainingAmountCents <= 0 && payment.paidAmountCents > 0) {
     return false;
   }
   const amountCents = resolveQuickPaymentAmountCents(registration);

--- a/src/lib/club-registration/payment-requested.ts
+++ b/src/lib/club-registration/payment-requested.ts
@@ -29,6 +29,8 @@ export function validateRegistrationStripeCheckout(params: {
   pricingConfig: RegistrationConfigV1;
   payment: RegistrationPayment | null;
   amountToPayCents: number;
+  alreadyPaidCents?: number;
+  remainingPayableCents?: number;
 }):
   | { ok: true }
   | { ok: false; status: number; body: Record<string, unknown> } {
@@ -82,6 +84,12 @@ export function validateRegistrationStripeCheckout(params: {
       donationDiscountCents: donationPricing.donationDiscountCents,
       aidDiscountCents,
       amountToPayCents: params.amountToPayCents,
+      ...(params.alreadyPaidCents != null
+        ? { alreadyPaidCents: params.alreadyPaidCents }
+        : {}),
+      ...(params.remainingPayableCents != null
+        ? { remainingPayableCents: params.remainingPayableCents }
+        : {}),
     });
   } catch (validationError) {
     return {
@@ -149,6 +157,8 @@ export async function persistPaymentRequestedAndNotify(params: {
   quote: PriceQuote | null;
   donationPricing: DonationPricingBreakdown | null;
   amountToPayCents: number;
+  /** Solde réellement demandé dans l'e-mail (après encaissements déjà reçus). */
+  payableCents?: number;
   paymentEmails: string[];
   adherentName: string;
   baseUrl: string;
@@ -172,10 +182,11 @@ export async function persistPaymentRequestedAndNotify(params: {
     params.donationPricing != null &&
     params.donationPricing.invoiceTotalCents > 0;
   const emailVariant = params.isResend ? "resend" : "initial";
+  const emailAmountCents = params.payableCents ?? params.amountToPayCents;
   const paymentMail = buildPaymentRequestEmail({
     registrationId: params.registrationId,
     adherentName: params.adherentName,
-    amountCents: params.amountToPayCents,
+    amountCents: emailAmountCents,
     appOrigin: params.baseUrl,
     quote: hasValidatedQuote ? params.quote : null,
     donationPricing: hasValidatedQuote ? params.donationPricing : null,
@@ -195,7 +206,7 @@ export async function persistPaymentRequestedAndNotify(params: {
     resource: "clubRegistration",
     resourceId: params.registrationId,
     details: {
-      amountCents: params.amountToPayCents,
+      amountCents: emailAmountCents,
       resend: Boolean(params.isResend),
       paymentHub: "mes_inscriptions",
       ...(hasValidatedQuote

--- a/src/lib/club-registration/payment/apply-stripe-checkout-paid.test.ts
+++ b/src/lib/club-registration/payment/apply-stripe-checkout-paid.test.ts
@@ -1,0 +1,109 @@
+import {
+  applyStripeCheckoutPaid,
+  hasStripeCheckoutReceipt,
+  stripeCheckoutReceiptNote,
+} from "./apply-stripe-checkout-paid";
+import { addManualReceivedPayment } from "./payment-mutations";
+import type { ExpectedPayment, RegistrationPayment } from "./types";
+
+function chequePlan(): ExpectedPayment[] {
+  return [1, 2, 3].map((n) => ({
+    id: `ep_${n}`,
+    method: "cheque" as const,
+    label: `Chèque ${n}/3`,
+    expectedAmountCents: 10_000,
+    status: "expected" as const,
+  }));
+}
+
+function basePayment(): RegistrationPayment {
+  return {
+    totalAmountCents: 30_000,
+    assistanceTotalAmountCents: 0,
+    amountToPayCents: 30_000,
+    aids: [],
+    paymentMethod: "cheque",
+    paymentInstallments: 3,
+    expectedPayments: chequePlan(),
+    receivedPayments: [],
+    paidAmountCents: 0,
+    remainingAmountCents: 30_000,
+    paymentStatus: "waiting_payment",
+  };
+}
+
+describe("applyStripeCheckoutPaid", () => {
+  it("CAS D — solde Stripe après espèces : deux received, reste 0, mode prévu chèque", () => {
+    const withCash = addManualReceivedPayment(basePayment(), {
+      method: "cash",
+      label: "Espèces",
+      amountCents: 10_000,
+      receivedAt: "2026-08-17T09:00:00.000Z",
+    });
+
+    const result = applyStripeCheckoutPaid({
+      payment: withCash,
+      sessionId: "cs_test_1",
+      amountTotal: 20_000,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(result.markRegistrationPaid).toBe(true);
+    expect(result.payment?.paymentMethod).toBe("cheque");
+    expect(result.payment?.remainingAmountCents).toBe(0);
+    expect(result.payment?.paymentStatus).toBe("paid");
+    expect(result.payment?.receivedPayments.map((line) => line.method)).toEqual([
+      "cash",
+      "card",
+    ]);
+    expect(result.payment?.receivedPayments[1].amountCents).toBe(20_000);
+    expect(result.payment?.expectedPayments.every((line) => line.status === "cancelled")).toBe(
+      true
+    );
+  });
+
+  it("CAS I — webhook reçu deux fois : pas de double receivedPayment", () => {
+    const first = applyStripeCheckoutPaid({
+      payment: basePayment(),
+      sessionId: "cs_test_dup",
+      amountTotal: 30_000,
+    });
+    const second = applyStripeCheckoutPaid({
+      existingStatus: "paid",
+      payment: first.payment,
+      sessionId: "cs_test_dup",
+      amountTotal: 30_000,
+    });
+
+    expect(second.duplicate).toBe(true);
+    expect(second.payment?.receivedPayments).toHaveLength(1);
+    expect(hasStripeCheckoutReceipt(second.payment!, "cs_test_dup")).toBe(true);
+    expect(second.payment?.receivedPayments[0].note).toBe(
+      stripeCheckoutReceiptNote("cs_test_dup")
+    );
+  });
+
+  it("n'invente pas de complément si Stripe n'a pas soldé le dossier", () => {
+    const result = applyStripeCheckoutPaid({
+      payment: basePayment(),
+      sessionId: "cs_test_partial",
+      amountTotal: 10_000,
+    });
+
+    expect(result.markRegistrationPaid).toBe(false);
+    expect(result.payment?.paymentStatus).toBe("partially_paid");
+    expect(result.payment?.remainingAmountCents).toBe(20_000);
+    expect(result.payment?.receivedPayments).toHaveLength(1);
+    expect(result.payment?.paymentMethod).toBe("cheque");
+  });
+
+  it("ignore un événement sans montant Stripe", () => {
+    const result = applyStripeCheckoutPaid({
+      payment: basePayment(),
+      sessionId: "cs_test_none",
+    });
+    expect(result.ignored).toBe("missing stripe amount");
+    expect(result.payment?.receivedPayments).toHaveLength(0);
+    expect(result.markRegistrationPaid).toBe(false);
+  });
+});

--- a/src/lib/club-registration/payment/apply-stripe-checkout-paid.ts
+++ b/src/lib/club-registration/payment/apply-stripe-checkout-paid.ts
@@ -1,0 +1,90 @@
+import { addManualReceivedPayment } from "@/lib/club-registration/payment/payment-mutations";
+import type { RegistrationPayment } from "@/lib/club-registration/payment/types";
+
+const STRIPE_CHECKOUT_NOTE_PREFIX = "Checkout ";
+
+export function stripeCheckoutReceiptNote(sessionId: string): string {
+  return `${STRIPE_CHECKOUT_NOTE_PREFIX}${sessionId}`;
+}
+
+export function hasStripeCheckoutReceipt(
+  payment: RegistrationPayment,
+  sessionId: string | undefined
+): boolean {
+  if (!sessionId) {
+    return false;
+  }
+  const needle = stripeCheckoutReceiptNote(sessionId);
+  return payment.receivedPayments.some(
+    (line) => line.recordedBy === "stripe" && line.note === needle
+  );
+}
+
+export type ApplyStripeCheckoutPaidInput = {
+  existingStatus?: string;
+  payment: RegistrationPayment | null;
+  sessionId?: string;
+  amountTotal?: number;
+};
+
+export type ApplyStripeCheckoutPaidResult = {
+  duplicate: boolean;
+  ignored?: string;
+  payment: RegistrationPayment | null;
+  markRegistrationPaid: boolean;
+};
+
+/**
+ * Applique un Checkout Stripe payé au modèle Payment.
+ * N'écrase pas `paymentMethod`. N'invente pas de complément de solde.
+ */
+export function applyStripeCheckoutPaid(
+  input: ApplyStripeCheckoutPaidInput
+): ApplyStripeCheckoutPaidResult {
+  if (input.payment && hasStripeCheckoutReceipt(input.payment, input.sessionId)) {
+    return {
+      duplicate: true,
+      payment: input.payment,
+      markRegistrationPaid: input.payment.remainingAmountCents === 0,
+    };
+  }
+
+  if (
+    input.existingStatus === "paid" &&
+    (!input.payment || input.payment.remainingAmountCents === 0)
+  ) {
+    return { duplicate: true, payment: input.payment, markRegistrationPaid: true };
+  }
+
+  const amountCents =
+    typeof input.amountTotal === "number" && input.amountTotal > 0 ? input.amountTotal : 0;
+
+  if (amountCents <= 0) {
+    return {
+      duplicate: false,
+      ignored: "missing stripe amount",
+      payment: input.payment,
+      markRegistrationPaid: false,
+    };
+  }
+
+  if (!input.payment) {
+    return { duplicate: false, payment: null, markRegistrationPaid: true };
+  }
+
+  const payment = addManualReceivedPayment(input.payment, {
+    method: "card",
+    label: "Paiement Stripe",
+    amountCents,
+    receivedAt: new Date().toISOString(),
+    recordedBy: "stripe",
+    ...(input.sessionId ? { note: stripeCheckoutReceiptNote(input.sessionId) } : {}),
+  });
+
+  return {
+    duplicate: false,
+    payment,
+    markRegistrationPaid:
+      payment.remainingAmountCents === 0 && payment.paymentStatus === "paid",
+  };
+}

--- a/src/lib/club-registration/payment/bnpl-checkout-copy.ts
+++ b/src/lib/club-registration/payment/bnpl-checkout-copy.ts
@@ -34,7 +34,7 @@ export const BNPL_SECRETARIAT_PAYMENT_TOOLTIP =
 
 /** Sous-titre page secrétariat — demandes d'adhésion. */
 export const BNPL_SECRETARIAT_PAGE_SUBTITLE =
-  "Relisez le dossier, vérifiez le montant, puis demandez le paiement : un e-mail avec lien Stripe part pour la carte bancaire (une fois ou BNPL sur la page Stripe, selon éligibilité). Les autres modes sont suivis manuellement dans le tableau ci-dessous.";
+  "Relisez le dossier, vérifiez le montant, puis demandez le paiement. Le mode déclaré à l'inscription reste une intention : vous pouvez envoyer un lien Stripe même si l'adhérent avait prévu un autre règlement.";
 
 /** Chaîne attendue dans les tests e-mail (repère stable). */
 export const BNPL_COPY_TEST_MARKER = "BNPL";
@@ -94,6 +94,13 @@ export const SECRETARIAT_RESEND_PAYMENT_BUTTON = "Renvoyer le lien de paiement";
 /** Tooltip secrétariat — renvoi. */
 export const SECRETARIAT_RESEND_PAYMENT_TOOLTIP =
   "Génère un nouveau lien Stripe (valable 24 h) et renvoie l'e-mail de paiement au contact du dossier.";
+
+/** Bouton secrétariat — proposer un paiement CB même si le mode prévu n'est pas carte. */
+export const SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON =
+  "Envoyer un lien de paiement en ligne";
+
+export const SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP =
+  "Envoie un e-mail invitant l'adhérent à régler le solde restant par carte (Stripe), quel que soit le mode prévu à l'inscription.";
 
 /** Liste secrétariat — action rapide renvoi. */
 export const SECRETARIAT_QUICK_RESEND_PAYMENT_LABEL = "Renvoyer le lien";

--- a/src/lib/club-registration/payment/expected-line-received.test.ts
+++ b/src/lib/club-registration/payment/expected-line-received.test.ts
@@ -1,0 +1,26 @@
+import { resolveExpectedLineReceivedCents } from "./expected-line-received";
+
+describe("resolveExpectedLineReceivedCents", () => {
+  it("retourne le montant encaissé rattaché à une échéance reçue", () => {
+    expect(
+      resolveExpectedLineReceivedCents(
+        { id: "ep_1", status: "received" },
+        [
+          {
+            expectedPaymentId: "ep_1",
+            amountCents: 10_000,
+          },
+        ]
+      )
+    ).toBe(10_000);
+  });
+
+  it("ignore les échéances encore attendues", () => {
+    expect(
+      resolveExpectedLineReceivedCents(
+        { id: "ep_1", status: "expected" },
+        [{ expectedPaymentId: "ep_1", amountCents: 10_000 }]
+      )
+    ).toBeNull();
+  });
+});

--- a/src/lib/club-registration/payment/expected-line-received.ts
+++ b/src/lib/club-registration/payment/expected-line-received.ts
@@ -1,0 +1,16 @@
+import type { ExpectedPayment, ReceivedPayment } from "./types";
+
+/** Montant réellement encaissé rattaché à une échéance prévue, s'il existe. */
+export function resolveExpectedLineReceivedCents(
+  line: Pick<ExpectedPayment, "id" | "status">,
+  receivedPayments: Pick<ReceivedPayment, "expectedPaymentId" | "amountCents">[]
+): number | null {
+  if (line.status !== "received") {
+    return null;
+  }
+  const linked = receivedPayments.filter((item) => item.expectedPaymentId === line.id);
+  if (linked.length === 0) {
+    return null;
+  }
+  return linked.reduce((sum, item) => sum + item.amountCents, 0);
+}

--- a/src/lib/club-registration/payment/index.ts
+++ b/src/lib/club-registration/payment/index.ts
@@ -49,3 +49,9 @@ export {
   isExpectedPaymentStatusId,
   isReceivedMethodIdSafe,
 } from "./normalize-payment";
+
+export {
+  resolveRemainingPayableCents,
+  resolveCheckoutChargeAmounts,
+  type CheckoutChargeAmounts,
+} from "./resolve-remaining-payable";

--- a/src/lib/club-registration/payment/payment-mutations.test.ts
+++ b/src/lib/club-registration/payment/payment-mutations.test.ts
@@ -2,6 +2,7 @@ import {
   CANCELLED_EXPECTED_REPLACED_NOTE,
   addManualReceivedPayment,
   cancelOutstandingExpectedPayments,
+  markExpectedPaymentReceived,
   markPaymentFullyPaid,
 } from "./payment-mutations";
 import type { ExpectedPayment, ReceivedPayment, RegistrationPayment } from "./types";
@@ -49,6 +50,9 @@ describe("addManualReceivedPayment", () => {
     expect(next.receivedPayments).toHaveLength(1);
     expect(next.receivedPayments[0].method).toBe("cash");
     expect(next.expectedPayments.every((line) => line.status === "expected")).toBe(true);
+    expect(
+      next.expectedPayments.reduce((sum, line) => sum + line.expectedAmountCents, 0)
+    ).toBe(20_000);
   });
 
   it("CAS E — solde couvert par CB : échéances encore expected passent en cancelled", () => {
@@ -114,6 +118,37 @@ describe("addManualReceivedPayment", () => {
 
     expect(next.expectedPayments[0].status).toBe("received");
     expect(next.expectedPayments[1].status).toBe("cancelled");
+  });
+});
+
+describe("markExpectedPaymentReceived", () => {
+  it("conserve le montant prévu et réajuste les échéances encore attendues au solde", () => {
+    const next = markExpectedPaymentReceived(
+      basePayment({
+        totalAmountCents: 29_000,
+        amountToPayCents: 29_000,
+        remainingAmountCents: 29_000,
+        expectedPayments: chequePlan([9666, 9666, 9668]),
+      }),
+      "ep_1",
+      {
+        amountCents: 10_000,
+        receivedAt: "2026-08-18T10:00:00.000Z",
+      }
+    );
+
+    expect(next).not.toBeNull();
+    expect(next?.expectedPayments[0]?.status).toBe("received");
+    expect(next?.expectedPayments[0]?.expectedAmountCents).toBe(9666);
+    expect(next?.receivedPayments[0]?.amountCents).toBe(10_000);
+    expect(next?.paidAmountCents).toBe(10_000);
+    expect(next?.remainingAmountCents).toBe(19_000);
+    expect(next?.expectedPayments[1]?.status).toBe("expected");
+    expect(next?.expectedPayments[2]?.status).toBe("expected");
+    expect(
+      (next?.expectedPayments[1]?.expectedAmountCents ?? 0) +
+        (next?.expectedPayments[2]?.expectedAmountCents ?? 0)
+    ).toBe(19_000);
   });
 });
 

--- a/src/lib/club-registration/payment/payment-mutations.test.ts
+++ b/src/lib/club-registration/payment/payment-mutations.test.ts
@@ -1,0 +1,146 @@
+import {
+  CANCELLED_EXPECTED_REPLACED_NOTE,
+  addManualReceivedPayment,
+  cancelOutstandingExpectedPayments,
+  markPaymentFullyPaid,
+} from "./payment-mutations";
+import type { ExpectedPayment, ReceivedPayment, RegistrationPayment } from "./types";
+
+function chequePlan(amounts: number[]): ExpectedPayment[] {
+  return amounts.map((expectedAmountCents, index) => ({
+    id: `ep_${index + 1}`,
+    method: "cheque" as const,
+    label: `Chèque ${index + 1}/${amounts.length}`,
+    expectedAmountCents,
+    status: "expected" as const,
+  }));
+}
+
+function basePayment(overrides: Partial<RegistrationPayment> = {}): RegistrationPayment {
+  return {
+    totalAmountCents: 30_000,
+    assistanceTotalAmountCents: 0,
+    amountToPayCents: 30_000,
+    aids: [],
+    paymentMethod: "cheque",
+    paymentInstallments: 3,
+    expectedPayments: chequePlan([10_000, 10_000, 10_000]),
+    receivedPayments: [],
+    paidAmountCents: 0,
+    remainingAmountCents: 30_000,
+    paymentStatus: "waiting_payment",
+    ...overrides,
+  };
+}
+
+describe("addManualReceivedPayment", () => {
+  it("CAS B — encaissement d'un autre moyen : totaux à jour, mode prévu inchangé", () => {
+    const next = addManualReceivedPayment(basePayment(), {
+      method: "cash",
+      label: "Espèces",
+      amountCents: 10_000,
+      receivedAt: "2026-08-17T10:00:00.000Z",
+    });
+
+    expect(next.paymentMethod).toBe("cheque");
+    expect(next.paidAmountCents).toBe(10_000);
+    expect(next.remainingAmountCents).toBe(20_000);
+    expect(next.paymentStatus).toBe("partially_paid");
+    expect(next.receivedPayments).toHaveLength(1);
+    expect(next.receivedPayments[0].method).toBe("cash");
+    expect(next.expectedPayments.every((line) => line.status === "expected")).toBe(true);
+  });
+
+  it("CAS E — solde couvert par CB : échéances encore expected passent en cancelled", () => {
+    const next = addManualReceivedPayment(basePayment(), {
+      method: "card",
+      label: "Paiement Stripe",
+      amountCents: 30_000,
+      receivedAt: "2026-08-17T10:00:00.000Z",
+    });
+
+    expect(next.paymentMethod).toBe("cheque");
+    expect(next.remainingAmountCents).toBe(0);
+    expect(next.paymentStatus).toBe("paid");
+    expect(next.expectedPayments.map((line) => line.status)).toEqual([
+      "cancelled",
+      "cancelled",
+      "cancelled",
+    ]);
+    expect(next.expectedPayments[0].note).toBe(CANCELLED_EXPECTED_REPLACED_NOTE);
+    expect(next.receivedPayments).toHaveLength(1);
+    expect(next.receivedPayments[0].method).toBe("card");
+  });
+
+  it("ne modifie pas les lignes already received", () => {
+    const alreadyReceived: ExpectedPayment = {
+      id: "ep_1",
+      method: "cheque",
+      label: "Chèque 1/3",
+      expectedAmountCents: 10_000,
+      status: "received",
+    };
+    const stillExpected: ExpectedPayment = {
+      id: "ep_2",
+      method: "cheque",
+      label: "Chèque 2/3",
+      expectedAmountCents: 10_000,
+      status: "expected",
+    };
+    const previous: ReceivedPayment = {
+      id: "rp_1",
+      method: "cheque",
+      label: "Chèque 1/3",
+      amountCents: 10_000,
+      receivedAt: "2026-08-01T10:00:00.000Z",
+      expectedPaymentId: "ep_1",
+    };
+
+    const next = addManualReceivedPayment(
+      basePayment({
+        expectedPayments: [alreadyReceived, stillExpected],
+        receivedPayments: [previous],
+        paidAmountCents: 10_000,
+        remainingAmountCents: 20_000,
+        paymentStatus: "partially_paid",
+      }),
+      {
+        method: "card",
+        label: "Paiement Stripe",
+        amountCents: 20_000,
+        receivedAt: "2026-08-17T10:00:00.000Z",
+      }
+    );
+
+    expect(next.expectedPayments[0].status).toBe("received");
+    expect(next.expectedPayments[1].status).toBe("cancelled");
+  });
+});
+
+describe("cancelOutstandingExpectedPayments", () => {
+  it("ne rapproche pas un paiement partiel", () => {
+    const payment = basePayment({
+      paidAmountCents: 5_000,
+      remainingAmountCents: 25_000,
+      paymentStatus: "partially_paid",
+    });
+    expect(cancelOutstandingExpectedPayments(payment).expectedPayments).toEqual(
+      payment.expectedPayments
+    );
+  });
+});
+
+describe("markPaymentFullyPaid", () => {
+  it("CAS J — n'invente plus un moyen à partir du mode prévu", () => {
+    const next = markPaymentFullyPaid(basePayment(), {
+      method: "cash",
+      recordedBy: "secretary",
+    });
+
+    expect(next.receivedPayments).toHaveLength(1);
+    expect(next.receivedPayments[0].method).toBe("cash");
+    expect(next.paymentMethod).toBe("cheque");
+    expect(next.remainingAmountCents).toBe(0);
+    expect(next.paymentStatus).toBe("paid");
+  });
+});

--- a/src/lib/club-registration/payment/payment-mutations.ts
+++ b/src/lib/club-registration/payment/payment-mutations.ts
@@ -1,5 +1,8 @@
 import { calculatePaymentSummary } from "./calculate-payment-summary";
-import { generateExpectedPayments } from "./generate-expected-payments";
+import {
+  generateExpectedPayments,
+  splitAmountAcrossInstallments,
+} from "./generate-expected-payments";
 import type {
   ExpectedPayment,
   ReceivedPayment,
@@ -180,8 +183,49 @@ export function cancelOutstandingExpectedPayments(
   return changed ? { ...payment, expectedPayments } : payment;
 }
 
+/**
+ * Recale les échéances encore « expected » pour qu'elles somment au solde restant.
+ * Les lignes déjà reçues ou annulées ne sont pas touchées (le plan d'origine y reste).
+ */
+export function rebalanceOutstandingExpectedPayments(
+  payment: RegistrationPayment
+): RegistrationPayment {
+  const outstandingIndexes: number[] = [];
+  payment.expectedPayments.forEach((line, index) => {
+    if (line.status === "expected") {
+      outstandingIndexes.push(index);
+    }
+  });
+
+  if (outstandingIndexes.length === 0) {
+    return payment;
+  }
+
+  const amounts = splitAmountAcrossInstallments(
+    Math.max(0, payment.remainingAmountCents),
+    outstandingIndexes.length
+  );
+  const amountByIndex = new Map(
+    outstandingIndexes.map((index, slot) => [index, amounts[slot] ?? 0])
+  );
+
+  let changed = false;
+  const expectedPayments = payment.expectedPayments.map((line, index) => {
+    const nextAmount = amountByIndex.get(index);
+    if (nextAmount === undefined || nextAmount === line.expectedAmountCents) {
+      return line;
+    }
+    changed = true;
+    return { ...line, expectedAmountCents: nextAmount };
+  });
+
+  return changed ? { ...payment, expectedPayments } : payment;
+}
+
 function finalizeAfterReceipt(payment: RegistrationPayment): RegistrationPayment {
-  return cancelOutstandingExpectedPayments(recalculateRegistrationPayment(payment));
+  return rebalanceOutstandingExpectedPayments(
+    cancelOutstandingExpectedPayments(recalculateRegistrationPayment(payment))
+  );
 }
 
 export function markPaymentFullyPaid(

--- a/src/lib/club-registration/payment/payment-mutations.ts
+++ b/src/lib/club-registration/payment/payment-mutations.ts
@@ -89,7 +89,7 @@ export function markExpectedPaymentReceived(
     receivedPayments: [...payment.receivedPayments, received],
   };
 
-  return recalculateRegistrationPayment(next);
+  return finalizeAfterReceipt(next);
 }
 
 export function cancelExpectedPayment(
@@ -133,7 +133,7 @@ export function addManualReceivedPayment(
     ...(input.note ? { note: input.note } : {}),
   };
 
-  return recalculateRegistrationPayment({
+  return finalizeAfterReceipt({
     ...payment,
     receivedPayments: [...payment.receivedPayments, received],
   });
@@ -152,33 +152,62 @@ function RECEIVED_PAYMENT_METHOD_LABELS_FALLBACK(
   return labels[method];
 }
 
+export const CANCELLED_EXPECTED_REPLACED_NOTE =
+  "Remplacé par le règlement effectivement reçu.";
+
+/**
+ * Plan prévisionnel : si le solde est à 0, les lignes encore « expected »
+ * sont annulées. Les lignes déjà « received » restent intactes.
+ */
+export function cancelOutstandingExpectedPayments(
+  payment: RegistrationPayment,
+  note: string = CANCELLED_EXPECTED_REPLACED_NOTE
+): RegistrationPayment {
+  if (payment.remainingAmountCents > 0) {
+    return payment;
+  }
+
+  let changed = false;
+  const expectedPayments = payment.expectedPayments.map((line) => {
+    if (line.status !== "expected") {
+      return line;
+    }
+    changed = true;
+    const cancelled: ExpectedPayment = { ...line, status: "cancelled", note };
+    return cancelled;
+  });
+
+  return changed ? { ...payment, expectedPayments } : payment;
+}
+
+function finalizeAfterReceipt(payment: RegistrationPayment): RegistrationPayment {
+  return cancelOutstandingExpectedPayments(recalculateRegistrationPayment(payment));
+}
+
 export function markPaymentFullyPaid(
   payment: RegistrationPayment,
-  input?: { note?: string; recordedBy?: string }
+  input: {
+    method: ReceivedPaymentMethodId;
+    note?: string;
+    recordedBy?: string;
+  }
 ): RegistrationPayment {
   const remaining = payment.remainingAmountCents;
   if (remaining <= 0) {
-    return recalculateRegistrationPayment({
+    return finalizeAfterReceipt({
       ...payment,
-      paymentStatus: "paid",
+      paymentStatus: "paid" satisfies PaymentStatusId,
     });
   }
 
-  const withReceipt = addManualReceivedPayment(payment, {
-    method: payment.paymentMethod === "cheque" ? "cheque" : "card",
+  return addManualReceivedPayment(payment, {
+    method: input.method,
     label: "Solde — marqué payé par le secrétariat",
     amountCents: remaining,
     receivedAt: new Date().toISOString(),
-    ...(input?.note ? { note: input.note } : {}),
-    ...(input?.recordedBy ? { recordedBy: input.recordedBy } : {}),
+    ...(input.note ? { note: input.note } : {}),
+    ...(input.recordedBy ? { recordedBy: input.recordedBy } : {}),
   });
-
-  return {
-    ...withReceipt,
-    paymentStatus: "paid" satisfies PaymentStatusId,
-    remainingAmountCents: 0,
-    paidAmountCents: withReceipt.amountToPayCents,
-  };
 }
 
 export function setManualFollowUp(

--- a/src/lib/club-registration/payment/received-method-from-planned.ts
+++ b/src/lib/club-registration/payment/received-method-from-planned.ts
@@ -1,0 +1,17 @@
+import {
+  RECEIVED_PAYMENT_METHOD_IDS,
+  type PaymentMethodId,
+  type ReceivedPaymentMethodId,
+} from "../payment-constants";
+
+const RECEIVED_METHOD_SET = new Set<string>(RECEIVED_PAYMENT_METHOD_IDS);
+
+/** Le mode prévu d'inscription est toujours un moyen d'encaissement possible. */
+export function receivedMethodFromPlanned(
+  paymentMethod: PaymentMethodId
+): ReceivedPaymentMethodId {
+  if (RECEIVED_METHOD_SET.has(paymentMethod)) {
+    return paymentMethod as ReceivedPaymentMethodId;
+  }
+  return "other";
+}

--- a/src/lib/club-registration/payment/resolve-remaining-payable.test.ts
+++ b/src/lib/club-registration/payment/resolve-remaining-payable.test.ts
@@ -1,0 +1,90 @@
+import {
+  resolveCheckoutChargeAmounts,
+  resolveRemainingPayableCents,
+} from "./resolve-remaining-payable";
+import type { ReceivedPayment, RegistrationPayment } from "./types";
+
+function payment(overrides: Partial<RegistrationPayment> = {}): RegistrationPayment {
+  return {
+    totalAmountCents: 30_000,
+    assistanceTotalAmountCents: 0,
+    amountToPayCents: 30_000,
+    aids: [],
+    paymentMethod: "cheque",
+    paymentInstallments: 3,
+    expectedPayments: [],
+    receivedPayments: [],
+    paidAmountCents: 0,
+    remainingAmountCents: 30_000,
+    paymentStatus: "waiting_payment",
+    ...overrides,
+  };
+}
+
+function cashReceived(amountCents: number): ReceivedPayment {
+  return {
+    id: "rp_cash",
+    method: "cash",
+    label: "Espèces",
+    amountCents,
+    receivedAt: "2026-08-17T10:00:00.000Z",
+  };
+}
+
+describe("resolveRemainingPayableCents", () => {
+  it("CAS A — mode prévu chèque, 300 €, aucun encaissement → reste 300 €", () => {
+    expect(resolveRemainingPayableCents(payment())).toBe(30_000);
+  });
+
+  it("CAS B — 100 € espèces reçus → reste 200 €, mode prévu inchangé", () => {
+    const partial = payment({
+      receivedPayments: [cashReceived(10_000)],
+      paidAmountCents: 10_000,
+      remainingAmountCents: 20_000,
+      paymentStatus: "partially_paid",
+    });
+    expect(resolveRemainingPayableCents(partial)).toBe(20_000);
+    expect(partial.paymentMethod).toBe("cheque");
+  });
+
+  it("retourne 0 si le dossier est soldé", () => {
+    expect(
+      resolveRemainingPayableCents(
+        payment({
+          paidAmountCents: 30_000,
+          remainingAmountCents: 0,
+          paymentStatus: "paid",
+        })
+      )
+    ).toBe(0);
+  });
+
+  it("retourne 0 sans objet payment", () => {
+    expect(resolveRemainingPayableCents(null)).toBe(0);
+  });
+});
+
+describe("resolveCheckoutChargeAmounts", () => {
+  it("CAS C/H — Checkout et relance utilisent le solde, pas le net initial", () => {
+    const amounts = resolveCheckoutChargeAmounts(
+      payment({
+        receivedPayments: [cashReceived(10_000)],
+        paidAmountCents: 10_000,
+        remainingAmountCents: 20_000,
+        paymentStatus: "partially_paid",
+      }),
+      30_000
+    );
+    expect(amounts.amountToPayCents).toBe(30_000);
+    expect(amounts.alreadyPaidCents).toBe(10_000);
+    expect(amounts.remainingPayableCents).toBe(20_000);
+  });
+
+  it("sans payment, retombe sur le montant fourni", () => {
+    expect(resolveCheckoutChargeAmounts(null, 15_000)).toEqual({
+      amountToPayCents: 15_000,
+      alreadyPaidCents: 0,
+      remainingPayableCents: 15_000,
+    });
+  });
+});

--- a/src/lib/club-registration/payment/resolve-remaining-payable.ts
+++ b/src/lib/club-registration/payment/resolve-remaining-payable.ts
@@ -1,0 +1,43 @@
+import type { RegistrationPayment } from "./types";
+
+/**
+ * Montant réellement encore payable maintenant.
+ * `amountToPayCents` = net après aides ; le solde déduit déjà les encaissements.
+ */
+export function resolveRemainingPayableCents(
+  payment: RegistrationPayment | null | undefined
+): number {
+  if (!payment) {
+    return 0;
+  }
+  return Math.max(0, payment.remainingAmountCents);
+}
+
+export type CheckoutChargeAmounts = {
+  amountToPayCents: number;
+  alreadyPaidCents: number;
+  remainingPayableCents: number;
+};
+
+/**
+ * Distingue le net après aides du solde à encaisser (Checkout, e-mails, relances).
+ */
+export function resolveCheckoutChargeAmounts(
+  payment: RegistrationPayment | null | undefined,
+  fallbackAmountToPayCents: number
+): CheckoutChargeAmounts {
+  const amountToPayCents = Math.max(
+    0,
+    payment?.amountToPayCents ?? fallbackAmountToPayCents
+  );
+  const alreadyPaidCents = Math.max(0, payment?.paidAmountCents ?? 0);
+  const remainingPayableCents = payment
+    ? resolveRemainingPayableCents(payment)
+    : amountToPayCents;
+
+  return {
+    amountToPayCents,
+    alreadyPaidCents,
+    remainingPayableCents,
+  };
+}

--- a/src/lib/club-registration/payment/settlement-firestore.ts
+++ b/src/lib/club-registration/payment/settlement-firestore.ts
@@ -1,0 +1,22 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { paymentToFirestoreUpdate } from "./normalize-payment";
+import type { RegistrationPayment } from "./types";
+
+export function shouldMarkRegistrationPaid(payment: RegistrationPayment): boolean {
+  return payment.remainingAmountCents === 0 && payment.paymentStatus === "paid";
+}
+
+/** Champs Firestore à merger après un encaissement (y compris soldé). */
+export function paymentWriteWithSettlement(
+  payment: RegistrationPayment
+): Record<string, unknown> {
+  return {
+    ...paymentToFirestoreUpdate(payment),
+    ...(shouldMarkRegistrationPaid(payment)
+      ? {
+          status: "paid",
+          paidAt: FieldValue.serverTimestamp(),
+        }
+      : {}),
+  };
+}

--- a/src/lib/club-registration/request-payment-checkout.ts
+++ b/src/lib/club-registration/request-payment-checkout.ts
@@ -16,7 +16,6 @@ import {
 } from "@/lib/club-registration/payment/normalize-payment";
 import {
   recalculateRegistrationPayment,
-  regenerateExpectedPayments,
   setManualFollowUp,
 } from "@/lib/club-registration/payment/payment-mutations";
 import { renderInvoiceHeader } from "@/lib/club-registration-config/helpers";
@@ -57,6 +56,7 @@ export async function processManualPaymentFollowUp(params: {
   adherentName: string;
   baseUrl: string;
   requestedByUid: string;
+  payableCents?: number;
 }): Promise<{ success: true } | { success: false; error: string }> {
   const paymentInstallments = params.payment?.paymentInstallments ?? 1;
   const baseManualPayment: RegistrationPayment =
@@ -94,7 +94,7 @@ export async function processManualPaymentFollowUp(params: {
 
   const instructionsMail = buildPaymentInstructionsEmail({
     adherentName: params.adherentName,
-    amountCents: params.amountToPayCents,
+    amountCents: params.payableCents ?? params.amountToPayCents,
     registrationId: params.registrationId,
     appOrigin: params.baseUrl,
     paymentMethod: manualPayment.paymentMethod,
@@ -135,7 +135,7 @@ export async function processManualPaymentFollowUp(params: {
     resource: "clubRegistration",
     resourceId: params.registrationId,
     details: {
-      amountCents: params.amountToPayCents,
+      amountCents: params.payableCents ?? params.amountToPayCents,
       manualFollowUp: true,
       paymentMethod: manualPayment.paymentMethod,
       donationCents: params.donationPricing?.voluntaryDonationCents ?? 0,
@@ -155,14 +155,10 @@ export function recalculatePaymentForRequest(
   if (!payment || !quote) {
     return payment;
   }
-  let updated = recalculateRegistrationPayment({
+  return recalculateRegistrationPayment({
     ...payment,
     totalAmountCents: invoiceTotalCents,
   });
-  if (updated.paymentMethod === "card" || updated.paymentMethod === "cheque") {
-    updated = regenerateExpectedPayments(updated);
-  }
-  return updated;
 }
 
 export async function createStripeCheckoutForRegistration(params: {
@@ -172,6 +168,8 @@ export async function createStripeCheckoutForRegistration(params: {
   pricingConfig: RegistrationConfigV1;
   payment: RegistrationPayment | null;
   amountToPayCents: number;
+  alreadyPaidCents?: number;
+  remainingPayableCents?: number;
   paymentEmail: string;
   adherentName: string;
   successUrl: string;
@@ -185,6 +183,9 @@ export async function createStripeCheckoutForRegistration(params: {
     params.donationPricing != null &&
     params.donationPricing.invoiceTotalCents > 0;
 
+  const remainingPayableCents = params.remainingPayableCents ?? params.amountToPayCents;
+  const alreadyPaidCents = Math.max(0, params.alreadyPaidCents ?? 0);
+
   if (useQuoteLineItems && params.quote && params.donationPricing) {
     const validation = validateRegistrationStripeCheckout({
       quote: params.quote,
@@ -192,6 +193,8 @@ export async function createStripeCheckoutForRegistration(params: {
       pricingConfig: params.pricingConfig,
       payment: params.payment,
       amountToPayCents: params.amountToPayCents,
+      alreadyPaidCents,
+      remainingPayableCents,
     });
     if (!validation.ok) {
       return validation;
@@ -226,6 +229,7 @@ export async function createStripeCheckoutForRegistration(params: {
       donationDiscountCents: donationPricing.donationDiscountCents,
       donationDiscountCouponName: stripePresentation.donationDiscountCouponName,
       aids: paymentAids,
+      alreadyPaidCents,
     });
 
     const session = await createMembershipCheckoutSession({
@@ -261,7 +265,7 @@ export async function createStripeCheckoutForRegistration(params: {
 
   const session = await createLegacySingleLineCheckoutSession({
     registrationId: params.registrationId,
-    amountCents: params.amountToPayCents,
+    amountCents: remainingPayableCents,
     customerEmail: params.paymentEmail,
     adherentName: params.adherentName,
     successUrl: params.successUrl,

--- a/src/lib/club-registration/self-service-checkout.test.ts
+++ b/src/lib/club-registration/self-service-checkout.test.ts
@@ -27,7 +27,29 @@ describe("self-service-checkout", () => {
     ).toBe(true);
   });
 
-  it("refuse si déjà payé ou hors carte", () => {
+  it("CAS F — autorise le self-service même si le mode prévu n'est pas carte", () => {
+    expect(
+      canSelfServiceCheckout({
+        status: "payment_requested",
+        paymentAmountCents: 22_400,
+        payment: {
+          paymentMethod: "cheque",
+          amountToPayCents: 22_400,
+          totalAmountCents: 22_400,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 0,
+          remainingAmountCents: 22_400,
+          paymentStatus: "waiting_payment",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("CAS G — refuse si déjà payé ou dossier pas encore prêt", () => {
     expect(
       canSelfServiceCheckout({
         status: "paid",
@@ -44,26 +66,6 @@ describe("self-service-checkout", () => {
         paymentAmountCents: 22_400,
         payment: {
           paymentMethod: "card",
-          amountToPayCents: 22_400,
-          totalAmountCents: 22_400,
-          assistanceTotalAmountCents: 0,
-          aids: [],
-          paymentInstallments: 1,
-          expectedPayments: [],
-          receivedPayments: [],
-          paidAmountCents: 0,
-          remainingAmountCents: 22_400,
-          paymentStatus: "waiting_payment",
-        },
-      })
-    ).toBe(false);
-
-    expect(
-      canSelfServiceCheckout({
-        status: "payment_requested",
-        paymentAmountCents: 22_400,
-        payment: {
-          paymentMethod: "cheque",
           amountToPayCents: 22_400,
           totalAmountCents: 22_400,
           assistanceTotalAmountCents: 0,
@@ -106,10 +108,28 @@ describe("self-service-checkout", () => {
         },
       })
     ).toBe(22_400);
+    expect(
+      resolveSelfServicePayableCents({
+        paymentAmountCents: 30_000,
+        payment: {
+          paymentMethod: "cheque",
+          amountToPayCents: 30_000,
+          totalAmountCents: 30_000,
+          assistanceTotalAmountCents: 0,
+          aids: [],
+          paymentInstallments: 1,
+          expectedPayments: [],
+          receivedPayments: [],
+          paidAmountCents: 10_000,
+          remainingAmountCents: 20_000,
+          paymentStatus: "partially_paid",
+        },
+      })
+    ).toBe(20_000);
     expect(resolveSelfServicePayableCents({ paymentAmountCents: 15_000 })).toBe(15_000);
   });
 
-  it("détecte l'attente hors carte", () => {
+  it("n'affiche plus l'attente hors carte si le self-service Stripe est ouvert", () => {
     expect(
       isAwaitingNonCardPayment({
         status: "payment_requested",
@@ -128,7 +148,7 @@ describe("self-service-checkout", () => {
           paymentStatus: "waiting_payment",
         },
       })
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isAwaitingNonCardPayment({
         status: "payment_requested",

--- a/src/lib/club-registration/self-service-checkout.ts
+++ b/src/lib/club-registration/self-service-checkout.ts
@@ -1,4 +1,5 @@
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import { resolveRemainingPayableCents } from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
 import type { PaymentMethodId } from "@/lib/club-registration/payment-constants";
 
@@ -17,8 +18,8 @@ export function resolveRegistrationPaymentMethod(
 
 export function resolveSelfServicePayableCents(data: SelfServiceCheckoutRecord): number {
   const payment = normalizeRegistrationPayment(data);
-  if (payment && payment.amountToPayCents > 0) {
-    return payment.amountToPayCents;
+  if (payment) {
+    return resolveRemainingPayableCents(payment);
   }
   if (typeof data.paymentAmountCents === "number" && data.paymentAmountCents > 0) {
     return data.paymentAmountCents;
@@ -33,13 +34,13 @@ export function canSelfServiceCheckout(data: SelfServiceCheckoutRecord): boolean
   if (isRegistrationPaidRecord(data)) {
     return false;
   }
-  if (resolveRegistrationPaymentMethod(data) !== "card") {
-    return false;
-  }
   return resolveSelfServicePayableCents(data) > 0;
 }
 
 export function isAwaitingNonCardPayment(data: SelfServiceCheckoutRecord): boolean {
+  if (canSelfServiceCheckout(data)) {
+    return false;
+  }
   if (data.status !== "payment_requested" || isRegistrationPaidRecord(data)) {
     return false;
   }

--- a/src/lib/club-registration/spreadsheet/column-labels.ts
+++ b/src/lib/club-registration/spreadsheet/column-labels.ts
@@ -70,7 +70,7 @@ export const SPREADSHEET_COLUMN_LABELS: Record<SpreadsheetColumnId, string> = {
   handisportPracticeLevel: "Niveau handisport",
   paymentStripeLineItems: "Lignes Stripe",
   payment: "Suivi paiement",
-  paymentMethod: "Mode de paiement",
+  paymentMethod: "Mode prévu",
   paymentInstallments: "Échéances",
   paymentAids: "Aides",
   holidayVoucherAmountCents: "Chèques vacances (centimes)",

--- a/src/lib/club-registration/stripe-checkout-discounts.test.ts
+++ b/src/lib/club-registration/stripe-checkout-discounts.test.ts
@@ -3,6 +3,7 @@ import {
   assertStripePayableAfterDiscounts,
   buildMergedCheckoutDiscountCouponName,
   computeSecretariatAidDiscountCents,
+  sumCheckoutDiscountCents,
   sumPaymentAidDiscountCents,
 } from "./stripe-checkout-discounts";
 
@@ -53,6 +54,50 @@ describe("stripe-checkout-discounts", () => {
         aids: [{ type: "pass_sport", label: "Pass Sport", amountCents: 2_000 }],
       })
     ).toBe("Remise don libre + Pass Sport");
+  });
+
+  it("valide le solde après un encaissement déjà reçu", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 30_000,
+        donationDiscountCents: 0,
+        aidDiscountCents: 0,
+        amountToPayCents: 30_000,
+        alreadyPaidCents: 10_000,
+        remainingPayableCents: 20_000,
+      })
+    ).not.toThrow();
+  });
+
+  it("rejette un Checkout au montant initial après paiement partiel", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 30_000,
+        donationDiscountCents: 0,
+        aidDiscountCents: 0,
+        amountToPayCents: 30_000,
+        alreadyPaidCents: 10_000,
+        remainingPayableCents: 30_000,
+      })
+    ).toThrow("Incohérence solde Stripe");
+  });
+
+  it("inclut le déjà encaissé dans le coupon Checkout", () => {
+    expect(
+      sumCheckoutDiscountCents({
+        donationDiscountCents: 0,
+        aids: [],
+        alreadyPaidCents: 10_000,
+      })
+    ).toBe(10_000);
+    expect(
+      buildMergedCheckoutDiscountCouponName({
+        donationDiscountCents: 0,
+        donationDiscountCouponName: "Remise don libre",
+        aids: [],
+        alreadyPaidCents: 10_000,
+      })
+    ).toBe("Déjà encaissé");
   });
 
   it("somme les aides", () => {

--- a/src/lib/club-registration/stripe-checkout-discounts.ts
+++ b/src/lib/club-registration/stripe-checkout-discounts.ts
@@ -16,23 +16,41 @@ export function buildMergedCheckoutDiscountCouponName(params: {
   donationDiscountCents: number;
   donationDiscountCouponName: string;
   aids: PaymentAid[];
+  alreadyPaidCents?: number;
 }): string {
   const activeAids = params.aids.filter((aid) => aid.amountCents > 0);
   const hasDonation = params.donationDiscountCents > 0;
+  const hasAlreadyPaid = (params.alreadyPaidCents ?? 0) > 0;
 
-  if (hasDonation && activeAids.length === 0) {
+  if (hasAlreadyPaid && !hasDonation && activeAids.length === 0) {
+    return "Déjà encaissé";
+  }
+
+  if (hasDonation && activeAids.length === 0 && !hasAlreadyPaid) {
     return params.donationDiscountCouponName;
   }
-  if (!hasDonation && activeAids.length === 1) {
+  if (!hasDonation && activeAids.length === 1 && !hasAlreadyPaid) {
     return activeAids[0]!.label;
   }
-  if (!hasDonation && activeAids.length > 1) {
+  if (!hasDonation && activeAids.length > 1 && !hasAlreadyPaid) {
     return "Remises aides secrétariat";
   }
-  if (hasDonation && activeAids.length === 1) {
+  if (hasDonation && activeAids.length === 1 && !hasAlreadyPaid) {
     return `${params.donationDiscountCouponName} + ${activeAids[0]!.label}`;
   }
   return "Remises adhésion";
+}
+
+export function sumCheckoutDiscountCents(params: {
+  donationDiscountCents: number;
+  aids: PaymentAid[];
+  alreadyPaidCents?: number;
+}): number {
+  return (
+    Math.max(0, params.donationDiscountCents) +
+    sumPaymentAidDiscountCents(params.aids) +
+    Math.max(0, params.alreadyPaidCents ?? 0)
+  );
 }
 
 /** Montant total des coupons « aides secrétariat » à appliquer sur la facture. */
@@ -59,6 +77,8 @@ export function assertStripePayableAfterDiscounts(params: {
   donationDiscountCents: number;
   aidDiscountCents: number;
   amountToPayCents: number;
+  alreadyPaidCents?: number;
+  remainingPayableCents?: number;
 }): void {
   void params.donationDiscountCents;
   const expectedPayable = params.invoiceTotalCents - params.aidDiscountCents;
@@ -66,6 +86,16 @@ export function assertStripePayableAfterDiscounts(params: {
     throw new Error(
       `Incohérence montant Stripe : facture ${params.invoiceTotalCents} cts, aides ${params.aidDiscountCents} cts, attendu ${params.amountToPayCents} cts, calculé ${expectedPayable} cts`
     );
+  }
+
+  if (params.remainingPayableCents != null) {
+    const alreadyPaid = Math.max(0, params.alreadyPaidCents ?? 0);
+    const expectedRemaining = Math.max(0, params.amountToPayCents - alreadyPaid);
+    if (expectedRemaining !== params.remainingPayableCents) {
+      throw new Error(
+        `Incohérence solde Stripe : net ${params.amountToPayCents} cts, déjà encaissé ${alreadyPaid} cts, attendu ${params.remainingPayableCents} cts, calculé ${expectedRemaining} cts`
+      );
+    }
   }
 }
 
@@ -79,10 +109,15 @@ export async function createCheckoutDiscountCouponIds(params: {
   donationDiscountCents: number;
   donationDiscountCouponName: string;
   aids: PaymentAid[];
+  alreadyPaidCents?: number;
 }): Promise<string[]> {
-  const aidTotal = sumPaymentAidDiscountCents(params.aids);
   const donationDiscount = Math.max(0, params.donationDiscountCents);
-  const totalOff = donationDiscount + aidTotal;
+  const alreadyPaidCents = Math.max(0, params.alreadyPaidCents ?? 0);
+  const totalOff = sumCheckoutDiscountCents({
+    donationDiscountCents: donationDiscount,
+    aids: params.aids,
+    alreadyPaidCents,
+  });
 
   if (totalOff <= 0) {
     return [];
@@ -96,6 +131,7 @@ export async function createCheckoutDiscountCouponIds(params: {
         donationDiscountCents: donationDiscount,
         donationDiscountCouponName: params.donationDiscountCouponName,
         aids: params.aids,
+        alreadyPaidCents,
       })
     ),
     kind: "merged_checkout_discount",

--- a/src/lib/club-registration/stripe-payment-capability.test.ts
+++ b/src/lib/club-registration/stripe-payment-capability.test.ts
@@ -11,26 +11,24 @@ describe("createStripePaymentForRegistration", () => {
     ).resolves.toEqual({ supported: true });
   });
 
-  it("refuse le mode chèque", async () => {
+  it("autorise Stripe même si le mode prévu est chèque", async () => {
     const result = await createStripePaymentForRegistration({
       registrationId: "reg_1",
       amountToPayCents: 12_000,
       paymentMethod: "cheque",
     });
 
-    expect(result.supported).toBe(false);
-    expect(result.reason).toContain("Chèque");
+    expect(result.supported).toBe(true);
   });
 
-  it("refuse les chèques vacances", async () => {
+  it("autorise Stripe pour les chèques vacances", async () => {
     const result = await createStripePaymentForRegistration({
       registrationId: "reg_1",
       amountToPayCents: 12_000,
       paymentMethod: "holiday_vouchers",
     });
 
-    expect(result.supported).toBe(false);
-    expect(result.reason).toContain("Chèques vacances");
+    expect(result.supported).toBe(true);
   });
 
   it("refuse un montant nul", async () => {

--- a/src/lib/club-registration/stripe.ts
+++ b/src/lib/club-registration/stripe.ts
@@ -4,10 +4,7 @@ import type {
   StripeCheckoutLineItem,
   StripeInvoiceCustomField,
 } from "@/lib/pricing/stripe-checkout-lines";
-import {
-  PAYMENT_METHOD_LABELS,
-  type PaymentMethodId,
-} from "@/lib/club-registration/payment-constants";
+import type { PaymentMethodId } from "@/lib/club-registration/payment-constants";
 
 export interface StripeCheckoutSession {
   id: string;
@@ -375,22 +372,16 @@ export function pickInvoiceDownloadUrl(links: StripeInvoiceLinks): string | null
 
 /**
  * Point d'extension pour le paiement CB en ligne via Checkout (carte ou BNPL sur Stripe).
- * Les autres modes passent en suivi secrétariat.
+ * Le mode prévu à l'inscription n'interdit plus un règlement en ligne du solde.
  */
 export async function createStripePaymentForRegistration(params: {
   registrationId: string;
   amountToPayCents: number;
-  paymentMethod: PaymentMethodId;
+  paymentMethod?: PaymentMethodId;
 }): Promise<{ supported: boolean; reason?: string }> {
+  void params.paymentMethod;
   if (params.amountToPayCents <= 0) {
     return { supported: false, reason: "Aucun montant à régler" };
-  }
-
-  if (params.paymentMethod !== "card") {
-    return {
-      supported: false,
-      reason: `Mode « ${PAYMENT_METHOD_LABELS[params.paymentMethod]} » : pas de lien de paiement en ligne. Suivez les encaissements dans le tableau ci-dessous.`,
-    };
   }
 
   return { supported: true };


### PR DESCRIPTION
## Summary
- Release staging → main : le mode de règlement choisi à l’inscription est une intention, pas une contrainte.
- Stripe et les relances portent sur le solde restant ; le secrétariat voit clairement le montant demandé par le lien de paiement.

## Test plan
- [ ] Dossier chèque avec encaissement partiel : le bouton Stripe affiche le solde (ex. 190 €), pas le net (ex. 290 €).
- [ ] Inscription carte : parcours Stripe inchangé.


Made with [Cursor](https://cursor.com)