### PR TITLE
feat(club-registration): complément chèques vacances en ligne

### DIFF
--- a/src/app/api/club/registration/[id]/checkout/route.ts
+++ b/src/app/api/club/registration/[id]/checkout/route.ts
@@ -26,7 +26,11 @@ import {
   canSelfServiceCheckout,
   resolveSelfServicePayableCents,
 } from "@/lib/club-registration/self-service-checkout";
-import { resolveCheckoutChargeAmounts } from "@/lib/club-registration/payment/resolve-remaining-payable";
+import {
+  parseStripeChargeMode,
+  resolveCheckoutChargeAmounts,
+  resolveStripeChargeForMode,
+} from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import type { PriceQuote } from "@/lib/pricing/types";
 
@@ -128,9 +132,11 @@ export async function POST(
       payment,
       resolveSelfServicePayableCents(data)
     );
+    const body = ((await req.json().catch(() => ({}))) ?? {}) as { charge?: unknown };
+    const stripeCharge = resolveStripeChargeForMode(charge, parseStripeChargeMode(body.charge));
 
-    if (charge.remainingPayableCents <= 0) {
-      return jsonNoStore({ error: "Aucun montant à régler pour ce dossier." }, { status: 400 });
+    if (stripeCharge.stripeCents <= 0) {
+      return jsonNoStore({ error: "Aucun montant à régler en ligne pour ce dossier." }, { status: 400 });
     }
 
     const checkoutResult = await createStripeCheckoutForRegistration({
@@ -141,7 +147,8 @@ export async function POST(
       payment,
       amountToPayCents: charge.amountToPayCents,
       alreadyPaidCents: charge.alreadyPaidCents,
-      remainingPayableCents: charge.remainingPayableCents,
+      remainingPayableCents: stripeCharge.stripeCents,
+      reservedHolidayVoucherCents: stripeCharge.reservedHolidayVoucherCents,
       paymentEmail,
       adherentName,
       successUrl,
@@ -169,7 +176,7 @@ export async function POST(
       resource: "clubRegistration",
       resourceId: id,
       details: {
-        amountCents: charge.remainingPayableCents,
+        amountCents: stripeCharge.stripeCents,
         stripeCheckoutSessionId: checkoutResult.result.session.id,
         selfService: true,
       },

--- a/src/app/api/club/registration/[id]/request-payment/route.ts
+++ b/src/app/api/club/registration/[id]/request-payment/route.ts
@@ -16,7 +16,11 @@ import {
   paymentToFirestoreUpdate,
 } from "@/lib/club-registration/payment/normalize-payment";
 import { recalculateRegistrationPayment } from "@/lib/club-registration/payment/payment-mutations";
-import { resolveCheckoutChargeAmounts } from "@/lib/club-registration/payment/resolve-remaining-payable";
+import {
+  parseStripeChargeMode,
+  resolveCheckoutChargeAmounts,
+  resolveStripeChargeForMode,
+} from "@/lib/club-registration/payment/resolve-remaining-payable";
 import {
   calculateQuoteForRecord,
   resolveRegistrationConfigForRecord,
@@ -76,6 +80,7 @@ export async function POST(
     const body = ((await req.json().catch(() => ({}))) ?? {}) as {
       amountCents?: number;
       channel?: "stripe" | "instructions";
+      charge?: unknown;
     };
 
     const db = getFirestoreAdmin();
@@ -269,9 +274,24 @@ export async function POST(
       );
     }
 
+    const stripeCharge = resolveStripeChargeForMode(
+      charge,
+      parseStripeChargeMode(body.charge)
+    );
+
+    if (stripeCharge.stripeCents <= 0) {
+      return jsonNoStore(
+        {
+          error:
+            "Aucun montant à demander en ligne : le solde restant est prévu hors carte (chèques vacances).",
+        },
+        { status: 400 }
+      );
+    }
+
     const stripeCapability = await createStripePaymentForRegistration({
       registrationId: id,
-      amountToPayCents: payableCents,
+      amountToPayCents: stripeCharge.stripeCents,
       paymentMethod,
     });
 
@@ -289,7 +309,8 @@ export async function POST(
       payment,
       amountToPayCents,
       alreadyPaidCents: charge.alreadyPaidCents,
-      remainingPayableCents: payableCents,
+      remainingPayableCents: stripeCharge.stripeCents,
+      reservedHolidayVoucherCents: stripeCharge.reservedHolidayVoucherCents,
     });
     if (!checkoutValidation.ok) {
       return jsonNoStore(checkoutValidation.body, { status: checkoutValidation.status });
@@ -302,7 +323,7 @@ export async function POST(
       quote,
       donationPricing,
       amountToPayCents,
-      payableCents,
+      payableCents: stripeCharge.stripeCents,
       paymentEmails,
       adherentName,
       baseUrl,

--- a/src/components/club-registration/MesInscriptionPayOnlineButton.tsx
+++ b/src/components/club-registration/MesInscriptionPayOnlineButton.tsx
@@ -7,12 +7,17 @@ import {
   ADHERENT_NON_CARD_PAYMENT_HINT,
   ADHERENT_PAY_ONLINE_BUTTON_LABEL,
   ADHERENT_PAY_ONLINE_HELPER,
+  ADHERENT_PAY_REMAINING_BUTTON_LABEL,
+  ADHERENT_PAY_REMAINING_HELPER,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import {
-  canSelfServiceCheckout,
+  canSelfServiceOnlineCheckout,
+  canSelfServiceRemainingOverride,
   isAwaitingNonCardPayment,
   type SelfServiceCheckoutRecord,
 } from "@/lib/club-registration/self-service-checkout";
+
+type ChargeMode = "online" | "remaining";
 
 type Props = {
   registration: SelfServiceCheckoutRecord & { id: string };
@@ -20,64 +25,95 @@ type Props = {
 };
 
 export function MesInscriptionPayOnlineButton({ registration, onError }: Props) {
-  const [loading, setLoading] = useState(false);
+  const [loadingCharge, setLoadingCharge] = useState<ChargeMode | null>(null);
+  const canPayOnline = canSelfServiceOnlineCheckout(registration);
+  const canPayRemaining = canSelfServiceRemainingOverride(registration);
 
-  if (canSelfServiceCheckout(registration)) {
-    const handlePay = async () => {
-      setLoading(true);
-      onError(null);
-      try {
-        const res = await fetch(
-          `/api/club/registration/${encodeURIComponent(registration.id)}/checkout`,
-          {
-            method: "POST",
-            credentials: "include",
-            headers: { "Content-Type": "application/json" },
-          }
-        );
-        const json = (await res.json().catch(() => ({}))) as {
-          checkoutUrl?: string;
-          error?: string;
-        };
-        if (!res.ok || !json.checkoutUrl) {
-          throw new Error(json.error || "Impossible d'ouvrir la page de paiement.");
+  if (!canPayOnline && !canPayRemaining) {
+    if (isAwaitingNonCardPayment(registration)) {
+      return (
+        <Typography variant="caption" color="text.secondary" sx={{ width: "100%" }}>
+          {ADHERENT_NON_CARD_PAYMENT_HINT}
+        </Typography>
+      );
+    }
+    return null;
+  }
+
+  const handlePay = async (charge: ChargeMode) => {
+    setLoadingCharge(charge);
+    onError(null);
+    try {
+      const res = await fetch(
+        `/api/club/registration/${encodeURIComponent(registration.id)}/checkout`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(charge === "remaining" ? { charge: "remaining" } : {}),
         }
-        window.location.assign(json.checkoutUrl);
-      } catch (err) {
-        onError(err instanceof Error ? err.message : "Impossible d'ouvrir la page de paiement.");
-        setLoading(false);
+      );
+      const json = (await res.json().catch(() => ({}))) as {
+        checkoutUrl?: string;
+        error?: string;
+      };
+      if (!res.ok || !json.checkoutUrl) {
+        throw new Error(json.error || "Impossible d'ouvrir la page de paiement.");
       }
-    };
+      window.location.assign(json.checkoutUrl);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Impossible d'ouvrir la page de paiement.");
+      setLoadingCharge(null);
+    }
+  };
 
-    return (
-      <>
+  const loading = loadingCharge != null;
+
+  return (
+    <>
+      {canPayOnline ? (
         <Button
           size="small"
           variant="contained"
           color="secondary"
           startIcon={
-            loading ? <CircularProgress size={16} color="inherit" /> : <PaymentIcon fontSize="small" />
+            loadingCharge === "online" ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <PaymentIcon fontSize="small" />
+            )
           }
           disabled={loading}
-          onClick={() => void handlePay()}
+          onClick={() => void handlePay("online")}
           sx={{ alignSelf: { xs: "stretch", sm: "auto" }, flexShrink: 0 }}
         >
-          {loading ? "Redirection…" : ADHERENT_PAY_ONLINE_BUTTON_LABEL}
+          {loadingCharge === "online" ? "Redirection…" : ADHERENT_PAY_ONLINE_BUTTON_LABEL}
         </Button>
-        <Typography variant="caption" color="text.secondary" sx={{ width: "100%" }}>
-          {ADHERENT_PAY_ONLINE_HELPER}
-        </Typography>
-      </>
-    );
-  }
-
-  if (isAwaitingNonCardPayment(registration)) {
-    return (
+      ) : null}
+      {canPayRemaining ? (
+        <Button
+          size="small"
+          variant={canPayOnline ? "outlined" : "contained"}
+          color="secondary"
+          startIcon={
+            loadingCharge === "remaining" ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <PaymentIcon fontSize="small" />
+            )
+          }
+          disabled={loading}
+          onClick={() => void handlePay("remaining")}
+          sx={{ alignSelf: { xs: "stretch", sm: "auto" }, flexShrink: 0 }}
+        >
+          {loadingCharge === "remaining"
+            ? "Redirection…"
+            : ADHERENT_PAY_REMAINING_BUTTON_LABEL}
+        </Button>
+      ) : null}
       <Typography variant="caption" color="text.secondary" sx={{ width: "100%" }}>
-        {ADHERENT_NON_CARD_PAYMENT_HINT}
+        {canPayRemaining ? ADHERENT_PAY_REMAINING_HELPER : ADHERENT_PAY_ONLINE_HELPER}
       </Typography>
-    );
-  }
-
-  return null;
+    </>
+  );
 }

--- a/src/components/club-registration/PaymentStep.tsx
+++ b/src/components/club-registration/PaymentStep.tsx
@@ -204,8 +204,10 @@ export function PaymentStep({ draft, onChange }: Props) {
       {draft.paymentMethod === "holiday_vouchers" ? (
         <Stack spacing={2}>
           <Alert severity="info" variant="outlined">
-            Les chèques vacances peuvent couvrir tout ou partie du règlement. En cas
-            de complément, le secrétariat vous indiquera la marche à suivre.
+            Les chèques vacances peuvent couvrir tout ou partie du règlement. Un
+            complément éventuel pourra être réglé en ligne après validation du
+            dossier. Si vous changez d&apos;avis, vous pourrez aussi régler tout le
+            solde par carte.
           </Alert>
           <EuroMonetaryInputField
             label="Montant prévu en chèques vacances"

--- a/src/components/club-registration/membership-requests/MembershipRequestDetailFooter.tsx
+++ b/src/components/club-registration/membership-requests/MembershipRequestDetailFooter.tsx
@@ -2,6 +2,7 @@
 
 import { SecretariatPaymentNotesSection } from "../secretariat/SecretariatPaymentNotesSection";
 import { isRegistrationPaymentSettled } from "@/lib/club-registration/resolve-settled-request-payment";
+import { resolveOnlinePayableCents } from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { formatPersonDisplayName } from "@/lib/shared/person-name-format";
 import { DeleteRegistrationSection } from "./DeleteRegistrationSection";
 import type { MembershipRequestDetailState } from "./useMembershipRequestDetail";
@@ -48,6 +49,9 @@ export function MembershipRequestDetailFooter({
         paymentEmailSentTo={selected.paymentEmailSentTo ?? null}
         paymentMethod={selectedPayment?.paymentMethod}
         remainingAmountCents={selectedPayment?.remainingAmountCents ?? null}
+        onlinePayableCents={
+          selectedPayment ? resolveOnlinePayableCents(selectedPayment) : null
+        }
         paymentSettled={isRegistrationPaymentSettled(
           {
             status: selected.status,
@@ -62,6 +66,9 @@ export function MembershipRequestDetailFooter({
         onSave={() => void save()}
         onRequestPayment={requestPayment}
         onRequestOnlinePayment={() => requestPayment("stripe")}
+        onRequestFullRemainingOnline={() =>
+          requestPayment("stripe", { charge: "remaining" })
+        }
       />
 
       {registrationId ? (

--- a/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
+++ b/src/components/club-registration/membership-requests/useMembershipRequestDetail.ts
@@ -360,7 +360,10 @@ export function useMembershipRequestDetail(
     }
   };
 
-  const requestPayment = async (channel?: "stripe" | "instructions") => {
+  const requestPayment = async (
+    channel?: "stripe" | "instructions",
+    options?: { charge?: "online" | "remaining" }
+  ) => {
     if (!registrationId || !form) return;
     const amountCents = parseAmountCents(form.amountEuros);
     if (amountCents === null || amountCents < 0) {
@@ -387,6 +390,7 @@ export function useMembershipRequestDetail(
           body: JSON.stringify({
             amountCents,
             ...(channel ? { channel } : {}),
+            ...(options?.charge ? { charge: options.charge } : {}),
           }),
         }
       );

--- a/src/components/club-registration/mes-inscriptions-shared.ts
+++ b/src/components/club-registration/mes-inscriptions-shared.ts
@@ -1,4 +1,6 @@
 import type { MedicalCertificateStatus } from "@/lib/club-registration/medical-certificate";
+import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import { resolveOnlinePayableCents } from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { getEnabledSections } from "@/lib/club-registration-config/helpers";
 import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
 
@@ -72,6 +74,18 @@ export function formatMesInscriptionAmount(cents: number | undefined): string | 
 export function formatMesInscriptionPayableAmount(
   registration: MesInscriptionSummary
 ): string | null {
+  const payment = normalizeRegistrationPayment(
+    registration as unknown as Record<string, unknown>
+  );
+  if (payment) {
+    const online = resolveOnlinePayableCents(payment);
+    if (online > 0) {
+      return formatMesInscriptionAmount(online);
+    }
+    if (payment.remainingAmountCents > 0) {
+      return formatMesInscriptionAmount(payment.remainingAmountCents);
+    }
+  }
   const remaining = registration.payment?.remainingAmountCents;
   if (typeof remaining === "number") {
     return formatMesInscriptionAmount(remaining);

--- a/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
+++ b/src/components/club-registration/secretariat/SecretariatPaymentNotesSection.tsx
@@ -21,6 +21,8 @@ import {
   SECRETARIAT_SELF_SERVICE_HINT,
   SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON,
   SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP,
+  SECRETARIAT_SEND_FULL_REMAINING_ONLINE_BUTTON,
+  SECRETARIAT_SEND_FULL_REMAINING_ONLINE_TOOLTIP,
 } from "@/lib/club-registration/payment/bnpl-checkout-copy";
 import { resolveSecretariatPaymentCta } from "@/lib/club-registration/payment/secretariat-payment-action";
 import { centsToEurosInput } from "@/lib/club-registration/payment/payment-draft-helpers";
@@ -40,6 +42,7 @@ type Props = {
   paymentEmailSentTo?: string | null | undefined;
   paymentMethod?: PaymentMethodId | null | undefined;
   remainingAmountCents?: number | null;
+  onlinePayableCents?: number | null;
   paymentSettled?: boolean;
   saving: boolean;
   requestingPayment: boolean;
@@ -47,6 +50,7 @@ type Props = {
   onSave: () => void | Promise<void>;
   onRequestPayment: () => void | Promise<void>;
   onRequestOnlinePayment?: () => void | Promise<void>;
+  onRequestFullRemainingOnline?: () => void | Promise<void>;
 };
 
 const tooltipEnterProps = { enterDelay: 400, enterNextDelay: 400 } as const;
@@ -88,6 +92,7 @@ export function SecretariatPaymentNotesSection({
   paymentEmailSentTo,
   paymentMethod,
   remainingAmountCents = null,
+  onlinePayableCents = null,
   paymentSettled = false,
   saving,
   requestingPayment,
@@ -95,8 +100,10 @@ export function SecretariatPaymentNotesSection({
   onSave,
   onRequestPayment,
   onRequestOnlinePayment,
+  onRequestFullRemainingOnline,
 }: Props) {
   const remaining = remainingAmountCents ?? null;
+  const onlinePayable = onlinePayableCents ?? remaining;
   const paymentCta = resolveSecretariatPaymentCta({
     registrationStatus,
     paymentSettled,
@@ -108,17 +115,30 @@ export function SecretariatPaymentNotesSection({
     paymentCta.kind !== "validate_settled" &&
     Boolean(onRequestOnlinePayment) &&
     paymentMethod !== "card" &&
-    (remaining == null || remaining > 0);
+    (onlinePayable == null || onlinePayable > 0);
+  const canOfferFullRemainingLink =
+    paymentCta.visible &&
+    paymentCta.kind !== "validate_settled" &&
+    Boolean(onRequestFullRemainingOnline) &&
+    remaining != null &&
+    remaining > 0 &&
+    onlinePayable != null &&
+    remaining > onlinePayable;
   const requestedAtLabel = formatPaymentRequestedAt(paymentRequestedAt);
   const remainingLabel = formatAmountCents(remaining);
+  const onlineLabel = formatAmountCents(onlinePayable);
   const netLabel = formatAmountCents(paymentAmountCents);
   const alreadyPaidCents =
     remaining != null && paymentAmountCents != null && remaining < paymentAmountCents
       ? paymentAmountCents - remaining
       : null;
   const hasPartialReceipt = alreadyPaidCents != null && alreadyPaidCents > 0;
+  const hasOfflineRemainder =
+    remaining != null && onlinePayable != null && onlinePayable > 0 && onlinePayable < remaining;
   const chargeButtonLabel =
     remaining != null && remaining > 0 ? remaining : null;
+  const onlineChargeLabel =
+    onlinePayable != null && onlinePayable > 0 ? onlinePayable : null;
 
   return (
     <>
@@ -163,7 +183,7 @@ export function SecretariatPaymentNotesSection({
         {remaining != null ? (
           <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
-              label="Solde qui sera demandé maintenant"
+              label="Solde encore dû"
               value={centsToEurosInput(remaining)}
               fullWidth
               InputProps={{
@@ -175,9 +195,13 @@ export function SecretariatPaymentNotesSection({
                 ),
               }}
               helperText={
-                hasPartialReceipt
-                  ? `${formatAmountCents(alreadyPaidCents)} déjà encaissé. C’est ce solde que le lien Stripe demandera.`
-                  : "Montant du lien de paiement et des instructions."
+                hasOfflineRemainder
+                  ? `Dont ${onlineLabel} en ligne ; le reste est prévu hors carte (chèques vacances).`
+                  : hasPartialReceipt && onlinePayable === remaining
+                    ? `${formatAmountCents(alreadyPaidCents)} déjà encaissé. C’est ce solde que le lien Stripe demandera.`
+                    : hasPartialReceipt
+                      ? `${formatAmountCents(alreadyPaidCents)} déjà encaissé. Le reste est prévu hors carte.`
+                      : "Montant du lien de paiement et des instructions."
               }
             />
           </Grid>
@@ -218,10 +242,24 @@ export function SecretariatPaymentNotesSection({
         </Alert>
       ) : null}
 
-      {hasPartialReceipt && remainingLabel && netLabel && paymentCta.visible ? (
+      {hasOfflineRemainder && onlineLabel ? (
         <Alert severity="warning" variant="outlined">
-          Un encaissement est déjà enregistré. Le lien de paiement demandera{" "}
-          <strong>{remainingLabel}</strong>, pas {netLabel}.
+          Le lien de paiement en ligne demandera <strong>{onlineLabel}</strong> par
+          défaut, pas {remainingLabel}. Si l&apos;adhérent ne remet pas les chèques
+          vacances, vous pouvez demander tout le solde en ligne.
+        </Alert>
+      ) : remaining != null && remaining > 0 && onlinePayable === 0 && remainingLabel ? (
+        <Alert severity="warning" variant="outlined">
+          Le complément carte est déjà encaissé. Le solde {remainingLabel} est prévu
+          en chèques vacances ; vous pouvez quand même demander tout ce solde en
+          ligne si l&apos;adhérent change d&apos;avis.
+        </Alert>
+      ) : hasPartialReceipt && remainingLabel && netLabel && paymentCta.visible ? (
+        <Alert severity="warning" variant="outlined">
+          Un encaissement est déjà enregistré.{" "}
+          {onlineChargeLabel && onlineLabel
+            ? `Le lien de paiement demandera ${onlineLabel}, pas ${netLabel}.`
+            : `Solde restant ${remainingLabel} (hors carte).`}
         </Alert>
       ) : null}
 
@@ -245,8 +283,8 @@ export function SecretariatPaymentNotesSection({
         {canOfferOnlineLink ? (
           <Tooltip
             title={
-              remainingLabel
-                ? `Envoie un e-mail invitant l'adhérent à régler ${remainingLabel} par carte (Stripe), pas le montant net initial.`
+              onlineLabel
+                ? `Envoie un e-mail invitant l'adhérent à régler ${onlineLabel} par carte (Stripe).`
                 : SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP
             }
             slotProps={{ popper: { sx: { maxWidth: 340 } } }}
@@ -262,7 +300,29 @@ export function SecretariatPaymentNotesSection({
               >
                 {withRemainingAmount(
                   SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON,
-                  chargeButtonLabel
+                  onlineChargeLabel
+                )}
+              </Button>
+            </span>
+          </Tooltip>
+        ) : null}
+        {canOfferFullRemainingLink ? (
+          <Tooltip
+            title={SECRETARIAT_SEND_FULL_REMAINING_ONLINE_TOOLTIP}
+            slotProps={{ popper: { sx: { maxWidth: 340 } } }}
+            {...tooltipEnterProps}
+          >
+            <span>
+              <Button
+                variant="outlined"
+                color="secondary"
+                startIcon={<MarkEmailReadIcon />}
+                onClick={() => void onRequestFullRemainingOnline?.()}
+                disabled={saving || requestingPayment || persistingQuote}
+              >
+                {withRemainingAmount(
+                  SECRETARIAT_SEND_FULL_REMAINING_ONLINE_BUTTON,
+                  remaining
                 )}
               </Button>
             </span>

--- a/src/lib/club-registration/membership-requests/registration-card-quick-actions.ts
+++ b/src/lib/club-registration/membership-requests/registration-card-quick-actions.ts
@@ -1,4 +1,5 @@
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
+import { resolveOnlinePayableCents } from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
 import type { RegistrationSummary } from "@/components/club-registration/membership-requests/types";
 
@@ -56,7 +57,7 @@ export function canQuickResendPaymentLink(registration: RegistrationSummary): bo
   const payment =
     registration.payment ??
     normalizeRegistrationPayment(registration as unknown as Record<string, unknown>);
-  if (payment && payment.remainingAmountCents <= 0 && payment.paidAmountCents > 0) {
+  if (payment && resolveOnlinePayableCents(payment) <= 0) {
     return false;
   }
   const amountCents = resolveQuickPaymentAmountCents(registration);

--- a/src/lib/club-registration/payment-requested.ts
+++ b/src/lib/club-registration/payment-requested.ts
@@ -31,6 +31,7 @@ export function validateRegistrationStripeCheckout(params: {
   amountToPayCents: number;
   alreadyPaidCents?: number;
   remainingPayableCents?: number;
+  reservedHolidayVoucherCents?: number;
 }):
   | { ok: true }
   | { ok: false; status: number; body: Record<string, unknown> } {
@@ -89,6 +90,9 @@ export function validateRegistrationStripeCheckout(params: {
         : {}),
       ...(params.remainingPayableCents != null
         ? { remainingPayableCents: params.remainingPayableCents }
+        : {}),
+      ...(params.reservedHolidayVoucherCents != null
+        ? { reservedHolidayVoucherCents: params.reservedHolidayVoucherCents }
         : {}),
     });
   } catch (validationError) {

--- a/src/lib/club-registration/payment/bnpl-checkout-copy.ts
+++ b/src/lib/club-registration/payment/bnpl-checkout-copy.ts
@@ -77,6 +77,12 @@ export const ADHERENT_PAY_ONLINE_BUTTON_LABEL = "Payer en ligne";
 export const ADHERENT_PAY_ONLINE_HELPER =
   "Paiement sécurisé Stripe. Carte ou paiement en plusieurs fois (BNPL) selon éligibilité.";
 
+/** Bouton adhérent — régler tout le solde malgré des CV prévus. */
+export const ADHERENT_PAY_REMAINING_BUTTON_LABEL = "Payer tout le solde par carte";
+
+export const ADHERENT_PAY_REMAINING_HELPER =
+  "Si vous ne remettez pas les chèques vacances, vous pouvez régler tout le reste dû par carte.";
+
 /** Dossier en attente hors carte bancaire. */
 export const ADHERENT_NON_CARD_PAYMENT_HINT =
   "Les instructions de règlement vous ont été envoyées par e-mail.";
@@ -107,7 +113,13 @@ export const SECRETARIAT_SEND_ONLINE_PAYMENT_BUTTON =
   "Envoyer un lien de paiement en ligne";
 
 export const SECRETARIAT_SEND_ONLINE_PAYMENT_TOOLTIP =
-  "Envoie un e-mail invitant l'adhérent à régler le solde restant par carte (Stripe), quel que soit le mode prévu à l'inscription.";
+  "Envoie un e-mail invitant l'adhérent à régler le complément par carte (Stripe), sans encaisser la part prévue en chèques vacances.";
+
+export const SECRETARIAT_SEND_FULL_REMAINING_ONLINE_BUTTON =
+  "Demander tout le solde en ligne";
+
+export const SECRETARIAT_SEND_FULL_REMAINING_ONLINE_TOOLTIP =
+  "Si l'adhérent change d'avis et ne remet pas les chèques vacances, encaisse tout le reste dû par carte.";
 
 /** Liste secrétariat — action rapide renvoi. */
 export const SECRETARIAT_QUICK_RESEND_PAYMENT_LABEL = "Renvoyer le lien";

--- a/src/lib/club-registration/payment/index.ts
+++ b/src/lib/club-registration/payment/index.ts
@@ -52,6 +52,8 @@ export {
 
 export {
   resolveRemainingPayableCents,
+  resolveOnlinePayableCents,
+  resolveUnpaidHolidayVoucherCents,
   resolveCheckoutChargeAmounts,
   type CheckoutChargeAmounts,
 } from "./resolve-remaining-payable";

--- a/src/lib/club-registration/payment/resolve-remaining-payable.test.ts
+++ b/src/lib/club-registration/payment/resolve-remaining-payable.test.ts
@@ -1,6 +1,9 @@
 import {
+  parseStripeChargeMode,
   resolveCheckoutChargeAmounts,
+  resolveOnlinePayableCents,
   resolveRemainingPayableCents,
+  resolveStripeChargeForMode,
 } from "./resolve-remaining-payable";
 import type { ReceivedPayment, RegistrationPayment } from "./types";
 
@@ -78,6 +81,8 @@ describe("resolveCheckoutChargeAmounts", () => {
     expect(amounts.amountToPayCents).toBe(30_000);
     expect(amounts.alreadyPaidCents).toBe(10_000);
     expect(amounts.remainingPayableCents).toBe(20_000);
+    expect(amounts.onlinePayableCents).toBe(20_000);
+    expect(amounts.reservedHolidayVoucherCents).toBe(0);
   });
 
   it("sans payment, retombe sur le montant fourni", () => {
@@ -85,6 +90,83 @@ describe("resolveCheckoutChargeAmounts", () => {
       amountToPayCents: 15_000,
       alreadyPaidCents: 0,
       remainingPayableCents: 15_000,
+      onlinePayableCents: 15_000,
+      reservedHolidayVoucherCents: 0,
     });
+  });
+
+  it("lien CB = complément si des chèques vacances sont encore dus", () => {
+    const mixed = payment({
+      paymentMethod: "holiday_vouchers",
+      holidayVoucherAmountCents: 25_000,
+      remainingPaymentMethod: "card",
+    });
+    expect(resolveOnlinePayableCents(mixed)).toBe(5_000);
+    expect(resolveCheckoutChargeAmounts(mixed, 30_000).onlinePayableCents).toBe(5_000);
+    expect(resolveCheckoutChargeAmounts(mixed, 30_000).reservedHolidayVoucherCents).toBe(
+      25_000
+    );
+  });
+
+  it("après complément CB, plus rien à demander en ligne tant que les CV manquent", () => {
+    const afterCard = payment({
+      paymentMethod: "holiday_vouchers",
+      holidayVoucherAmountCents: 25_000,
+      remainingPaymentMethod: "card",
+      receivedPayments: [
+        {
+          id: "rp_card",
+          method: "card",
+          label: "Paiement Stripe",
+          amountCents: 5_000,
+          receivedAt: "2026-08-19T10:00:00.000Z",
+        },
+      ],
+      paidAmountCents: 5_000,
+      remainingAmountCents: 25_000,
+      paymentStatus: "partially_paid",
+    });
+    expect(resolveRemainingPayableCents(afterCard)).toBe(25_000);
+    expect(resolveOnlinePayableCents(afterCard)).toBe(0);
+  });
+
+  it("le mode remaining encaisse tout le solde, y compris la part CV prévue", () => {
+    const mixed = payment({
+      paymentMethod: "holiday_vouchers",
+      holidayVoucherAmountCents: 25_000,
+      remainingPaymentMethod: "card",
+    });
+    const amounts = resolveCheckoutChargeAmounts(mixed, 30_000);
+    expect(parseStripeChargeMode(undefined)).toBe("online");
+    expect(parseStripeChargeMode("remaining")).toBe("remaining");
+    expect(resolveStripeChargeForMode(amounts, "online")).toEqual({
+      stripeCents: 5_000,
+      reservedHolidayVoucherCents: 25_000,
+    });
+    expect(resolveStripeChargeForMode(amounts, "remaining")).toEqual({
+      stripeCents: 30_000,
+      reservedHolidayVoucherCents: 0,
+    });
+  });
+
+  it("après encaissement des CV, le lien CB demande le solde restant", () => {
+    const afterVouchers = payment({
+      paymentMethod: "holiday_vouchers",
+      holidayVoucherAmountCents: 25_000,
+      remainingPaymentMethod: "card",
+      receivedPayments: [
+        {
+          id: "rp_cv",
+          method: "holiday_vouchers",
+          label: "Chèques vacances",
+          amountCents: 25_000,
+          receivedAt: "2026-08-19T10:00:00.000Z",
+        },
+      ],
+      paidAmountCents: 25_000,
+      remainingAmountCents: 5_000,
+      paymentStatus: "partially_paid",
+    });
+    expect(resolveOnlinePayableCents(afterVouchers)).toBe(5_000);
   });
 });

--- a/src/lib/club-registration/payment/resolve-remaining-payable.ts
+++ b/src/lib/club-registration/payment/resolve-remaining-payable.ts
@@ -1,7 +1,7 @@
 import type { RegistrationPayment } from "./types";
 
 /**
- * Montant réellement encore payable maintenant.
+ * Montant réellement encore dû (tous moyens confondus).
  * `amountToPayCents` = net après aides ; le solde déduit déjà les encaissements.
  */
 export function resolveRemainingPayableCents(
@@ -13,14 +13,49 @@ export function resolveRemainingPayableCents(
   return Math.max(0, payment.remainingAmountCents);
 }
 
+/**
+ * Part chèques vacances encore prévue et non encaissée.
+ * Par défaut cette part n'est pas demandée sur Stripe (remise physique au club).
+ * Un encaissement Stripe « remaining » peut quand même la couvrir si l'adhérent change d'avis.
+ */
+export function resolveUnpaidHolidayVoucherCents(
+  payment: RegistrationPayment | null | undefined
+): number {
+  if (!payment) {
+    return 0;
+  }
+  const declared = Math.max(0, payment.holidayVoucherAmountCents ?? 0);
+  if (declared <= 0) {
+    return 0;
+  }
+  const received = payment.receivedPayments
+    .filter((line) => line.method === "holiday_vouchers")
+    .reduce((sum, line) => sum + Math.max(0, line.amountCents), 0);
+  const outstanding = Math.max(0, declared - received);
+  return Math.min(outstanding, resolveRemainingPayableCents(payment));
+}
+
+/**
+ * Montant à encaisser en ligne par défaut : solde moins les CV encore dus.
+ * Sans chèques vacances déclarés, égal au solde (chèque → lien CB sur tout le reste).
+ */
+export function resolveOnlinePayableCents(
+  payment: RegistrationPayment | null | undefined
+): number {
+  const remaining = resolveRemainingPayableCents(payment);
+  return Math.max(0, remaining - resolveUnpaidHolidayVoucherCents(payment));
+}
+
 export type CheckoutChargeAmounts = {
   amountToPayCents: number;
   alreadyPaidCents: number;
   remainingPayableCents: number;
+  onlinePayableCents: number;
+  reservedHolidayVoucherCents: number;
 };
 
 /**
- * Distingue le net après aides du solde à encaisser (Checkout, e-mails, relances).
+ * Distingue le net après aides, le solde total, et ce que Stripe peut demander maintenant.
  */
 export function resolveCheckoutChargeAmounts(
   payment: RegistrationPayment | null | undefined,
@@ -34,10 +69,44 @@ export function resolveCheckoutChargeAmounts(
   const remainingPayableCents = payment
     ? resolveRemainingPayableCents(payment)
     : amountToPayCents;
+  const reservedHolidayVoucherCents = payment
+    ? resolveUnpaidHolidayVoucherCents(payment)
+    : 0;
+  const onlinePayableCents = payment
+    ? resolveOnlinePayableCents(payment)
+    : remainingPayableCents;
 
   return {
     amountToPayCents,
     alreadyPaidCents,
     remainingPayableCents,
+    onlinePayableCents,
+    reservedHolidayVoucherCents,
+  };
+}
+
+export type StripeChargeMode = "online" | "remaining";
+
+export function parseStripeChargeMode(value: unknown): StripeChargeMode {
+  return value === "remaining" ? "remaining" : "online";
+}
+
+/**
+ * `online` = complément (solde − CV encore dus).
+ * `remaining` = tout le reste dû, si l'adhérent ne remet pas les chèques vacances.
+ */
+export function resolveStripeChargeForMode(
+  charge: CheckoutChargeAmounts,
+  mode: StripeChargeMode
+): { stripeCents: number; reservedHolidayVoucherCents: number } {
+  if (mode === "remaining") {
+    return {
+      stripeCents: charge.remainingPayableCents,
+      reservedHolidayVoucherCents: 0,
+    };
+  }
+  return {
+    stripeCents: charge.onlinePayableCents,
+    reservedHolidayVoucherCents: charge.reservedHolidayVoucherCents,
   };
 }

--- a/src/lib/club-registration/request-payment-checkout.ts
+++ b/src/lib/club-registration/request-payment-checkout.ts
@@ -170,6 +170,7 @@ export async function createStripeCheckoutForRegistration(params: {
   amountToPayCents: number;
   alreadyPaidCents?: number;
   remainingPayableCents?: number;
+  reservedHolidayVoucherCents?: number;
   paymentEmail: string;
   adherentName: string;
   successUrl: string;
@@ -195,6 +196,9 @@ export async function createStripeCheckoutForRegistration(params: {
       amountToPayCents: params.amountToPayCents,
       alreadyPaidCents,
       remainingPayableCents,
+      ...(params.reservedHolidayVoucherCents != null
+        ? { reservedHolidayVoucherCents: params.reservedHolidayVoucherCents }
+        : {}),
     });
     if (!validation.ok) {
       return validation;
@@ -230,6 +234,9 @@ export async function createStripeCheckoutForRegistration(params: {
       donationDiscountCouponName: stripePresentation.donationDiscountCouponName,
       aids: paymentAids,
       alreadyPaidCents,
+      ...(params.reservedHolidayVoucherCents != null
+        ? { reservedHolidayVoucherCents: params.reservedHolidayVoucherCents }
+        : {}),
     });
 
     const session = await createMembershipCheckoutSession({

--- a/src/lib/club-registration/self-service-checkout.test.ts
+++ b/src/lib/club-registration/self-service-checkout.test.ts
@@ -1,5 +1,7 @@
 import {
   canSelfServiceCheckout,
+  canSelfServiceOnlineCheckout,
+  canSelfServiceRemainingOverride,
   isAwaitingNonCardPayment,
   resolveSelfServicePayableCents,
 } from "./self-service-checkout";
@@ -127,6 +129,55 @@ describe("self-service-checkout", () => {
       })
     ).toBe(20_000);
     expect(resolveSelfServicePayableCents({ paymentAmountCents: 15_000 })).toBe(15_000);
+  });
+
+  it("pour des chèques vacances, le self-service propose le complément et tout le solde", () => {
+    const mixed = {
+      status: "payment_requested",
+      paymentAmountCents: 30_000,
+      payment: {
+        paymentMethod: "holiday_vouchers",
+        amountToPayCents: 30_000,
+        totalAmountCents: 30_000,
+        assistanceTotalAmountCents: 0,
+        aids: [],
+        paymentInstallments: 1,
+        expectedPayments: [],
+        receivedPayments: [],
+        paidAmountCents: 0,
+        remainingAmountCents: 30_000,
+        holidayVoucherAmountCents: 25_000,
+        remainingPaymentMethod: "card",
+        paymentStatus: "waiting_payment",
+      },
+    };
+    expect(resolveSelfServicePayableCents(mixed)).toBe(5_000);
+    expect(canSelfServiceOnlineCheckout(mixed)).toBe(true);
+    expect(canSelfServiceRemainingOverride(mixed)).toBe(true);
+    expect(canSelfServiceCheckout(mixed)).toBe(true);
+
+    const afterCard = {
+      status: "payment_requested",
+      paymentAmountCents: 30_000,
+      payment: {
+        paymentMethod: "holiday_vouchers",
+        amountToPayCents: 30_000,
+        totalAmountCents: 30_000,
+        assistanceTotalAmountCents: 0,
+        aids: [],
+        paymentInstallments: 1,
+        expectedPayments: [],
+        receivedPayments: [],
+        paidAmountCents: 5_000,
+        remainingAmountCents: 25_000,
+        holidayVoucherAmountCents: 25_000,
+        remainingPaymentMethod: "card",
+        paymentStatus: "partially_paid",
+      },
+    };
+    expect(canSelfServiceOnlineCheckout(afterCard)).toBe(false);
+    expect(canSelfServiceRemainingOverride(afterCard)).toBe(true);
+    expect(canSelfServiceCheckout(afterCard)).toBe(true);
   });
 
   it("n'affiche plus l'attente hors carte si le self-service Stripe est ouvert", () => {

--- a/src/lib/club-registration/self-service-checkout.ts
+++ b/src/lib/club-registration/self-service-checkout.ts
@@ -1,5 +1,8 @@
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
-import { resolveRemainingPayableCents } from "@/lib/club-registration/payment/resolve-remaining-payable";
+import {
+  resolveOnlinePayableCents,
+  resolveRemainingPayableCents,
+} from "@/lib/club-registration/payment/resolve-remaining-payable";
 import { isRegistrationPaidRecord } from "@/lib/club-registration/payment-proof";
 import type { PaymentMethodId } from "@/lib/club-registration/payment-constants";
 
@@ -16,10 +19,15 @@ export function resolveRegistrationPaymentMethod(
   return payment?.paymentMethod ?? null;
 }
 
+function isSelfServiceEligible(data: SelfServiceCheckoutRecord): boolean {
+  return data.status === "payment_requested" && !isRegistrationPaidRecord(data);
+}
+
+/** Montant Stripe par défaut : complément, sans la part CV encore due. */
 export function resolveSelfServicePayableCents(data: SelfServiceCheckoutRecord): number {
   const payment = normalizeRegistrationPayment(data);
   if (payment) {
-    return resolveRemainingPayableCents(payment);
+    return resolveOnlinePayableCents(payment);
   }
   if (typeof data.paymentAmountCents === "number" && data.paymentAmountCents > 0) {
     return data.paymentAmountCents;
@@ -27,23 +35,36 @@ export function resolveSelfServicePayableCents(data: SelfServiceCheckoutRecord):
   return 0;
 }
 
+export function canSelfServiceOnlineCheckout(data: SelfServiceCheckoutRecord): boolean {
+  return isSelfServiceEligible(data) && resolveSelfServicePayableCents(data) > 0;
+}
+
+/** Tout le solde par carte, si une part CV n'a pas (encore) été remise. */
+export function canSelfServiceRemainingOverride(data: SelfServiceCheckoutRecord): boolean {
+  if (!isSelfServiceEligible(data)) {
+    return false;
+  }
+  const payment = normalizeRegistrationPayment(data);
+  if (!payment) {
+    return false;
+  }
+  const remaining = resolveRemainingPayableCents(payment);
+  return remaining > 0 && remaining > resolveOnlinePayableCents(payment);
+}
+
 export function canSelfServiceCheckout(data: SelfServiceCheckoutRecord): boolean {
-  if (data.status !== "payment_requested") {
-    return false;
-  }
-  if (isRegistrationPaidRecord(data)) {
-    return false;
-  }
-  return resolveSelfServicePayableCents(data) > 0;
+  return canSelfServiceOnlineCheckout(data) || canSelfServiceRemainingOverride(data);
 }
 
 export function isAwaitingNonCardPayment(data: SelfServiceCheckoutRecord): boolean {
   if (canSelfServiceCheckout(data)) {
     return false;
   }
-  if (data.status !== "payment_requested" || isRegistrationPaidRecord(data)) {
+  if (!isSelfServiceEligible(data)) {
     return false;
   }
   const method = resolveRegistrationPaymentMethod(data);
-  return method != null && method !== "card" && resolveSelfServicePayableCents(data) > 0;
+  const payment = normalizeRegistrationPayment(data);
+  const remaining = payment ? resolveRemainingPayableCents(payment) : 0;
+  return method != null && method !== "card" && remaining > 0;
 }

--- a/src/lib/club-registration/stripe-checkout-discounts.test.ts
+++ b/src/lib/club-registration/stripe-checkout-discounts.test.ts
@@ -82,6 +82,34 @@ describe("stripe-checkout-discounts", () => {
     ).toThrow("Incohérence solde Stripe");
   });
 
+  it("valide un Checkout du seul complément CB, CV encore dus", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 30_000,
+        donationDiscountCents: 0,
+        aidDiscountCents: 0,
+        amountToPayCents: 30_000,
+        alreadyPaidCents: 0,
+        reservedHolidayVoucherCents: 25_000,
+        remainingPayableCents: 5_000,
+      })
+    ).not.toThrow();
+  });
+
+  it("valide un Checkout de tout le solde si l'adhérent ne remet pas les CV", () => {
+    expect(() =>
+      assertStripePayableAfterDiscounts({
+        invoiceTotalCents: 30_000,
+        donationDiscountCents: 0,
+        aidDiscountCents: 0,
+        amountToPayCents: 30_000,
+        alreadyPaidCents: 0,
+        reservedHolidayVoucherCents: 0,
+        remainingPayableCents: 30_000,
+      })
+    ).not.toThrow();
+  });
+
   it("inclut le déjà encaissé dans le coupon Checkout", () => {
     expect(
       sumCheckoutDiscountCents({
@@ -98,6 +126,24 @@ describe("stripe-checkout-discounts", () => {
         alreadyPaidCents: 10_000,
       })
     ).toBe("Déjà encaissé");
+  });
+
+  it("inclut les chèques vacances prévus dans le coupon Checkout", () => {
+    expect(
+      buildMergedCheckoutDiscountCouponName({
+        donationDiscountCents: 0,
+        donationDiscountCouponName: "Remise don libre",
+        aids: [],
+        reservedHolidayVoucherCents: 25_000,
+      })
+    ).toBe("Chèques vacances prévus");
+    expect(
+      sumCheckoutDiscountCents({
+        donationDiscountCents: 0,
+        aids: [],
+        reservedHolidayVoucherCents: 25_000,
+      })
+    ).toBe(25_000);
   });
 
   it("somme les aides", () => {

--- a/src/lib/club-registration/stripe-checkout-discounts.ts
+++ b/src/lib/club-registration/stripe-checkout-discounts.ts
@@ -17,12 +17,18 @@ export function buildMergedCheckoutDiscountCouponName(params: {
   donationDiscountCouponName: string;
   aids: PaymentAid[];
   alreadyPaidCents?: number;
+  reservedHolidayVoucherCents?: number;
 }): string {
   const activeAids = params.aids.filter((aid) => aid.amountCents > 0);
   const hasDonation = params.donationDiscountCents > 0;
   const hasAlreadyPaid = (params.alreadyPaidCents ?? 0) > 0;
+  const hasReservedVouchers = (params.reservedHolidayVoucherCents ?? 0) > 0;
 
-  if (hasAlreadyPaid && !hasDonation && activeAids.length === 0) {
+  if (hasReservedVouchers && !hasAlreadyPaid && !hasDonation && activeAids.length === 0) {
+    return "Chèques vacances prévus";
+  }
+
+  if (hasAlreadyPaid && !hasDonation && activeAids.length === 0 && !hasReservedVouchers) {
     return "Déjà encaissé";
   }
 
@@ -45,11 +51,13 @@ export function sumCheckoutDiscountCents(params: {
   donationDiscountCents: number;
   aids: PaymentAid[];
   alreadyPaidCents?: number;
+  reservedHolidayVoucherCents?: number;
 }): number {
   return (
     Math.max(0, params.donationDiscountCents) +
     sumPaymentAidDiscountCents(params.aids) +
-    Math.max(0, params.alreadyPaidCents ?? 0)
+    Math.max(0, params.alreadyPaidCents ?? 0) +
+    Math.max(0, params.reservedHolidayVoucherCents ?? 0)
   );
 }
 
@@ -79,6 +87,7 @@ export function assertStripePayableAfterDiscounts(params: {
   amountToPayCents: number;
   alreadyPaidCents?: number;
   remainingPayableCents?: number;
+  reservedHolidayVoucherCents?: number;
 }): void {
   void params.donationDiscountCents;
   const expectedPayable = params.invoiceTotalCents - params.aidDiscountCents;
@@ -90,10 +99,14 @@ export function assertStripePayableAfterDiscounts(params: {
 
   if (params.remainingPayableCents != null) {
     const alreadyPaid = Math.max(0, params.alreadyPaidCents ?? 0);
-    const expectedRemaining = Math.max(0, params.amountToPayCents - alreadyPaid);
+    const reservedVouchers = Math.max(0, params.reservedHolidayVoucherCents ?? 0);
+    const expectedRemaining = Math.max(
+      0,
+      params.amountToPayCents - alreadyPaid - reservedVouchers
+    );
     if (expectedRemaining !== params.remainingPayableCents) {
       throw new Error(
-        `Incohérence solde Stripe : net ${params.amountToPayCents} cts, déjà encaissé ${alreadyPaid} cts, attendu ${params.remainingPayableCents} cts, calculé ${expectedRemaining} cts`
+        `Incohérence solde Stripe : net ${params.amountToPayCents} cts, déjà encaissé ${alreadyPaid} cts, CV prévus ${reservedVouchers} cts, attendu ${params.remainingPayableCents} cts, calculé ${expectedRemaining} cts`
       );
     }
   }
@@ -110,13 +123,16 @@ export async function createCheckoutDiscountCouponIds(params: {
   donationDiscountCouponName: string;
   aids: PaymentAid[];
   alreadyPaidCents?: number;
+  reservedHolidayVoucherCents?: number;
 }): Promise<string[]> {
   const donationDiscount = Math.max(0, params.donationDiscountCents);
   const alreadyPaidCents = Math.max(0, params.alreadyPaidCents ?? 0);
+  const reservedHolidayVoucherCents = Math.max(0, params.reservedHolidayVoucherCents ?? 0);
   const totalOff = sumCheckoutDiscountCents({
     donationDiscountCents: donationDiscount,
     aids: params.aids,
     alreadyPaidCents,
+    reservedHolidayVoucherCents,
   });
 
   if (totalOff <= 0) {
@@ -132,6 +148,7 @@ export async function createCheckoutDiscountCouponIds(params: {
         donationDiscountCouponName: params.donationDiscountCouponName,
         aids: params.aids,
         alreadyPaidCents,
+        reservedHolidayVoucherCents,
       })
     ),
     kind: "merged_checkout_discount",


### PR DESCRIPTION
## Summary
- Stripe encaisse par défaut le **complément** (solde − chèques vacances encore dus), pas toute l’adhésion.
- L’adhérent et le secrétariat peuvent encore **changer d’avis** et demander tout le solde par carte.
- Sans CV déclarés, le lien CB continue de demander tout le reste dû.

## Test plan
- [ ] Dossier 300 € dont 250 € CV : « Payer en ligne » demande 50 €
- [ ] Même dossier : « Payer tout le solde par carte » / « Demander tout le solde en ligne » demande 300 €
- [ ] Après les 50 € CB : le complément disparaît, le solde CV (250 €) reste payable en ligne si changement d’avis
- [ ] Dossier chèque sans CV : le lien CB demande toujours tout le solde


Made with [Cursor](https://cursor.com)