### PR TITLE
fix(club-registration): aligner le paiement après un changement de devis

### DIFF
--- a/src/app/api/club/registration/[id]/pricing/route.ts
+++ b/src/app/api/club/registration/[id]/pricing/route.ts
@@ -12,6 +12,7 @@ import {
   readVoluntaryDonationCents,
   resolveRegistrationDonationPricing,
 } from "@/lib/club-registration/resolve-registration-donation";
+import { buildPaymentSyncPatchForQuote } from "@/lib/club-registration/payment/sync-payment-after-quote-change";
 import type { PriceQuote } from "@/lib/pricing/types";
 
 const COLLECTION = "clubRegistrations";
@@ -159,6 +160,13 @@ export async function POST(
         const donation = resolveRegistrationDonationPricing(quote, merged);
         patch.paymentAmountCents = donation.invoiceTotalCents;
         patch.donationDiscountCents = donation.donationDiscountCents;
+        Object.assign(
+          patch,
+          buildPaymentSyncPatchForQuote({
+            currentData: snap.data() ?? {},
+            invoiceTotalCents: donation.invoiceTotalCents,
+          })
+        );
       }
       if (body.handisportPracticeLevel !== undefined) {
         patch.handisportPracticeLevel = body.handisportPracticeLevel;

--- a/src/lib/club-registration/build-manager-registration-pricing-patch.ts
+++ b/src/lib/club-registration/build-manager-registration-pricing-patch.ts
@@ -2,11 +2,18 @@ import { FieldValue } from "firebase-admin/firestore";
 import { ensureRegistrationConfigSeeded, getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
 import { calculateQuoteWithConfig } from "@/lib/club-registration-config/pricing-resolve";
 import { buildPricingContextFromRecord } from "@/lib/pricing/from-registration-record";
+import { isValidVoluntaryDonationCents } from "@/lib/pricing/donation-discount";
 import { applyDonationPricingPatch } from "./apply-donation-pricing-patch";
+import {
+  readVoluntaryDonationCents,
+  resolveRegistrationDonationPricing,
+} from "./resolve-registration-donation";
+import { buildPaymentSyncPatchForQuote } from "./payment/sync-payment-after-quote-change";
 
 export async function buildManagerRegistrationPricingPatch(
   mergedForPricing: Record<string, unknown>,
-  currentData: Record<string, unknown>
+  currentData: Record<string, unknown>,
+  paymentSourceData: Record<string, unknown> = currentData
 ): Promise<Record<string, unknown>> {
   const pricingCtx = buildPricingContextFromRecord(mergedForPricing);
   if (!pricingCtx) {
@@ -23,5 +30,18 @@ export async function buildManagerRegistrationPricingPatch(
     pricingQuoteComputedAt: FieldValue.serverTimestamp(),
   };
   applyDonationPricingPatch(pricingPatch, quote, mergedForPricing, currentData);
+
+  const donationCents = readVoluntaryDonationCents(mergedForPricing);
+  const invoiceTotalCents = isValidVoluntaryDonationCents(donationCents)
+    ? resolveRegistrationDonationPricing(quote, mergedForPricing).invoiceTotalCents
+    : quote.totalCents;
+  Object.assign(
+    pricingPatch,
+    buildPaymentSyncPatchForQuote({
+      currentData: paymentSourceData,
+      invoiceTotalCents,
+    })
+  );
+
   return pricingPatch;
 }

--- a/src/lib/club-registration/patch-manager-registration.ts
+++ b/src/lib/club-registration/patch-manager-registration.ts
@@ -193,17 +193,11 @@ export async function patchManagerRegistration(
     }
   }
 
-  const mergedForPricing = { ...currentData, ...updates };
-  const pricingPatch = await buildManagerRegistrationPricingPatch(
-    mergedForPricing,
-    currentData
-  );
-
   if (updates.paymentAids !== undefined) {
     await ensureRegistrationConfigSeeded();
     const config = await getActiveRegistrationConfig();
     const aidsUpdate = resolveManagerPaymentAidsUpdate(
-      mergedForPricing,
+      { ...currentData, ...updates },
       currentData,
       updates.paymentAids,
       config,
@@ -214,6 +208,13 @@ export async function patchManagerRegistration(
     }
     Object.assign(updates, aidsUpdate.patch);
   }
+
+  const mergedForPricing = { ...currentData, ...updates };
+  const pricingPatch = await buildManagerRegistrationPricingPatch(
+    mergedForPricing,
+    currentData,
+    mergedForPricing
+  );
 
   await docRef.set(
     {

--- a/src/lib/club-registration/payment/index.ts
+++ b/src/lib/club-registration/payment/index.ts
@@ -59,6 +59,11 @@ export {
 } from "./resolve-remaining-payable";
 
 export {
+  syncPaymentAfterQuoteChange,
+  buildPaymentSyncPatchForQuote,
+} from "./sync-payment-after-quote-change";
+
+export {
   isCollectableAid,
   isAidReceiptPending,
   hasPendingAidReceipt,

--- a/src/lib/club-registration/payment/sync-payment-after-quote-change.test.ts
+++ b/src/lib/club-registration/payment/sync-payment-after-quote-change.test.ts
@@ -1,0 +1,137 @@
+import {
+  buildPaymentSyncPatchForQuote,
+  syncPaymentAfterQuoteChange,
+} from "./sync-payment-after-quote-change";
+import type { ExpectedPayment, RegistrationPayment } from "./types";
+
+function basePayment(overrides: Partial<RegistrationPayment> = {}): RegistrationPayment {
+  return {
+    totalAmountCents: 23_900,
+    assistanceTotalAmountCents: 0,
+    amountToPayCents: 23_900,
+    aids: [],
+    paymentMethod: "holiday_vouchers",
+    paymentInstallments: 1,
+    expectedPayments: [],
+    receivedPayments: [],
+    paidAmountCents: 0,
+    remainingAmountCents: 23_900,
+    holidayVoucherAmountCents: 23_900,
+    paymentStatus: "pending_validation",
+    ...overrides,
+  };
+}
+
+describe("syncPaymentAfterQuoteChange", () => {
+  it("aligne totaux et solde sur le nouveau devis, sans toucher aux CV déclarés", () => {
+    const next = syncPaymentAfterQuoteChange(basePayment(), 26_400);
+
+    expect(next.totalAmountCents).toBe(26_400);
+    expect(next.amountToPayCents).toBe(26_400);
+    expect(next.remainingAmountCents).toBe(26_400);
+    expect(next.holidayVoucherAmountCents).toBe(23_900);
+    expect(next.paymentMethod).toBe("holiday_vouchers");
+    expect(next.paymentStatus).toBe("pending_validation");
+  });
+
+  it("conserve les encaissements et recalcule le reliquat", () => {
+    const next = syncPaymentAfterQuoteChange(
+      basePayment({
+        receivedPayments: [
+          {
+            id: "rp_1",
+            method: "holiday_vouchers",
+            label: "Chèques vacances",
+            amountCents: 23_900,
+            receivedAt: "2026-08-19T10:00:00.000Z",
+          },
+        ],
+        paidAmountCents: 23_900,
+        remainingAmountCents: 0,
+        paymentStatus: "paid",
+      }),
+      26_400
+    );
+
+    expect(next.paidAmountCents).toBe(23_900);
+    expect(next.remainingAmountCents).toBe(2_500);
+    expect(next.paymentStatus).toBe("partially_paid");
+    expect(next.holidayVoucherAmountCents).toBe(23_900);
+  });
+
+  it("régénère les échéances chèque tant qu'aucune n'est reçue", () => {
+    const expected: ExpectedPayment[] = [
+      {
+        id: "ep_old",
+        method: "cheque",
+        label: "Chèque 1/1",
+        expectedAmountCents: 23_900,
+        status: "expected",
+      },
+    ];
+    const next = syncPaymentAfterQuoteChange(
+      basePayment({
+        paymentMethod: "cheque",
+        expectedPayments: expected,
+      }),
+      26_400
+    );
+
+    expect(next.expectedPayments).toHaveLength(1);
+    expect(next.expectedPayments[0].expectedAmountCents).toBe(26_400);
+    expect(next.expectedPayments[0].id).not.toBe("ep_old");
+  });
+
+  it("ne régénère pas les échéances si un chèque a déjà été reçu", () => {
+    const next = syncPaymentAfterQuoteChange(
+      basePayment({
+        paymentMethod: "cheque",
+        expectedPayments: [
+          {
+            id: "ep_1",
+            method: "cheque",
+            label: "Chèque 1/1",
+            expectedAmountCents: 23_900,
+            status: "received",
+          },
+        ],
+      }),
+      26_400
+    );
+
+    expect(next.expectedPayments[0].id).toBe("ep_1");
+    expect(next.expectedPayments[0].status).toBe("received");
+    expect(next.remainingAmountCents).toBe(26_400);
+  });
+});
+
+describe("buildPaymentSyncPatchForQuote", () => {
+  it("écrit le paiement nested et le montant plat", () => {
+    const patch = buildPaymentSyncPatchForQuote({
+      currentData: { payment: basePayment(), paymentAmountCents: 23_900 },
+      invoiceTotalCents: 26_400,
+    });
+
+    expect(patch.paymentAmountCents).toBe(26_400);
+    expect(patch.payment).toMatchObject({
+      totalAmountCents: 26_400,
+      amountToPayCents: 26_400,
+      remainingAmountCents: 26_400,
+      holidayVoucherAmountCents: 23_900,
+    });
+  });
+
+  it("ne réécrit pas si le paiement est déjà aligné", () => {
+    const aligned = basePayment({
+      totalAmountCents: 26_400,
+      amountToPayCents: 26_400,
+      remainingAmountCents: 26_400,
+    });
+    expect(
+      buildPaymentSyncPatchForQuote({
+        currentData: { payment: aligned, paymentAmountCents: 26_400 },
+        invoiceTotalCents: 26_400,
+      })
+    ).toEqual({});
+  });
+});

--- a/src/lib/club-registration/payment/sync-payment-after-quote-change.ts
+++ b/src/lib/club-registration/payment/sync-payment-after-quote-change.ts
@@ -1,0 +1,59 @@
+import {
+  normalizeRegistrationPayment,
+  paymentToFirestoreUpdate,
+} from "./normalize-payment";
+import {
+  recalculateRegistrationPayment,
+  regenerateExpectedPayments,
+} from "./payment-mutations";
+import type { RegistrationPayment } from "./types";
+
+/**
+ * Aligne le paiement stocké sur un nouveau total devis (ex. option ajoutée après coup).
+ * Ne touche pas aux chèques vacances déclarés ni aux encaissements déjà notés.
+ */
+export function syncPaymentAfterQuoteChange(
+  payment: RegistrationPayment,
+  invoiceTotalCents: number
+): RegistrationPayment {
+  let next = recalculateRegistrationPayment(
+    { ...payment, totalAmountCents: Math.max(0, invoiceTotalCents) },
+    { preserveManualFollowUp: true }
+  );
+
+  const hasReceivedExpected = next.expectedPayments.some((line) => line.status === "received");
+  if (!hasReceivedExpected && (next.paymentMethod === "cheque" || next.paymentMethod === "card")) {
+    next = regenerateExpectedPayments(next);
+  }
+
+  return next;
+}
+
+function paymentNeedsQuoteSync(
+  current: RegistrationPayment,
+  next: RegistrationPayment
+): boolean {
+  return (
+    current.totalAmountCents !== next.totalAmountCents ||
+    current.amountToPayCents !== next.amountToPayCents ||
+    current.remainingAmountCents !== next.remainingAmountCents
+  );
+}
+
+/** Patch Firestore `payment` + champs plats, ou `{}` si déjà aligné. */
+export function buildPaymentSyncPatchForQuote(params: {
+  currentData: Record<string, unknown>;
+  invoiceTotalCents: number;
+}): Record<string, unknown> {
+  const payment = normalizeRegistrationPayment(params.currentData);
+  if (!payment || params.invoiceTotalCents <= 0) {
+    return {};
+  }
+
+  const next = syncPaymentAfterQuoteChange(payment, params.invoiceTotalCents);
+  if (!paymentNeedsQuoteSync(payment, next)) {
+    return {};
+  }
+
+  return paymentToFirestoreUpdate(next);
+}


### PR DESCRIPTION
## Summary
- Un ajout d’option (championnat par équipes, etc.) mettait à jour le catalogue sans recalculer le **suivi de paiement** (total, solde, montant à régler).
- « Enregistrer le dossier » et « Enregistrer le devis » alignent désormais le paiement stocké sur le devis. Les chèques vacances déclarés et les encaissements déjà notés restent inchangés.

## Test plan
- [ ] Dossier à 239 €, ajouter championnat (+25 €), enregistrer le dossier → suivi et solde passent à 264 €
- [ ] Même dossier en CV 239 € : le montant CV déclaré reste 239 € (complément 25 €)
- [ ] Encaissement déjà noté : le reliquat = nouveau net − déjà payé


Made with [Cursor](https://cursor.com)