### PR TITLE
feat(attendance): pointage des entraînements et file des essais

### DIFF
--- a/docs/technical/adr/0006-training-attendance.md
+++ b/docs/technical/adr/0006-training-attendance.md
@@ -1,0 +1,50 @@
+# ADR-0006: Pointage des présences aux entraînements
+
+## Statut
+
+Accepté — 2026-08-20
+
+## Contexte
+
+Le club doit pointer les présences sur tablette, par créneau du jour. Les créneaux existent déjà dans la config d’inscription (`clubRegistrationConfig.sites[].slots`) et les dossiers (`clubRegistrations.slotIds`), mais il n’y a ni séances datées ni pointage.
+
+Deux référentiels personnes coexistent : `clubRegistrations` (adhérents saisonniers) et `players` (roster FFTT). Les coachs lisent les dossiers mais n’écrivent pas les adhésions d’autrui.
+
+## Décision
+
+1. **Domaine isolé** : collections `attendanceMarks` et `attendanceLeads`, API `/api/club/attendance/*`, pas de présence stockée dans `clubRegistrations`. Accès client Firestore refusé (Admin SDK uniquement).
+2. **Effectif** : dossiers non refusés dont `slotIds` contient le créneau. Source = `clubRegistrations`, jamais `players`.
+3. **Créneaux du jour** : champs structurés `weekday` (ISO 1–7), `startMinutes`, `endMinutes` sur chaque slot, backfill depuis le libellé / l’id.
+4. **Pointage** : un document par présence, id déterministe `{date}_{slotId}_{personKey}` (idempotent). Dépointage = suppression. Geste opt-in « Présent ».
+5. **Walk-in adhérent** : mark `walkin` ; ajout optionnel du créneau via un endpoint dédié (`arrayUnion` sur `slotIds` uniquement), pas le PATCH manager des dossiers.
+6. **Essai** : `attendanceLeads` (identité minimale) + mark `guest`. File de relance (`ADMIN`/`SECRETARY`/`BOARD_MEMBER`). Pas de dossier d’adhésion ni de joueur FFTT.
+7. **Rôles** : pointage / stats / export = `ADMIN` + `SECRETARY` + `BOARD_MEMBER` + `COACH`. File des essais = `ADMIN` + `SECRETARY` + `BOARD_MEMBER` (pas le coach, ni le secrétaire adjoint).
+8. **Offline** : reporté. Les ids déterministes n’interdisent pas une file locale plus tard.
+9. **Stats V1** : taux = présences `enrolled` / occurrences calendaires du weekday depuis max(début de saison, date d’inscription) jusqu’à aujourd’hui. Pas d’exclusion jours fériés.
+
+## Conséquences
+
+### Positives
+- Frontière claire adhésion / présence / championnat.
+- Les coachs ne gagnent pas l’écriture générale des dossiers.
+- Deux tablettes sur le même créneau ne dupliquent pas un pointage.
+
+### Négatives
+- Catalogue d’inscription enrichi (horaire structuré) à maintenir dans l’éditeur de config.
+- Taux de présence V1 ignore les séances annulées.
+
+### Neutres
+- Fuseau `Europe/Paris`. Saison = `meta.seasonLabel` (1er septembre → 31 août).
+
+## Alternatives considérées
+
+### Alternative 1: sous-collection sur le dossier d’adhésion
+- **Pourquoi rejetée** : mélange planning et workflow de validation ; requêtes « séance du soir » peu naturelles.
+
+### Alternative 2: réutiliser `players`
+- **Pourquoi rejetée** : roster FFTT ≠ adhérents de la saison ; les loisirs sans licence n’y sont pas.
+
+## Références
+
+- `.cursor/rules/80-club-platform-extension.mdc`
+- `src/lib/club-registration/registration-access.ts`

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -407,6 +407,66 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "attendanceMarks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "slotId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "attendanceMarks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "attendanceMarks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "seasonLabel",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "slotId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "attendanceLeads",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -294,6 +294,17 @@ service cloud.firestore {
     }
 
     // ============================================
+    // Collections: attendanceMarks / attendanceLeads
+    // ============================================
+    // Pointage entraînement — Admin SDK uniquement (routes /api/club/attendance/*).
+    match /attendanceMarks/{markId} {
+      allow read, write: if false;
+    }
+    match /attendanceLeads/{leadId} {
+      allow read, write: if false;
+    }
+
+    // ============================================
     // Règle par défaut : refuser tout accès non explicitement autorisé
     // ============================================
     match /{document=**} {

--- a/src/app/api/club/attendance/add-slot/route.ts
+++ b/src/app/api/club/attendance/add-slot/route.ts
@@ -1,0 +1,74 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import {
+  invalidOriginResponse,
+  requireAttendanceOperator,
+} from "@/lib/attendance/api-auth";
+import { attendanceAddSlotSchema } from "@/lib/attendance/schema";
+import { findSlotOption } from "@/lib/attendance/slots-for-date";
+import { isRejectedRegistration } from "@/lib/attendance/alerts";
+import { displayNameFromParts } from "@/lib/attendance/roster";
+import { addSlotToRegistration, getRegistrationData } from "@/lib/attendance/store";
+
+/** POST /api/club/attendance/add-slot — ajoute le créneau au dossier (arrayUnion). */
+export async function POST(req: Request) {
+  if (!validateOrigin(req)) {
+    return invalidOriginResponse();
+  }
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return jsonNoStore({ error: "JSON invalide" }, { status: 400 });
+  }
+  const parsed = attendanceAddSlotSchema.safeParse(json);
+  if (!parsed.success) {
+    return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slot = findSlotOption(config, parsed.data.slotId, parsed.data.date);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    const data = await getRegistrationData(auth.session.db, parsed.data.registrationId);
+    if (!data || isRejectedRegistration(data)) {
+      return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
+    }
+    const firstName = typeof data.firstName === "string" ? data.firstName : "";
+    const lastName = typeof data.lastName === "string" ? data.lastName : "";
+    await addSlotToRegistration(auth.session.db, {
+      date: parsed.data.date,
+      slotId: parsed.data.slotId,
+      siteId: slot.siteId,
+      seasonLabel: config.meta.seasonLabel,
+      registrationId: parsed.data.registrationId,
+      displayName: displayNameFromParts(firstName, lastName) || parsed.data.registrationId,
+      markedByUid: auth.session.uid,
+    });
+    logAuditAction(AUDIT_ACTIONS.ATTENDANCE_SLOT_ADDED, auth.session.uid, {
+      resource: "clubRegistration",
+      resourceId: parsed.data.registrationId,
+      details: { slotId: parsed.data.slotId },
+      success: true,
+    });
+    return jsonNoStore({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "Dossier introuvable" || message === "Dossier refusé") {
+      return jsonNoStore({ error: message }, { status: 404 });
+    }
+    console.error("[api/club/attendance/add-slot POST]", error);
+    return jsonNoStore({ error: "Impossible d'ajouter le créneau" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/export/route.ts
+++ b/src/app/api/club/attendance/export/route.ts
@@ -1,0 +1,55 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { isYmd, todayYmdInParis } from "@/lib/attendance/calendar";
+import { findSlotOption } from "@/lib/attendance/slots-for-date";
+import { listMarksForSession, listRegistrationsForSlot } from "@/lib/attendance/store";
+import { buildSessionPayload } from "@/lib/attendance/roster";
+import { buildAttendanceExportCsv, sessionToExportRows } from "@/lib/attendance/stats";
+
+/** GET /api/club/attendance/export?date=&slotId= — CSV de la séance. */
+export async function GET(req: Request) {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const dateParam = url.searchParams.get("date");
+  const slotId = url.searchParams.get("slotId")?.trim() ?? "";
+  const date = dateParam && isYmd(dateParam) ? dateParam : todayYmdInParis();
+  if (!slotId) {
+    return jsonNoStore({ error: "Créneau requis" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slot = findSlotOption(config, slotId, date);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    const [registrations, marks] = await Promise.all([
+      listRegistrationsForSlot(auth.session.db, slotId),
+      listMarksForSession(auth.session.db, date, slotId),
+    ]);
+    const session = buildSessionPayload({ date, slot, registrations, marks });
+    const csv = buildAttendanceExportCsv(sessionToExportRows(session));
+    const res = new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="presences-${date}-${slotId}.csv"`,
+      },
+    });
+    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    res.headers.set("Pragma", "no-cache");
+    res.headers.set("Expires", "0");
+    return res;
+  } catch (error) {
+    console.error("[api/club/attendance/export GET]", error);
+    return jsonNoStore({ error: "Impossible d'exporter la séance" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/leads/[id]/route.ts
+++ b/src/app/api/club/attendance/leads/[id]/route.ts
@@ -1,0 +1,53 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import {
+  invalidOriginResponse,
+  requireAttendanceLeadManager,
+} from "@/lib/attendance/api-auth";
+import { attendanceLeadPatchSchema } from "@/lib/attendance/schema";
+import { patchLeadStatus } from "@/lib/attendance/store";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/** PATCH /api/club/attendance/leads/[id] — statut de relance. */
+export async function PATCH(req: Request, context: RouteContext) {
+  if (!validateOrigin(req)) {
+    return invalidOriginResponse();
+  }
+  const auth = await requireAttendanceLeadManager();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { id } = await context.params;
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return jsonNoStore({ error: "JSON invalide" }, { status: 400 });
+  }
+  const parsed = attendanceLeadPatchSchema.safeParse(json);
+  if (!parsed.success) {
+    return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+  }
+
+  try {
+    const lead = await patchLeadStatus(auth.session.db, id, parsed.data.status);
+    if (!lead) {
+      return jsonNoStore({ error: "Essai introuvable" }, { status: 404 });
+    }
+    logAuditAction(AUDIT_ACTIONS.ATTENDANCE_LEAD_UPDATED, auth.session.uid, {
+      resource: "attendanceLead",
+      resourceId: id,
+      details: { status: parsed.data.status },
+      success: true,
+    });
+    return jsonNoStore({ lead });
+  } catch (error) {
+    console.error("[api/club/attendance/leads PATCH]", error);
+    return jsonNoStore({ error: "Impossible de mettre à jour l'essai" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/leads/route.ts
+++ b/src/app/api/club/attendance/leads/route.ts
@@ -1,0 +1,113 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { checkRateLimit } from "@/lib/auth/rate-limit";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import {
+  invalidOriginResponse,
+  requireAttendanceLeadManager,
+  requireAttendanceOperator,
+} from "@/lib/attendance/api-auth";
+import {
+  ATTENDANCE_LEAD_STATUSES,
+  type AttendanceLeadStatus,
+} from "@/lib/attendance/constants";
+import { attendanceLeadCreateSchema } from "@/lib/attendance/schema";
+import { findSlotOption } from "@/lib/attendance/slots-for-date";
+import { createLeadWithGuestMark, listLeads } from "@/lib/attendance/store";
+
+function isLeadStatus(value: string | null): value is AttendanceLeadStatus {
+  return Boolean(
+    value && (ATTENDANCE_LEAD_STATUSES as readonly string[]).includes(value),
+  );
+}
+
+/** GET /api/club/attendance/leads?status= — file de relance des essais. */
+export async function GET(req: Request) {
+  const auth = await requireAttendanceLeadManager();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const statusParam = url.searchParams.get("status");
+  const status = isLeadStatus(statusParam) ? statusParam : undefined;
+
+  try {
+    const leads = await listLeads(auth.session.db, status);
+    return jsonNoStore({ leads });
+  } catch (error) {
+    console.error("[api/club/attendance/leads GET]", error);
+    return jsonNoStore(
+      { error: "Impossible de charger les essais" },
+      { status: 500 },
+    );
+  }
+}
+
+/** POST /api/club/attendance/leads — essai + présence guest. */
+export async function POST(req: Request) {
+  if (!validateOrigin(req)) {
+    return invalidOriginResponse();
+  }
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const rate = checkRateLimit(
+    `attendance-lead:${auth.session.uid}`,
+    20,
+    15 * 60 * 1000,
+  );
+  if (!rate.allowed) {
+    return jsonNoStore({ error: "Trop de créations d'essai" }, { status: 429 });
+  }
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return jsonNoStore({ error: "JSON invalide" }, { status: 400 });
+  }
+  const parsed = attendanceLeadCreateSchema.safeParse(json);
+  if (!parsed.success) {
+    return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slot = findSlotOption(config, parsed.data.slotId, parsed.data.date);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    const email = parsed.data.email?.trim()
+      ? parsed.data.email.trim()
+      : undefined;
+    const created = await createLeadWithGuestMark(auth.session.db, {
+      date: parsed.data.date,
+      slotId: parsed.data.slotId,
+      siteId: slot.siteId,
+      seasonLabel: config.meta.seasonLabel,
+      firstName: parsed.data.firstName,
+      lastName: parsed.data.lastName,
+      phone: parsed.data.phone,
+      email,
+      createdByUid: auth.session.uid,
+    });
+    logAuditAction(AUDIT_ACTIONS.ATTENDANCE_LEAD_CREATED, auth.session.uid, {
+      resource: "attendanceLead",
+      resourceId: created.lead.id,
+      success: true,
+    });
+    return jsonNoStore(created, { status: 201 });
+  } catch (error) {
+    console.error("[api/club/attendance/leads POST]", error);
+    return jsonNoStore(
+      { error: "Impossible d'enregistrer l'essai" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/club/attendance/marks/route.ts
+++ b/src/app/api/club/attendance/marks/route.ts
@@ -1,0 +1,136 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import {
+  invalidOriginResponse,
+  requireAttendanceOperator,
+} from "@/lib/attendance/api-auth";
+import { attendanceMarkBodySchema } from "@/lib/attendance/schema";
+import { findSlotOption } from "@/lib/attendance/slots-for-date";
+import { isYmd } from "@/lib/attendance/calendar";
+import { isRejectedRegistration } from "@/lib/attendance/alerts";
+import { displayNameFromParts } from "@/lib/attendance/roster";
+import { buildAttendanceMarkId } from "@/lib/attendance/mark-id";
+import {
+  deleteAttendanceMark,
+  getRegistrationData,
+  upsertAttendanceMark,
+} from "@/lib/attendance/store";
+
+function readName(data: Record<string, unknown>): string {
+  const firstName = typeof data.firstName === "string" ? data.firstName : "";
+  const lastName = typeof data.lastName === "string" ? data.lastName : "";
+  return displayNameFromParts(firstName, lastName);
+}
+
+/** PUT /api/club/attendance/marks — pointer présent. */
+export async function PUT(req: Request) {
+  if (!validateOrigin(req)) {
+    return invalidOriginResponse();
+  }
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return jsonNoStore({ error: "JSON invalide" }, { status: 400 });
+  }
+  const parsed = attendanceMarkBodySchema.safeParse(json);
+  if (!parsed.success) {
+    return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+  }
+  const body = parsed.data;
+  if (!isYmd(body.date)) {
+    return jsonNoStore({ error: "Date invalide" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slot = findSlotOption(config, body.slotId, body.date);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+
+    let displayName = "Présent";
+    if (body.kind !== "guest" && body.registrationId) {
+      const data = await getRegistrationData(auth.session.db, body.registrationId);
+      if (!data || isRejectedRegistration(data)) {
+        return jsonNoStore({ error: "Dossier introuvable" }, { status: 404 });
+      }
+      displayName = readName(data) || body.registrationId;
+    }
+
+    const mark = await upsertAttendanceMark(auth.session.db, {
+      date: body.date,
+      slotId: body.slotId,
+      siteId: slot.siteId,
+      seasonLabel: config.meta.seasonLabel,
+      kind: body.kind,
+      registrationId: body.registrationId,
+      leadId: body.leadId,
+      displayName,
+      markedByUid: auth.session.uid,
+      addSlotRequested: body.addSlotRequested,
+    });
+    logAuditAction(AUDIT_ACTIONS.ATTENDANCE_MARKED, auth.session.uid, {
+      resource: "attendanceMark",
+      resourceId: mark.id,
+      success: true,
+    });
+    return jsonNoStore({ mark });
+  } catch (error) {
+    console.error("[api/club/attendance/marks PUT]", error);
+    return jsonNoStore({ error: "Impossible d'enregistrer la présence" }, { status: 500 });
+  }
+}
+
+/** DELETE /api/club/attendance/marks?date=&slotId=&kind=&registrationId=&leadId= */
+export async function DELETE(req: Request) {
+  if (!validateOrigin(req)) {
+    return invalidOriginResponse();
+  }
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const parsed = attendanceMarkBodySchema.safeParse({
+    date: url.searchParams.get("date"),
+    slotId: url.searchParams.get("slotId"),
+    kind: url.searchParams.get("kind"),
+    registrationId: url.searchParams.get("registrationId") || undefined,
+    leadId: url.searchParams.get("leadId") || undefined,
+  });
+  if (!parsed.success) {
+    return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+  }
+
+  const markId = buildAttendanceMarkId(parsed.data);
+  if (!markId) {
+    return jsonNoStore({ error: "Identifiant invalide" }, { status: 400 });
+  }
+
+  try {
+    const deleted = await deleteAttendanceMark(auth.session.db, markId);
+    if (!deleted) {
+      return jsonNoStore({ error: "Présence introuvable" }, { status: 404 });
+    }
+    logAuditAction(AUDIT_ACTIONS.ATTENDANCE_UNMARKED, auth.session.uid, {
+      resource: "attendanceMark",
+      resourceId: markId,
+      success: true,
+    });
+    return jsonNoStore({ ok: true });
+  } catch (error) {
+    console.error("[api/club/attendance/marks DELETE]", error);
+    return jsonNoStore({ error: "Impossible de retirer la présence" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/members/route.ts
+++ b/src/app/api/club/attendance/members/route.ts
@@ -1,0 +1,37 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { checkRateLimit } from "@/lib/auth/rate-limit";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { searchMembersNotOnSlot } from "@/lib/attendance/search-members";
+
+/** GET /api/club/attendance/members?q=&slotId= */
+export async function GET(req: Request) {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const query = url.searchParams.get("q")?.trim() ?? "";
+  const slotId = url.searchParams.get("slotId")?.trim() ?? "";
+  if (query.length < 2) {
+    return jsonNoStore({ members: [] });
+  }
+  if (!slotId) {
+    return jsonNoStore({ error: "Créneau requis" }, { status: 400 });
+  }
+
+  const rate = checkRateLimit(`attendance-search:${auth.session.uid}`, 30, 60 * 1000);
+  if (!rate.allowed) {
+    return jsonNoStore({ error: "Trop de recherches" }, { status: 429 });
+  }
+
+  try {
+    const members = await searchMembersNotOnSlot(auth.session.db, query, slotId);
+    return jsonNoStore({ members });
+  } catch (error) {
+    console.error("[api/club/attendance/members GET]", error);
+    return jsonNoStore({ error: "Impossible de chercher un adhérent" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/sessions/route.ts
+++ b/src/app/api/club/attendance/sessions/route.ts
@@ -1,0 +1,42 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { isYmd, todayYmdInParis } from "@/lib/attendance/calendar";
+import { findSlotOption } from "@/lib/attendance/slots-for-date";
+import { listMarksForSession, listRegistrationsForSlot } from "@/lib/attendance/store";
+import { buildSessionPayload } from "@/lib/attendance/roster";
+
+/** GET /api/club/attendance/sessions?date=&slotId= */
+export async function GET(req: Request) {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const dateParam = url.searchParams.get("date");
+  const slotId = url.searchParams.get("slotId")?.trim() ?? "";
+  const date = dateParam && isYmd(dateParam) ? dateParam : todayYmdInParis();
+  if (!slotId) {
+    return jsonNoStore({ error: "Créneau requis" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slot = findSlotOption(config, slotId, date);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    const [registrations, marks] = await Promise.all([
+      listRegistrationsForSlot(auth.session.db, slotId),
+      listMarksForSession(auth.session.db, date, slotId),
+    ]);
+    const session = buildSessionPayload({ date, slot, registrations, marks });
+    return jsonNoStore({ session, seasonLabel: config.meta.seasonLabel });
+  } catch (error) {
+    console.error("[api/club/attendance/sessions GET]", error);
+    return jsonNoStore({ error: "Impossible de charger la séance" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/slots/route.ts
+++ b/src/app/api/club/attendance/slots/route.ts
@@ -1,0 +1,30 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { isYmd, todayYmdInParis, currentMinutesInParis } from "@/lib/attendance/calendar";
+import { listSlotsForDate } from "@/lib/attendance/slots-for-date";
+
+/** GET /api/club/attendance/slots?date=YYYY-MM-DD */
+export async function GET(req: Request) {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const dateParam = url.searchParams.get("date");
+  const date = dateParam && isYmd(dateParam) ? dateParam : todayYmdInParis();
+  const nowMinutes =
+    date === todayYmdInParis() ? currentMinutesInParis() : 12 * 60;
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slots = listSlotsForDate(config, date, nowMinutes);
+    return jsonNoStore({ date, slots, seasonLabel: config.meta.seasonLabel });
+  } catch (error) {
+    console.error("[api/club/attendance/slots GET]", error);
+    return jsonNoStore({ error: "Impossible de charger les créneaux" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/attendance/stats/route.ts
+++ b/src/app/api/club/attendance/stats/route.ts
@@ -1,0 +1,57 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { isYmd, todayYmdInParis } from "@/lib/attendance/calendar";
+import { findSlotOption } from "@/lib/attendance/slots-for-date";
+import { listMarksForSlotSeason, listRegistrationsForSlot } from "@/lib/attendance/store";
+import { buildSlotStats } from "@/lib/attendance/stats";
+import { isIsoWeekday, resolveSlotSchedule } from "@/lib/club-registration-config/slot-schedule";
+
+/** GET /api/club/attendance/stats?date=&slotId= */
+export async function GET(req: Request) {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const url = new URL(req.url);
+  const dateParam = url.searchParams.get("date");
+  const slotId = url.searchParams.get("slotId")?.trim() ?? "";
+  const date = dateParam && isYmd(dateParam) ? dateParam : todayYmdInParis();
+  if (!slotId) {
+    return jsonNoStore({ error: "Créneau requis" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const slot = findSlotOption(config, slotId, date);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    const site = config.sites.find((item) => item.id === slot.siteId);
+    const catalogSlot = site?.slots.find((item) => item.id === slotId);
+    const schedule = catalogSlot ? resolveSlotSchedule(catalogSlot) : null;
+    const weekday = schedule?.weekday ?? slot.weekday;
+    if (!isIsoWeekday(weekday)) {
+      return jsonNoStore({ error: "Créneau sans horaire structuré" }, { status: 400 });
+    }
+    const [registrations, marks] = await Promise.all([
+      listRegistrationsForSlot(auth.session.db, slotId),
+      listMarksForSlotSeason(auth.session.db, config.meta.seasonLabel, slotId),
+    ]);
+    const stats = buildSlotStats({
+      date,
+      slotId,
+      weekday,
+      seasonLabel: config.meta.seasonLabel,
+      registrations,
+      marks,
+    });
+    return jsonNoStore({ stats });
+  } catch (error) {
+    console.error("[api/club/attendance/stats GET]", error);
+    return jsonNoStore({ error: "Impossible de charger les statistiques" }, { status: 500 });
+  }
+}

--- a/src/app/club/presences/essais/page.tsx
+++ b/src/app/club/presences/essais/page.tsx
@@ -1,0 +1,14 @@
+import { AuthGuard } from "@/components/AuthGuard";
+import { AttendanceLeadsClient } from "@/components/attendance/AttendanceLeadsClient";
+import { ATTENDANCE_LEAD_MANAGER_ROLES } from "@/lib/attendance/access";
+
+export default function ClubPresencesEssaisPage() {
+  return (
+    <AuthGuard
+      allowedRoles={[...ATTENDANCE_LEAD_MANAGER_ROLES]}
+      redirectWhenUnauthorized="/joueur"
+    >
+      <AttendanceLeadsClient />
+    </AuthGuard>
+  );
+}

--- a/src/app/club/presences/page.tsx
+++ b/src/app/club/presences/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+import { AuthGuard } from "@/components/AuthGuard";
+import { AttendanceSlotSelectClient } from "@/components/attendance/AttendanceSlotSelectClient";
+import { ATTENDANCE_OPERATOR_ROLES } from "@/lib/attendance/access";
+
+export default function ClubPresencesPage() {
+  return (
+    <AuthGuard
+      allowedRoles={[...ATTENDANCE_OPERATOR_ROLES]}
+      redirectWhenUnauthorized="/joueur"
+    >
+      <Suspense>
+        <AttendanceSlotSelectClient />
+      </Suspense>
+    </AuthGuard>
+  );
+}

--- a/src/app/club/presences/seance/page.tsx
+++ b/src/app/club/presences/seance/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+import { AuthGuard } from "@/components/AuthGuard";
+import { AttendanceSessionClient } from "@/components/attendance/AttendanceSessionClient";
+import { ATTENDANCE_OPERATOR_ROLES } from "@/lib/attendance/access";
+
+export default function ClubPresencesSeancePage() {
+  return (
+    <AuthGuard
+      allowedRoles={[...ATTENDANCE_OPERATOR_ROLES]}
+      redirectWhenUnauthorized="/joueur"
+    >
+      <Suspense>
+        <AttendanceSessionClient />
+      </Suspense>
+    </AuthGuard>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,11 +14,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import {
-  AccountCircle,
-  Logout,
-  Menu as MenuIcon,
-} from "@mui/icons-material";
+import { AccountCircle, Logout, Menu as MenuIcon } from "@mui/icons-material";
 import { LayoutAccountMenuItems } from "@/components/LayoutAccountMenuItems";
 import {
   buildLayoutAccountMenuItems,
@@ -43,8 +39,15 @@ interface LayoutProps {
 }
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
-  const { user, signOut, isAdmin, isPlayerLike, isAssistantSecretary, isSecretary } =
-    useAuth();
+  const {
+    user,
+    signOut,
+    isAdmin,
+    isPlayerLike,
+    isAssistantSecretary,
+    isSecretary,
+    isBoardMember,
+  } = useAuth();
 
   const router = useRouter();
   const pathname = usePathname();
@@ -58,29 +61,34 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
       isPlayerLike,
       isAssistantSecretary,
       isSecretary,
+      isBoardMember,
       canAccessSpreadsheet: Boolean(
-        user && canAccessRegistrationsSpreadsheet(user.role)
+        user && canAccessRegistrationsSpreadsheet(user.role),
       ),
     }),
-    [isAdmin, isAssistantSecretary, isPlayerLike, isSecretary, user]
+    [
+      isAdmin,
+      isAssistantSecretary,
+      isBoardMember,
+      isPlayerLike,
+      isSecretary,
+      user,
+    ],
   );
 
   const navigation = useMemo(
     () => buildLayoutNavigation(navOptions),
-    [navOptions]
+    [navOptions],
   );
 
   const accountMenuItems = useMemo(
     () => buildLayoutAccountMenuItems(navOptions),
-    [navOptions]
+    [navOptions],
   );
 
   const homeHref = useMemo(
-    () =>
-      user
-        ? resolveLayoutHomeHref({ isPlayerLike })
-        : "/",
-    [isPlayerLike, user]
+    () => (user ? resolveLayoutHomeHref({ isPlayerLike }) : "/"),
+    [isPlayerLike, user],
   );
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
@@ -101,8 +109,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     }
   };
 
-  const hasNav =
-    hasLayoutNavigation(navigation) || accountMenuItems.length > 0;
+  const hasNav = hasLayoutNavigation(navigation) || accountMenuItems.length > 0;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
@@ -119,7 +126,12 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
               color="inherit"
               aria-label="Ouvrir le menu de navigation"
               onClick={() => setDrawerOpen(true)}
-              sx={{ display: { xs: "inline-flex", [NAV_DESKTOP_BREAKPOINT]: "none" } }}
+              sx={{
+                display: {
+                  xs: "inline-flex",
+                  [NAV_DESKTOP_BREAKPOINT]: "none",
+                },
+              }}
             >
               <MenuIcon />
             </IconButton>

--- a/src/components/attendance/AttendanceAlertChips.tsx
+++ b/src/components/attendance/AttendanceAlertChips.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Chip, Stack } from "@mui/material";
+import { ATTENDANCE_ALERT_LABELS, type AttendanceAlert } from "@/lib/attendance/constants";
+
+export function AttendanceAlertChips({ alerts }: { alerts: AttendanceAlert[] }) {
+  if (alerts.length === 0) {
+    return null;
+  }
+  return (
+    <Stack direction="row" gap={0.75} flexWrap="wrap">
+      {alerts.map((alert) => (
+        <Chip key={alert} size="small" color="warning" label={ATTENDANCE_ALERT_LABELS[alert]} />
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/attendance/AttendanceGuestDialog.tsx
+++ b/src/components/attendance/AttendanceGuestDialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: {
+    firstName: string;
+    lastName: string;
+    phone: string;
+    email?: string;
+  }) => Promise<void>;
+};
+
+export function AttendanceGuestDialog({ open, onClose, onSubmit }: Props) {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  function reset() {
+    setFirstName("");
+    setLastName("");
+    setPhone("");
+    setEmail("");
+  }
+
+  async function handleSubmit() {
+    setBusy(true);
+    try {
+      await onSubmit({
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        phone: phone.trim(),
+        ...(email.trim() ? { email: email.trim() } : {}),
+      });
+      reset();
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const canSubmit = firstName.trim() && lastName.trim() && phone.trim().length >= 8;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Ajouter un essai</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Prénom"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            label="Nom"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            label="Téléphone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            label="Email (optionnel)"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            fullWidth
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Annuler</Button>
+        <Button
+          variant="contained"
+          disabled={!canSubmit || busy}
+          onClick={() => void handleSubmit()}
+          sx={{ minHeight: 48 }}
+        >
+          Pointer présent
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/attendance/AttendanceLeadsClient.tsx
+++ b/src/components/attendance/AttendanceLeadsClient.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Chip,
+  Container,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { PageHeader } from "@/components/ui";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import {
+  ATTENDANCE_LEAD_STATUSES,
+  ATTENDANCE_LEAD_STATUS_LABELS,
+  type AttendanceLeadStatus,
+} from "@/lib/attendance/constants";
+import type { AttendanceLead } from "@/lib/attendance/types";
+
+export function AttendanceLeadsClient() {
+  const [leads, setLeads] = useState<AttendanceLead[]>([]);
+  const [status, setStatus] = useState<AttendanceLeadStatus | "all">("open");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (status !== "all") params.set("status", status);
+      const res = await fetch(`/api/club/attendance/leads?${params.toString()}`);
+      const json = await readJsonResponse<{ leads?: AttendanceLead[]; error?: string }>(res);
+      if (!res.ok) throw new Error(json.error ?? "Impossible de charger les essais");
+      setLeads(json.leads ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function patchStatus(id: string, next: AttendanceLeadStatus) {
+    setBusyId(id);
+    try {
+      const res = await fetch(`/api/club/attendance/leads/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+      const json = await readJsonResponse<{ error?: string }>(res);
+      if (!res.ok) throw new Error(json.error ?? "Mise à jour impossible");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 2, md: 3 } }}>
+      <PageHeader
+        eyebrow="Club"
+        title="Essais à relancer"
+        subtitle="Personnes pointées comme essai depuis un entraînement, sans dossier d'adhésion."
+        marginBottom={3}
+      />
+      <Stack spacing={2}>
+        <TextField
+          select
+          label="Statut"
+          value={status}
+          onChange={(e) => setStatus(e.target.value as AttendanceLeadStatus | "all")}
+          sx={{ maxWidth: 240 }}
+        >
+          <MenuItem value="all">Tous</MenuItem>
+          {ATTENDANCE_LEAD_STATUSES.map((value) => (
+            <MenuItem key={value} value={value}>
+              {ATTENDANCE_LEAD_STATUS_LABELS[value]}
+            </MenuItem>
+          ))}
+        </TextField>
+        {error ? <Alert severity="error">{error}</Alert> : null}
+        {loading ? <Alert severity="info">Chargement…</Alert> : null}
+        {leads.map((lead) => (
+          <Stack
+            key={lead.id}
+            spacing={1}
+            sx={{ p: 2, border: 1, borderColor: "divider", borderRadius: 2 }}
+          >
+            <Stack direction="row" justifyContent="space-between" gap={1} flexWrap="wrap">
+              <Typography variant="h6">
+                {lead.firstName} {lead.lastName}
+              </Typography>
+              <Chip label={ATTENDANCE_LEAD_STATUS_LABELS[lead.status]} />
+            </Stack>
+            <Typography color="text.secondary">
+              {lead.phone}
+              {lead.email ? ` · ${lead.email}` : ""}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Séance du {lead.sourceDate} · créneau {lead.sourceSlotId}
+            </Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ATTENDANCE_LEAD_STATUSES.filter((value) => value !== lead.status).map((value) => (
+                <Button
+                  key={value}
+                  size="small"
+                  variant="outlined"
+                  disabled={busyId === lead.id}
+                  onClick={() => void patchStatus(lead.id, value)}
+                >
+                  {ATTENDANCE_LEAD_STATUS_LABELS[value]}
+                </Button>
+              ))}
+            </Stack>
+          </Stack>
+        ))}
+        {!loading && leads.length === 0 ? (
+          <Typography color="text.secondary">Aucun essai dans ce filtre.</Typography>
+        ) : null}
+      </Stack>
+    </Container>
+  );
+}

--- a/src/components/attendance/AttendancePlayerCard.tsx
+++ b/src/components/attendance/AttendancePlayerCard.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import type { AttendanceRosterPerson } from "@/lib/attendance/types";
+import { ATTENDANCE_ALERT_LABELS } from "@/lib/attendance/constants";
+
+type Props = {
+  person: AttendanceRosterPerson;
+  busy: boolean;
+  onToggle: () => void;
+};
+
+export function AttendancePlayerCard({ person, busy, onToggle }: Props) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        p: 1.5,
+        border: 1,
+        borderColor: person.present ? "success.main" : "divider",
+        bgcolor: person.present ? "success.light" : "background.paper",
+        borderRadius: 2,
+        minHeight: 72,
+      }}
+    >
+      <Stack spacing={0.5} sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="h6" component="p" sx={{ fontSize: "1.15rem", lineHeight: 1.2 }}>
+          {person.displayName}
+          {person.age != null ? (
+            <Typography component="span" color="text.secondary" sx={{ ml: 1, fontSize: "0.95rem" }}>
+              {person.age} ans
+            </Typography>
+          ) : null}
+        </Typography>
+        {person.alerts.length > 0 ? (
+          <Stack direction="row" gap={0.75} flexWrap="wrap">
+            {person.alerts.map((alert) => (
+              <Chip
+                key={alert}
+                size="small"
+                color="warning"
+                label={ATTENDANCE_ALERT_LABELS[alert]}
+              />
+            ))}
+          </Stack>
+        ) : null}
+      </Stack>
+      <Button
+        variant={person.present ? "contained" : "outlined"}
+        color={person.present ? "success" : "primary"}
+        onClick={onToggle}
+        disabled={busy}
+        sx={{ minHeight: 56, minWidth: 120, fontWeight: 700 }}
+      >
+        {person.present ? "Présent" : "Pointer"}
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/attendance/AttendanceRoster.tsx
+++ b/src/components/attendance/AttendanceRoster.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Stack, TextField, Typography } from "@mui/material";
+import type { AttendanceRosterPerson } from "@/lib/attendance/types";
+import { AttendancePlayerCard } from "./AttendancePlayerCard";
+
+type Props = {
+  title: string;
+  people: AttendanceRosterPerson[];
+  filter: string;
+  onFilterChange?: (value: string) => void;
+  busyKey: string | null;
+  onToggle: (person: AttendanceRosterPerson) => void;
+  emptyLabel: string;
+};
+
+export function AttendanceRoster({
+  title,
+  people,
+  filter,
+  onFilterChange,
+  busyKey,
+  onToggle,
+  emptyLabel,
+}: Props) {
+  const needle = filter.trim().toLowerCase();
+  const visible = needle
+    ? people.filter((person) => person.displayName.toLowerCase().includes(needle))
+    : people;
+
+  return (
+    <Stack spacing={1.25}>
+      <Typography variant="h6">{title}</Typography>
+      {onFilterChange ? (
+        <TextField
+          value={filter}
+          onChange={(e) => onFilterChange(e.target.value)}
+          placeholder="Filtrer la liste…"
+          size="medium"
+          fullWidth
+          inputProps={{ "aria-label": "Filtrer les inscrits" }}
+        />
+      ) : null}
+      {visible.length === 0 ? (
+        <Typography color="text.secondary">{emptyLabel}</Typography>
+      ) : (
+        visible.map((person) => (
+          <AttendancePlayerCard
+            key={person.personKey}
+            person={person}
+            busy={busyKey === person.personKey}
+            onToggle={() => onToggle(person)}
+          />
+        ))
+      )}
+    </Stack>
+  );
+}

--- a/src/components/attendance/AttendanceSearchDialog.tsx
+++ b/src/components/attendance/AttendanceSearchDialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import type { AttendanceMemberSearchHit } from "@/lib/attendance/types";
+import { AttendanceAlertChips } from "./AttendanceAlertChips";
+
+type Props = {
+  open: boolean;
+  slotId: string;
+  onClose: () => void;
+  onPick: (member: AttendanceMemberSearchHit, addSlot: boolean) => Promise<void>;
+};
+
+export function AttendanceSearchDialog({ open, slotId, onClose, onPick }: Props) {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<AttendanceMemberSearchHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setHits([]);
+      setError(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || query.trim().length < 2) {
+      setHits([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const params = new URLSearchParams({ q: query.trim(), slotId });
+          const res = await fetch(`/api/club/attendance/members?${params.toString()}`);
+          const json = await readJsonResponse<{
+            members?: AttendanceMemberSearchHit[];
+            error?: string;
+          }>(res);
+          if (cancelled) return;
+          if (!res.ok) throw new Error(json.error ?? "Recherche impossible");
+          setHits(json.members ?? []);
+        } catch (err) {
+          if (cancelled) return;
+          setHits([]);
+          setError(err instanceof Error ? err.message : "Erreur");
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [open, query, slotId]);
+
+  async function pick(member: AttendanceMemberSearchHit, addSlot: boolean) {
+    setBusyId(member.registrationId);
+    try {
+      await onPick(member, addSlot);
+      onClose();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Chercher un adhérent</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            autoFocus
+            label="Nom ou prénom"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            fullWidth
+          />
+          {loading ? <CircularProgress size={24} /> : null}
+          {error ? <Typography color="error">{error}</Typography> : null}
+          {hits.map((hit) => (
+            <Stack
+              key={hit.registrationId}
+              spacing={1}
+              sx={{ p: 1.5, border: 1, borderColor: "divider", borderRadius: 2 }}
+            >
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                {hit.displayName}
+              </Typography>
+              <AttendanceAlertChips alerts={hit.alerts} />
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+                <Button
+                  variant="contained"
+                  disabled={busyId === hit.registrationId}
+                  onClick={() => void pick(hit, false)}
+                  sx={{ minHeight: 48 }}
+                >
+                  Présent ce soir
+                </Button>
+                <Button
+                  variant="outlined"
+                  disabled={busyId === hit.registrationId}
+                  onClick={() => void pick(hit, true)}
+                  sx={{ minHeight: 48 }}
+                >
+                  Présent + ajouter le créneau
+                </Button>
+              </Stack>
+            </Stack>
+          ))}
+          {!loading && query.trim().length >= 2 && hits.length === 0 ? (
+            <Typography color="text.secondary">Aucun adhérent hors créneau.</Typography>
+          ) : null}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Fermer</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/attendance/AttendanceSessionClient.tsx
+++ b/src/components/attendance/AttendanceSessionClient.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Alert,
+  Button,
+  Container,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from "@mui/material";
+import ArrowBack from "@mui/icons-material/ArrowBack";
+import { PageHeader } from "@/components/ui";
+import { TabPanel } from "@/components/ui";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import { todayYmdInParis } from "@/lib/attendance/calendar";
+import {
+  attendancePickerHref,
+  readAttendanceDateParam,
+} from "@/lib/attendance/urls";
+import { formatMinutesAsLabel } from "@/lib/club-registration-config/slot-schedule";
+import type { AttendanceMemberSearchHit, AttendanceRosterPerson } from "@/lib/attendance/types";
+import { useAttendanceSession } from "./useAttendanceSession";
+import { AttendanceRoster } from "./AttendanceRoster";
+import { AttendanceSearchDialog } from "./AttendanceSearchDialog";
+import { AttendanceGuestDialog } from "./AttendanceGuestDialog";
+import { AttendanceStatsPanel } from "./AttendanceStatsPanel";
+import { AttendanceSessionDock, AttendanceSessionDockSpacer } from "./AttendanceSessionDock";
+
+export function AttendanceSessionClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const date = readAttendanceDateParam(searchParams.get("date"), todayYmdInParis());
+  const slotId = searchParams.get("slot")?.trim() || null;
+  const [filter, setFilter] = useState("");
+  const [tab, setTab] = useState(0);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [guestOpen, setGuestOpen] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const { session, loading, error, busyKey, reload, togglePresent } = useAttendanceSession(
+    date,
+    slotId
+  );
+
+  useEffect(() => {
+    if (!slotId) {
+      router.replace(attendancePickerHref(date));
+    }
+  }, [date, router, slotId]);
+
+  const waiting = session?.roster.filter((person) => !person.present) ?? [];
+  const present = session?.roster.filter((person) => person.present) ?? [];
+  const counts = session?.counts;
+
+  async function handleWalkIn(member: AttendanceMemberSearchHit, addSlot: boolean) {
+    if (!slotId) return;
+    setActionError(null);
+    try {
+      const markRes = await fetch("/api/club/attendance/marks", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          date,
+          slotId,
+          kind: "walkin",
+          registrationId: member.registrationId,
+        }),
+      });
+      const markJson = await readJsonResponse<{ error?: string }>(markRes);
+      if (!markRes.ok) {
+        throw new Error(markJson.error ?? "Impossible de pointer");
+      }
+      if (addSlot) {
+        const slotRes = await fetch("/api/club/attendance/add-slot", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            date,
+            slotId,
+            registrationId: member.registrationId,
+          }),
+        });
+        const slotJson = await readJsonResponse<{ error?: string }>(slotRes);
+        if (!slotRes.ok) {
+          throw new Error(slotJson.error ?? "Impossible d'ajouter le créneau");
+        }
+      }
+      await reload();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de pointer";
+      setActionError(message);
+      throw err;
+    }
+  }
+
+  async function handleGuest(payload: {
+    firstName: string;
+    lastName: string;
+    phone: string;
+    email?: string;
+  }) {
+    if (!slotId) return;
+    setActionError(null);
+    try {
+      const res = await fetch("/api/club/attendance/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date, slotId, ...payload }),
+      });
+      const json = await readJsonResponse<{ error?: string }>(res);
+      if (!res.ok) {
+        throw new Error(json.error ?? "Impossible d'enregistrer l'essai");
+      }
+      await reload();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible d'enregistrer l'essai";
+      setActionError(message);
+      throw err;
+    }
+  }
+
+  function onToggle(person: AttendanceRosterPerson) {
+    void togglePresent({
+      personKey: person.personKey,
+      kind: person.kind,
+      present: person.present,
+      ...(person.registrationId ? { registrationId: person.registrationId } : {}),
+      ...(person.leadId ? { leadId: person.leadId } : {}),
+    });
+  }
+
+  if (!slotId) {
+    return null;
+  }
+
+  const slotTitle = session
+    ? `${formatMinutesAsLabel(session.slot.startMinutes)} – ${formatMinutesAsLabel(session.slot.endMinutes)}`
+    : "Séance";
+  const slotSubtitle = session
+    ? `${session.slot.siteLabel} · ${session.slot.label}`
+    : "Chargement du créneau…";
+
+  return (
+    <Container maxWidth="md" sx={{ pt: { xs: 2, md: 3 }, pb: 2 }}>
+      <Button
+        startIcon={<ArrowBack />}
+        onClick={() => router.push(attendancePickerHref(date))}
+        sx={{ mb: 1, minHeight: 44 }}
+      >
+        Changer de créneau
+      </Button>
+      <PageHeader
+        eyebrow={date}
+        title={slotTitle}
+        subtitle={slotSubtitle}
+        marginBottom={2}
+        actions={
+          counts ? (
+            <Typography variant="body2" color="text.secondary">
+              {counts.presentEnrolled}/{counts.enrolled} inscrits
+            </Typography>
+          ) : undefined
+        }
+      />
+      <Tabs
+        value={tab}
+        onChange={(_event, value: number) => setTab(value)}
+        aria-label="Vues de la séance"
+        sx={{ mb: 2 }}
+      >
+        <Tab id="attendance-tab-0" aria-controls="attendance-tabpanel-0" label="Pointage" />
+        <Tab id="attendance-tab-1" aria-controls="attendance-tabpanel-1" label="Taux" />
+      </Tabs>
+      {actionError || error ? (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {actionError ?? error}
+        </Alert>
+      ) : null}
+      <TabPanel value={tab} index={0} baseId="attendance">
+        <Stack spacing={3}>
+          {loading && !session ? (
+            <Alert severity="info">Chargement de la liste…</Alert>
+          ) : null}
+          <AttendanceRoster
+            title="À pointer"
+            people={waiting}
+            filter={filter}
+            onFilterChange={setFilter}
+            busyKey={busyKey}
+            onToggle={onToggle}
+            emptyLabel="Tout le monde est pointé, ou aucun inscrit."
+          />
+          <AttendanceRoster
+            title="Présents inscrits"
+            people={present}
+            filter={filter}
+            busyKey={busyKey}
+            onToggle={onToggle}
+            emptyLabel="Personne n'est encore pointé."
+          />
+          <AttendanceRoster
+            title="Hors créneau / essais"
+            people={session?.extras ?? []}
+            filter=""
+            busyKey={busyKey}
+            onToggle={onToggle}
+            emptyLabel="Aucun visiteur pour cette séance."
+          />
+          <AttendanceSessionDockSpacer />
+        </Stack>
+      </TabPanel>
+      <TabPanel value={tab} index={1} baseId="attendance">
+        <Stack spacing={2}>
+          <Button
+            variant="outlined"
+            href={`/api/club/attendance/export?date=${encodeURIComponent(date)}&slotId=${encodeURIComponent(slotId)}`}
+            sx={{ alignSelf: "flex-start", minHeight: 48 }}
+          >
+            Exporter CSV
+          </Button>
+          <AttendanceStatsPanel date={date} slotId={slotId} />
+        </Stack>
+      </TabPanel>
+      {tab === 0 ? (
+        <AttendanceSessionDock
+          onSearch={() => setSearchOpen(true)}
+          onGuest={() => setGuestOpen(true)}
+        />
+      ) : null}
+      <AttendanceSearchDialog
+        open={searchOpen}
+        slotId={slotId}
+        onClose={() => setSearchOpen(false)}
+        onPick={handleWalkIn}
+      />
+      <AttendanceGuestDialog
+        open={guestOpen}
+        onClose={() => setGuestOpen(false)}
+        onSubmit={handleGuest}
+      />
+    </Container>
+  );
+}

--- a/src/components/attendance/AttendanceSessionDock.tsx
+++ b/src/components/attendance/AttendanceSessionDock.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Box, Button, Paper, Stack } from "@mui/material";
+
+type Props = {
+  onSearch: () => void;
+  onGuest: () => void;
+};
+
+/** Hauteur réservée au-dessus du dock (boutons + safe area). */
+export const ATTENDANCE_SESSION_DOCK_CLEARANCE =
+  "calc(96px + env(safe-area-inset-bottom, 0px))";
+
+export function AttendanceSessionDock({ onSearch, onGuest }: Props) {
+  return (
+    <Paper
+      elevation={8}
+      square
+      sx={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 8,
+        px: 2,
+        pt: 1.5,
+        pb: "calc(12px + env(safe-area-inset-bottom, 0px))",
+        borderTop: 1,
+        borderColor: "divider",
+      }}
+    >
+      <Stack direction="row" spacing={1.5} sx={{ maxWidth: 900, mx: "auto" }}>
+        <Button variant="contained" fullWidth onClick={onSearch} sx={{ minHeight: 52 }}>
+          Chercher un adhérent
+        </Button>
+        <Button variant="outlined" fullWidth onClick={onGuest} sx={{ minHeight: 52 }}>
+          Ajouter un essai
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}
+
+export function AttendanceSessionDockSpacer() {
+  return <Box aria-hidden sx={{ height: ATTENDANCE_SESSION_DOCK_CLEARANCE, flexShrink: 0 }} />;
+}

--- a/src/components/attendance/AttendanceSlotPicker.tsx
+++ b/src/components/attendance/AttendanceSlotPicker.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { AttendanceSlotOption } from "@/lib/attendance/types";
+import { formatMinutesAsLabel } from "@/lib/club-registration-config/slot-schedule";
+
+type Props = {
+  slots: AttendanceSlotOption[];
+  loading: boolean;
+  error: string | null;
+  selectedSlotId: string | null;
+  onSelect: (slotId: string) => void;
+};
+
+export function AttendanceSlotPicker({
+  slots,
+  loading,
+  error,
+  selectedSlotId,
+  onSelect,
+}: Props) {
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+  if (slots.length === 0) {
+    return (
+      <Alert severity="info">Aucun créneau prévu pour ce jour.</Alert>
+    );
+  }
+
+  const bySite = new Map<string, AttendanceSlotOption[]>();
+  for (const slot of slots) {
+    const list = bySite.get(slot.siteLabel) ?? [];
+    list.push(slot);
+    bySite.set(slot.siteLabel, list);
+  }
+
+  return (
+    <Stack spacing={2}>
+      {[...bySite.entries()].map(([siteLabel, siteSlots]) => (
+        <Box key={siteLabel}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1 }}>
+            {siteLabel}
+            {siteSlots[0]?.gymnasiumName ? ` · ${siteSlots[0].gymnasiumName}` : ""}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" gap={1.5}>
+            {siteSlots.map((slot) => {
+              const selected = slot.slotId === selectedSlotId;
+              return (
+                <Button
+                  key={slot.slotId}
+                  variant={selected ? "contained" : "outlined"}
+                  color={slot.highlighted ? "secondary" : "primary"}
+                  onClick={() => onSelect(slot.slotId)}
+                  sx={{
+                    minHeight: 64,
+                    px: 2,
+                    justifyContent: "flex-start",
+                    textAlign: "left",
+                    borderWidth: slot.highlighted ? 2 : 1,
+                  }}
+                >
+                  <Stack spacing={0.25} alignItems="flex-start">
+                    <Typography variant="body1" sx={{ fontWeight: 700 }}>
+                      {formatMinutesAsLabel(slot.startMinutes)} –{" "}
+                      {formatMinutesAsLabel(slot.endMinutes)}
+                    </Typography>
+                    <Typography variant="caption" sx={{ opacity: 0.9 }}>
+                      {slot.label}
+                    </Typography>
+                    {slot.highlighted ? (
+                      <Chip size="small" label="Proche de maintenant" />
+                    ) : null}
+                  </Stack>
+                </Button>
+              );
+            })}
+          </Stack>
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/attendance/AttendanceSlotSelectClient.tsx
+++ b/src/components/attendance/AttendanceSlotSelectClient.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Container, Stack, TextField, Typography } from "@mui/material";
+import { PageHeader } from "@/components/ui";
+import { todayYmdInParis } from "@/lib/attendance/calendar";
+import { attendanceSessionHref, readAttendanceDateParam } from "@/lib/attendance/urls";
+import { useAttendanceSlots } from "./useAttendanceSlots";
+import { AttendanceSlotPicker } from "./AttendanceSlotPicker";
+
+export function AttendanceSlotSelectClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const date = readAttendanceDateParam(searchParams.get("date"), todayYmdInParis());
+  const { slots, loading, error } = useAttendanceSlots(date);
+
+  useEffect(() => {
+    if (!searchParams.get("date")) {
+      router.replace(`/club/presences?date=${encodeURIComponent(date)}`);
+    }
+  }, [date, router, searchParams]);
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 2, md: 3 } }}>
+      <PageHeader
+        eyebrow="Présences"
+        title="Choisir un créneau"
+        subtitle="Sélectionnez la séance à pointer. Le créneau le plus proche de l’heure actuelle est mis en avant."
+        marginBottom={3}
+      />
+      <Stack spacing={3}>
+        <TextField
+          label="Jour"
+          type="date"
+          value={date}
+          onChange={(e) => {
+            const next = e.target.value;
+            router.replace(`/club/presences?date=${encodeURIComponent(next)}`);
+          }}
+          slotProps={{ inputLabel: { shrink: true } }}
+          sx={{ maxWidth: 280 }}
+        />
+        <Typography variant="subtitle2" color="text.secondary">
+          Créneaux du jour
+        </Typography>
+        <AttendanceSlotPicker
+          slots={slots}
+          loading={loading}
+          error={error}
+          selectedSlotId={null}
+          onSelect={(slotId) => router.push(attendanceSessionHref(date, slotId))}
+        />
+      </Stack>
+    </Container>
+  );
+}

--- a/src/components/attendance/AttendanceStatsPanel.tsx
+++ b/src/components/attendance/AttendanceStatsPanel.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  LinearProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import type { AttendanceSlotStats } from "@/lib/attendance/types";
+
+type Props = {
+  date: string;
+  slotId: string | null;
+};
+
+export function AttendanceStatsPanel({ date, slotId }: Props) {
+  const [stats, setStats] = useState<AttendanceSlotStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slotId) {
+      setStats(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({ date, slotId });
+        const res = await fetch(`/api/club/attendance/stats?${params.toString()}`);
+        const json = await readJsonResponse<{ stats?: AttendanceSlotStats; error?: string }>(res);
+        if (!res.ok || !json.stats) {
+          throw new Error(json.error ?? "Impossible de charger les stats");
+        }
+        if (!cancelled) setStats(json.stats);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Erreur");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [date, slotId]);
+
+  if (!slotId) {
+    return null;
+  }
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+  if (!stats) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Taux de présence (saison)</Typography>
+      <Typography color="text.secondary">
+        Séance : {stats.presentEnrolled}/{stats.enrolled} inscrits · {stats.walkin} hors
+        créneau · {stats.guest} essai{stats.guest > 1 ? "s" : ""}
+      </Typography>
+      {stats.players.map((player) => {
+        const percent = player.rate == null ? 0 : Math.round(player.rate * 100);
+        return (
+          <Box key={player.registrationId}>
+            <Stack direction="row" justifyContent="space-between">
+              <Typography>{player.displayName}</Typography>
+              <Typography color="text.secondary">
+                {player.presentCount}/{player.expectedCount}
+                {player.rate != null ? ` · ${percent} %` : ""}
+              </Typography>
+            </Stack>
+            <LinearProgress
+              variant="determinate"
+              value={Math.min(100, percent)}
+              sx={{ height: 10, borderRadius: 1, mt: 0.5 }}
+            />
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/src/components/attendance/useAttendanceSession.ts
+++ b/src/components/attendance/useAttendanceSession.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import type { AttendanceMarkKind } from "@/lib/attendance/constants";
+import type { AttendanceSessionPayload } from "@/lib/attendance/types";
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  const json = await readJsonResponse<{ error?: string }>(res);
+  return json.error ?? fallback;
+}
+
+export function useAttendanceSession(date: string, slotId: string | null) {
+  const [session, setSession] = useState<AttendanceSessionPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!slotId) {
+      setSession(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ date, slotId });
+      const res = await fetch(`/api/club/attendance/sessions?${params.toString()}`);
+      const json = await readJsonResponse<{
+        session?: AttendanceSessionPayload;
+        error?: string;
+      }>(res);
+      if (!res.ok || !json.session) {
+        throw new Error(json.error ?? "Impossible de charger la séance");
+      }
+      setSession(json.session);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur");
+      setSession(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [date, slotId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const togglePresent = useCallback(
+    async (params: {
+      personKey: string;
+      kind: AttendanceMarkKind;
+      registrationId?: string;
+      leadId?: string;
+      present: boolean;
+    }) => {
+      if (!slotId) return;
+      setBusyKey(params.personKey);
+      try {
+        if (params.present) {
+          const query = new URLSearchParams({
+            date,
+            slotId,
+            kind: params.kind,
+          });
+          if (params.registrationId) query.set("registrationId", params.registrationId);
+          if (params.leadId) query.set("leadId", params.leadId);
+          const res = await fetch(`/api/club/attendance/marks?${query.toString()}`, {
+            method: "DELETE",
+          });
+          if (!res.ok) throw new Error(await readError(res, "Impossible de dépointer"));
+        } else {
+          const res = await fetch("/api/club/attendance/marks", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              date,
+              slotId,
+              kind: params.kind,
+              registrationId: params.registrationId,
+              leadId: params.leadId,
+            }),
+          });
+          if (!res.ok) throw new Error(await readError(res, "Impossible de pointer"));
+        }
+        await load();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Erreur");
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [date, slotId, load]
+  );
+
+  return { session, loading, error, setError, busyKey, reload: load, togglePresent };
+}

--- a/src/components/attendance/useAttendanceSlots.ts
+++ b/src/components/attendance/useAttendanceSlots.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import type { AttendanceSlotOption } from "@/lib/attendance/types";
+import { todayYmdInParis } from "@/lib/attendance/calendar";
+
+export function useAttendanceSlots(date: string) {
+  const [slots, setSlots] = useState<AttendanceSlotOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/club/attendance/slots?date=${encodeURIComponent(date)}`);
+      const json = await readJsonResponse<{ slots?: AttendanceSlotOption[]; error?: string }>(
+        res
+      );
+      if (!res.ok) {
+        throw new Error(json.error ?? "Impossible de charger les créneaux");
+      }
+      setSlots(json.slots ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur");
+      setSlots([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [date]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { slots, loading, error, reload: load };
+}
+
+export function useDefaultAttendanceDate(): [string, (value: string) => void] {
+  const [date, setDate] = useState(todayYmdInParis);
+  return [date, setDate];
+}

--- a/src/components/club-registration-config/SiteLocationEditorCard.tsx
+++ b/src/components/club-registration-config/SiteLocationEditorCard.tsx
@@ -222,6 +222,9 @@ export function createEmptySlot(existingSlots: RegistrationSiteSlot[]) {
     label: "Nouveau créneau",
     enabled: true,
     sortOrder: nextSortOrder(existingSlots),
+    weekday: 1 as const,
+    startMinutes: 17 * 60,
+    endMinutes: 18 * 60 + 30,
   };
 }
 

--- a/src/components/club-registration-config/SiteSlotEditorCard.tsx
+++ b/src/components/club-registration-config/SiteSlotEditorCard.tsx
@@ -2,11 +2,23 @@
 
 import type { ConfigEditorDragHandleProps } from "./ConfigEditorLayout";
 import {
+  FormControl,
   FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
   Switch,
   TextField,
 } from "@mui/material";
 import type { RegistrationSiteSlot } from "@/lib/club-registration-config/types";
+import {
+  ISO_WEEKDAY_LABELS,
+  formatMinutesAsInput,
+  isIsoWeekday,
+  parseTimeInput,
+  type IsoWeekday,
+} from "@/lib/club-registration-config/slot-schedule";
 import { ConfigEditorCollapsibleItem, ConfigEditorOptionPanel } from "./ConfigEditorLayout";
 import { ConfigEditorRemoveAction } from "./ConfigEditorRemoveAction";
 import { slotItemDecor } from "./config-editor-item-decor";
@@ -24,6 +36,8 @@ type Props = {
   isDragging?: boolean;
 };
 
+const WEEKDAY_OPTIONS: IsoWeekday[] = [1, 2, 3, 4, 5, 6, 7];
+
 export function SiteSlotEditorCard({
   slot,
   expanded,
@@ -35,6 +49,9 @@ export function SiteSlotEditorCard({
   isDragging = false,
 }: Props) {
   const schoolPickupEnabled = Boolean(slot.schoolPickupSchool);
+  const weekday = isIsoWeekday(slot.weekday) ? slot.weekday : 1;
+  const startInput = formatMinutesAsInput(slot.startMinutes ?? 17 * 60);
+  const endInput = formatMinutesAsInput(slot.endMinutes ?? 18 * 60 + 30);
 
   return (
     <ConfigEditorCollapsibleItem
@@ -59,6 +76,46 @@ export function SiteSlotEditorCard({
         helperText="Ex. Lundi / 17h00 – 18h30 / Jeunes Loisirs"
         fullWidth
       />
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5}>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id={`slot-weekday-${slot.id}`}>Jour</InputLabel>
+          <Select
+            labelId={`slot-weekday-${slot.id}`}
+            label="Jour"
+            value={weekday}
+            onChange={(e) => onChange({ weekday: Number(e.target.value) as IsoWeekday })}
+          >
+            {WEEKDAY_OPTIONS.map((value) => (
+              <MenuItem key={value} value={value}>
+                {ISO_WEEKDAY_LABELS[value]}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          label="Début"
+          type="time"
+          size="small"
+          value={startInput}
+          onChange={(e) => {
+            const minutes = parseTimeInput(e.target.value);
+            if (minutes != null) onChange({ startMinutes: minutes });
+          }}
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
+        <TextField
+          label="Fin"
+          type="time"
+          size="small"
+          value={endInput}
+          onChange={(e) => {
+            const minutes = parseTimeInput(e.target.value);
+            if (minutes != null) onChange({ endMinutes: minutes });
+          }}
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
+      </Stack>
 
       <ConfigEditorOptionPanel title="Récupération scolaire">
         <FormControlLabel

--- a/src/components/club-registration-config/config-editor-summary-meta.ts
+++ b/src/components/club-registration-config/config-editor-summary-meta.ts
@@ -1,5 +1,9 @@
 import type { RegistrationConfigV1, RegistrationSection } from "@/lib/club-registration-config/types";
 import { pricingProfileLabel } from "@/lib/club-registration-config/pricing-profiles";
+import {
+  formatSlotScheduleSummary,
+  resolveSlotSchedule,
+} from "@/lib/club-registration-config/slot-schedule";
 import { centsToEuroInput } from "./config-editor-utils";
 
 export function sectionSummaryMeta(
@@ -17,9 +21,27 @@ export function sectionSummaryMeta(
 }
 
 export function slotSummaryMeta(
-  slot: { enabled: boolean; schoolPickupSchool?: string | undefined }
+  slot: {
+    enabled: boolean;
+    schoolPickupSchool?: string | undefined;
+    weekday?: number | undefined;
+    startMinutes?: number | undefined;
+    endMinutes?: number | undefined;
+    id?: string;
+    label?: string;
+  }
 ): string | undefined {
   const parts: string[] = [];
+  const schedule = resolveSlotSchedule({
+    id: slot.id ?? "",
+    label: slot.label ?? "",
+    weekday: slot.weekday,
+    startMinutes: slot.startMinutes,
+    endMinutes: slot.endMinutes,
+  });
+  if (schedule) {
+    parts.push(formatSlotScheduleSummary(schedule));
+  }
   if (!slot.enabled) parts.push("Inactif");
   if (slot.schoolPickupSchool) parts.push("Récup. scolaire");
   return parts.length > 0 ? parts.join(" · ") : undefined;

--- a/src/components/layout-navigation.test.ts
+++ b/src/components/layout-navigation.test.ts
@@ -11,6 +11,7 @@ describe("buildLayoutNavigation", () => {
     isPlayerLike: false,
     isAssistantSecretary: false,
     isSecretary: false,
+    isBoardMember: false,
     canAccessSpreadsheet: false,
   };
 
@@ -43,6 +44,23 @@ describe("buildLayoutNavigation", () => {
     ]);
   });
 
+  it("adds attendance pages for board members", () => {
+    const nav = buildLayoutNavigation({
+      ...base,
+      isPlayerLike: true,
+      isBoardMember: true,
+      canAccessSpreadsheet: true,
+    });
+    expect(nav.primary.map((item) => item.href)).toEqual([
+      "/joueur",
+      "/club/inscription",
+      "/club/mes-inscriptions",
+      "/club/adhesions-tableau",
+      "/club/presences",
+      "/club/presences/essais",
+    ]);
+  });
+
   it("adds license validation page for assistant secretary", () => {
     const nav = buildLayoutNavigation({
       ...base,
@@ -64,6 +82,7 @@ describe("buildLayoutNavigation", () => {
     expect(nav.primary.map((item) => item.href)).toEqual([
       "/",
       "/club/demandes-adhesion",
+      "/club/presences",
       "/club/idees",
     ]);
     expect(nav.groups).toHaveLength(1);
@@ -71,6 +90,7 @@ describe("buildLayoutNavigation", () => {
     expect(nav.groups[0]?.label).toBe("Adhésions");
     expect(nav.groups[0]?.items.map((item) => item.href)).toEqual([
       "/club/adhesions-tableau",
+      "/club/presences/essais",
       "/club/parametrage-inscription",
       "/club/inscription",
       "/club/validations-licence",
@@ -81,6 +101,7 @@ describe("buildLayoutNavigation", () => {
     const nav = buildLayoutNavigation(base);
     expect(nav.primary.map((item) => item.href)).toEqual([
       "/",
+      "/club/presences",
       "/compositions",
       "/disponibilites",
       "/club/adhesions-tableau",
@@ -115,6 +136,8 @@ describe("buildLayoutNavigation", () => {
     ]);
     expect(nav.groups[1]?.items.map((item) => item.href)).toEqual([
       "/club/adhesions-tableau",
+      "/club/presences",
+      "/club/presences/essais",
       "/club/parametrage-inscription",
       "/club/inscription",
       "/club/validations-licence",
@@ -129,14 +152,15 @@ describe("buildLayoutAccountMenuItems", () => {
     isPlayerLike: false,
     isAssistantSecretary: false,
     isSecretary: false,
+    isBoardMember: false,
     canAccessSpreadsheet: false,
   };
 
   it("returns no account menu for player-like roles", () => {
     expect(
       buildLayoutAccountMenuItems({ ...base, isPlayerLike: true }).map(
-        (item) => item.href
-      )
+        (item) => item.href,
+      ),
     ).toEqual([]);
   });
 
@@ -150,8 +174,8 @@ describe("buildLayoutAccountMenuItems", () => {
   it("omits new adhesion for admin account menu", () => {
     expect(
       buildLayoutAccountMenuItems({ ...base, isAdmin: true }).map(
-        (item) => item.href
-      )
+        (item) => item.href,
+      ),
     ).toEqual(["/club/mes-inscriptions"]);
   });
 });

--- a/src/components/layout-navigation.tsx
+++ b/src/components/layout-navigation.tsx
@@ -5,6 +5,7 @@ import {
   AdminPanelSettings,
   Assignment,
   Event,
+  EventAvailable,
   FactCheck,
   Groups,
   Home,
@@ -103,6 +104,16 @@ const NAV = {
     href: "/club/validations-licence",
     icon: <VerifiedUser />,
   },
+  presences: {
+    label: "Présences",
+    href: "/club/presences",
+    icon: <EventAvailable />,
+  },
+  presencesEssais: {
+    label: "Essais présence",
+    href: "/club/presences/essais",
+    icon: <HowToReg />,
+  },
 } as const satisfies Record<string, LayoutNavigationItem>;
 
 export const LAYOUT_NAV = NAV;
@@ -113,18 +124,18 @@ type LayoutNavOptions = {
   isPlayerLike: boolean;
   isAssistantSecretary: boolean;
   isSecretary: boolean;
+  isBoardMember: boolean;
   canAccessSpreadsheet: boolean;
 };
 
 export function hasLayoutNavigation(nav: LayoutNavigationStructure): boolean {
   return (
-    nav.primary.length > 0 ||
-    nav.groups.some((group) => group.items.length > 0)
+    nav.primary.length > 0 || nav.groups.some((group) => group.items.length > 0)
   );
 }
 
 export function buildLayoutAccountMenuItems(
-  options: LayoutNavOptions
+  options: LayoutNavOptions,
 ): LayoutNavigationItem[] {
   const { hasUser, isAdmin, isPlayerLike, isSecretary } = options;
   if (!hasUser || isPlayerLike) {
@@ -143,7 +154,7 @@ export function buildLayoutAccountMenuItems(
 }
 
 export function buildLayoutNavigation(
-  options: LayoutNavOptions
+  options: LayoutNavOptions,
 ): LayoutNavigationStructure {
   const {
     hasUser,
@@ -151,6 +162,7 @@ export function buildLayoutNavigation(
     isPlayerLike,
     isAssistantSecretary,
     isSecretary,
+    isBoardMember,
     canAccessSpreadsheet,
   } = options;
   if (!hasUser) {
@@ -166,6 +178,9 @@ export function buildLayoutNavigation(
     if (canAccessSpreadsheet) {
       primary.push(NAV.tableauAdhesions);
     }
+    if (isBoardMember) {
+      primary.push(NAV.presences, NAV.presencesEssais);
+    }
     if (isAssistantSecretary) {
       primary.push(NAV.validationsLicence);
     }
@@ -174,13 +189,19 @@ export function buildLayoutNavigation(
 
   if (isSecretary) {
     return {
-      primary: [NAV.accueilStaff, NAV.dossiersAValider, NAV.boiteIdees],
+      primary: [
+        NAV.accueilStaff,
+        NAV.dossiersAValider,
+        NAV.presences,
+        NAV.boiteIdees,
+      ],
       groups: [
         {
           id: "adhesions",
           label: "Adhésions",
           items: [
             NAV.tableauAdhesions,
+            NAV.presencesEssais,
             NAV.campagnesTarifs,
             NAV.apercuFormulaire,
             NAV.validationsLicence,
@@ -215,6 +236,8 @@ export function buildLayoutNavigation(
           label: "Adhésions",
           items: [
             NAV.tableauAdhesions,
+            NAV.presences,
+            NAV.presencesEssais,
             NAV.campagnesTarifs,
             NAV.apercuFormulaire,
             NAV.validationsLicence,
@@ -227,6 +250,7 @@ export function buildLayoutNavigation(
   return {
     primary: [
       NAV.accueilStaff,
+      NAV.presences,
       NAV.compositions,
       NAV.disponibilites,
       NAV.tableauAdhesions,

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -58,10 +58,10 @@ export const useAuth = () => {
     signUp: async () => ({ success: false, error: "Use /signup page" }),
     isAdmin: role === USER_ROLES.ADMIN,
     isSecretary: role === USER_ROLES.SECRETARY,
+    isBoardMember: role === USER_ROLES.BOARD_MEMBER,
     isAssistantSecretary: isAssistantSecretary(role),
     isPlayerLike: hasPlayerLikeAccess(role),
-    isCoach:
-      role === USER_ROLES.COACH || role === USER_ROLES.ADMIN,
+    isCoach: role === USER_ROLES.COACH || role === USER_ROLES.ADMIN,
     isPlayer: role === USER_ROLES.PLAYER,
     refreshUser,
     sendEmailVerification: async () => {},

--- a/src/lib/attendance/access.test.ts
+++ b/src/lib/attendance/access.test.ts
@@ -1,0 +1,26 @@
+import { USER_ROLES } from "@/lib/auth/roles";
+import {
+  ATTENDANCE_LEAD_MANAGER_ROLES,
+  ATTENDANCE_OPERATOR_ROLES,
+  isAttendanceLeadManager,
+  isAttendanceOperator,
+} from "./access";
+
+describe("attendance access", () => {
+  it("autorise secrétaire et membre du bureau au pointage", () => {
+    expect(isAttendanceOperator(USER_ROLES.SECRETARY)).toBe(true);
+    expect(isAttendanceOperator(USER_ROLES.BOARD_MEMBER)).toBe(true);
+    expect(isAttendanceOperator(USER_ROLES.COACH)).toBe(true);
+    expect(isAttendanceOperator(USER_ROLES.ADMIN)).toBe(true);
+    expect(isAttendanceOperator(USER_ROLES.PLAYER)).toBe(false);
+    expect(isAttendanceOperator(USER_ROLES.ASSISTANT_SECRETARY)).toBe(false);
+  });
+
+  it("autorise secrétaire et membre du bureau à la file des essais", () => {
+    expect(isAttendanceLeadManager(USER_ROLES.SECRETARY)).toBe(true);
+    expect(isAttendanceLeadManager(USER_ROLES.BOARD_MEMBER)).toBe(true);
+    expect(isAttendanceLeadManager(USER_ROLES.COACH)).toBe(false);
+    expect(ATTENDANCE_OPERATOR_ROLES).toContain(USER_ROLES.BOARD_MEMBER);
+    expect(ATTENDANCE_LEAD_MANAGER_ROLES).toContain(USER_ROLES.SECRETARY);
+  });
+});

--- a/src/lib/attendance/access.ts
+++ b/src/lib/attendance/access.ts
@@ -1,0 +1,24 @@
+import { hasAnyRole, USER_ROLES, type UserRole } from "@/lib/auth/roles";
+
+/** Pointage, recherche, stats, export. */
+export const ATTENDANCE_OPERATOR_ROLES = [
+  USER_ROLES.ADMIN,
+  USER_ROLES.SECRETARY,
+  USER_ROLES.BOARD_MEMBER,
+  USER_ROLES.COACH,
+] as const;
+
+/** File de relance des essais. */
+export const ATTENDANCE_LEAD_MANAGER_ROLES = [
+  USER_ROLES.ADMIN,
+  USER_ROLES.SECRETARY,
+  USER_ROLES.BOARD_MEMBER,
+] as const;
+
+export function isAttendanceOperator(role: UserRole): boolean {
+  return hasAnyRole(role, ATTENDANCE_OPERATOR_ROLES);
+}
+
+export function isAttendanceLeadManager(role: UserRole): boolean {
+  return hasAnyRole(role, ATTENDANCE_LEAD_MANAGER_ROLES);
+}

--- a/src/lib/attendance/alerts.ts
+++ b/src/lib/attendance/alerts.ts
@@ -1,0 +1,44 @@
+import { normalizeMedicalCertificateStatus } from "@/lib/club-registration/medical-certificate";
+import { normalizePpsFollowUpStatus } from "@/lib/club-registration/pps-follow-up";
+import { resolveRegistrationPaymentStatus } from "@/lib/club-registration/resolve-registration-payment-status";
+import type { AttendanceAlert } from "./constants";
+
+export function attendanceAlertsFromRegistration(
+  data: Record<string, unknown>
+): AttendanceAlert[] {
+  const alerts: AttendanceAlert[] = [];
+  const status = typeof data.status === "string" ? data.status : null;
+  const paymentStatus = resolveRegistrationPaymentStatus(data);
+  const paid =
+    status === "paid" || paymentStatus === "paid";
+  if (!paid) {
+    alerts.push("unpaid");
+  }
+
+  const certificate = normalizeMedicalCertificateStatus(
+    data.medicalCertificateStatus,
+    typeof data.medicalCertificateDeclaration === "string"
+      ? data.medicalCertificateDeclaration
+      : null
+  );
+  if (certificate === "required_not_received") {
+    alerts.push("certificate");
+  }
+
+  const pps = normalizePpsFollowUpStatus(
+    data.ppsFollowUpStatus,
+    typeof data.medicalCertificateDeclaration === "string"
+      ? data.medicalCertificateDeclaration
+      : null,
+    typeof data.birthDate === "string" ? data.birthDate : null
+  );
+  if (pps === "expected" || pps === "checked_incomplete") {
+    alerts.push("pps");
+  }
+
+  return alerts;
+}
+
+export function isRejectedRegistration(data: Record<string, unknown>): boolean {
+  return data.status === "rejected";
+}

--- a/src/lib/attendance/api-auth.ts
+++ b/src/lib/attendance/api-auth.ts
@@ -1,0 +1,71 @@
+import { cookies } from "next/headers";
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { adminAuth, getFirestoreAdmin } from "@/lib/firebase-admin";
+import { hasAnyRole, resolveRole, type UserRole } from "@/lib/auth/roles";
+import {
+  ATTENDANCE_LEAD_MANAGER_ROLES,
+  ATTENDANCE_OPERATOR_ROLES,
+} from "./access";
+
+export type AttendanceSessionAuth = {
+  uid: string;
+  role: UserRole;
+  db: ReturnType<typeof getFirestoreAdmin>;
+};
+
+async function requireAttendanceRoles(
+  allowed: readonly UserRole[]
+): Promise<
+  | { ok: true; session: AttendanceSessionAuth }
+  | { ok: false; response: ReturnType<typeof jsonNoStore> }
+> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get("__session")?.value;
+
+  if (!sessionCookie) {
+    return {
+      ok: false,
+      response: jsonNoStore({ error: "Authentification requise" }, { status: 401 }),
+    };
+  }
+
+  try {
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    if (!decoded.email_verified) {
+      return {
+        ok: false,
+        response: jsonNoStore({ error: "Email non vérifié" }, { status: 403 }),
+      };
+    }
+
+    const role = resolveRole(decoded.role as string | undefined);
+    if (!hasAnyRole(role, allowed)) {
+      return {
+        ok: false,
+        response: jsonNoStore({ error: "Accès refusé" }, { status: 403 }),
+      };
+    }
+
+    return {
+      ok: true,
+      session: { uid: decoded.uid, role, db: getFirestoreAdmin() },
+    };
+  } catch {
+    return {
+      ok: false,
+      response: jsonNoStore({ error: "Session invalide" }, { status: 401 }),
+    };
+  }
+}
+
+export function requireAttendanceOperator() {
+  return requireAttendanceRoles(ATTENDANCE_OPERATOR_ROLES);
+}
+
+export function requireAttendanceLeadManager() {
+  return requireAttendanceRoles(ATTENDANCE_LEAD_MANAGER_ROLES);
+}
+
+export function invalidOriginResponse() {
+  return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+}

--- a/src/lib/attendance/attendance.test.ts
+++ b/src/lib/attendance/attendance.test.ts
@@ -1,0 +1,227 @@
+import { attendanceAlertsFromRegistration } from "./alerts";
+import { buildAttendanceMarkId } from "./mark-id";
+import { buildSessionPayload } from "./roster";
+import { registrationMatchesQuery } from "./search-members";
+import { buildSlotStats, buildAttendanceExportCsv } from "./stats";
+import { countIsoWeekdayOccurrences, isoWeekdayFromYmd, seasonBoundsYmd } from "./calendar";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import { listSlotsForDate } from "./slots-for-date";
+
+describe("attendance alerts", () => {
+  it("signale paiement et certificat manquant", () => {
+    expect(
+      attendanceAlertsFromRegistration({
+        status: "submitted",
+        paymentStatus: "waiting_payment",
+        medicalCertificateDeclaration: "adult_certificate_required",
+        medicalCertificateStatus: "required_not_received",
+        birthDate: "1990-01-01",
+      })
+    ).toEqual(["unpaid", "certificate"]);
+  });
+
+  it("signale un PPS attendu", () => {
+    expect(
+      attendanceAlertsFromRegistration({
+        status: "paid",
+        paymentStatus: "paid",
+        medicalCertificateDeclaration: "adult_pps_declared",
+        ppsFollowUpStatus: "expected",
+        birthDate: "1990-01-01",
+      })
+    ).toEqual(["pps"]);
+  });
+
+  it("n'alerte pas un dossier soldé sans certificat requis", () => {
+    expect(
+      attendanceAlertsFromRegistration({
+        status: "paid",
+        paymentStatus: "paid",
+        medicalCertificateDeclaration: "under_40_all_no",
+        ppsFollowUpStatus: "not_applicable",
+        birthDate: "2015-01-01",
+      })
+    ).toEqual([]);
+  });
+});
+
+describe("attendance mark id", () => {
+  it("est déterministe pour un adhérent inscrit", () => {
+    expect(
+      buildAttendanceMarkId({
+        date: "2026-08-20",
+        slotId: "voisins-jeu-1900-adultes-elite",
+        kind: "enrolled",
+        registrationId: "reg-1",
+      })
+    ).toBe("2026-08-20__voisins-jeu-1900-adultes-elite__reg_reg-1");
+  });
+
+  it("partage le même document walk-in et enrolled", () => {
+    const base = {
+      date: "2026-08-20",
+      slotId: "slot-a",
+      registrationId: "reg-1",
+    };
+    expect(buildAttendanceMarkId({ ...base, kind: "walkin" })).toBe(
+      buildAttendanceMarkId({ ...base, kind: "enrolled" })
+    );
+  });
+});
+
+describe("attendance roster", () => {
+  it("place les inscrits en liste et les essais en extras", () => {
+    const payload = buildSessionPayload({
+      date: "2026-08-20",
+      slot: {
+        slotId: "slot-a",
+        label: "Jeudi / 19h00",
+        siteId: "voisins",
+        siteLabel: "Voisins",
+        weekday: 4,
+        startMinutes: 19 * 60,
+        endMinutes: 20 * 60 + 45,
+        highlighted: true,
+      },
+      registrations: [
+        {
+          id: "reg-b",
+          data: { firstName: "Béatrice", lastName: "Martin", status: "submitted" },
+        },
+        {
+          id: "reg-a",
+          data: { firstName: "Alain", lastName: "Dupont", status: "paid", paymentStatus: "paid" },
+        },
+      ],
+      marks: [
+        {
+          id: "m1",
+          date: "2026-08-20",
+          slotId: "slot-a",
+          siteId: "voisins",
+          seasonLabel: "2025-2026",
+          sessionId: "s",
+          kind: "enrolled",
+          registrationId: "reg-a",
+          displayName: "Alain Dupont",
+          markedAt: "2026-08-20T18:00:00.000Z",
+          markedByUid: "coach-1",
+        },
+        {
+          id: "m2",
+          date: "2026-08-20",
+          slotId: "slot-a",
+          siteId: "voisins",
+          seasonLabel: "2025-2026",
+          sessionId: "s",
+          kind: "guest",
+          leadId: "lead-1",
+          displayName: "Essai Test",
+          markedAt: "2026-08-20T18:01:00.000Z",
+          markedByUid: "coach-1",
+        },
+      ],
+    });
+    expect(payload.roster.map((p) => p.registrationId)).toEqual(["reg-a", "reg-b"]);
+    expect(payload.roster[0]?.present).toBe(true);
+    expect(payload.roster[1]?.present).toBe(false);
+    expect(payload.extras).toHaveLength(1);
+    expect(payload.counts).toEqual({
+      enrolled: 2,
+      presentEnrolled: 1,
+      walkin: 0,
+      guest: 1,
+    });
+  });
+});
+
+describe("attendance calendar / stats", () => {
+  it("liste les créneaux du jeudi depuis la config par défaut", () => {
+    const config = getDefaultRegistrationConfig();
+    const slots = listSlotsForDate(config, "2026-08-20", 19 * 60);
+    expect(slots.length).toBeGreaterThan(0);
+    expect(slots.every((slot) => slot.weekday === 4)).toBe(true);
+    expect(slots.some((slot) => slot.highlighted)).toBe(true);
+  });
+
+  it("compte les jeudis entre deux dates", () => {
+    expect(isoWeekdayFromYmd("2026-08-20")).toBe(4);
+    expect(countIsoWeekdayOccurrences("2026-08-20", "2026-08-27", 4)).toBe(2);
+  });
+
+  it("calcule un taux enrolled / occurrences", () => {
+    const bounds = seasonBoundsYmd("2025-2026");
+    expect(bounds).toEqual({ start: "2025-09-01", end: "2026-08-31" });
+    const stats = buildSlotStats({
+      date: "2026-08-20",
+      slotId: "slot-a",
+      weekday: 4,
+      seasonLabel: "2025-2026",
+      registrations: [
+        {
+          id: "reg-1",
+          data: {
+            firstName: "Alain",
+            lastName: "Dupont",
+            submittedAt: "2026-08-06T10:00:00.000Z",
+          },
+        },
+      ],
+      marks: [
+        {
+          id: "m1",
+          date: "2026-08-13",
+          slotId: "slot-a",
+          siteId: "voisins",
+          seasonLabel: "2025-2026",
+          sessionId: "s",
+          kind: "enrolled",
+          registrationId: "reg-1",
+          displayName: "Alain Dupont",
+          markedAt: "x",
+          markedByUid: "c",
+        },
+        {
+          id: "m2",
+          date: "2026-08-20",
+          slotId: "slot-a",
+          siteId: "voisins",
+          seasonLabel: "2025-2026",
+          sessionId: "s",
+          kind: "walkin",
+          registrationId: "reg-2",
+          displayName: "Walk In",
+          markedAt: "x",
+          markedByUid: "c",
+        },
+      ],
+    });
+    expect(stats.players[0]?.expectedCount).toBe(
+      countIsoWeekdayOccurrences("2026-08-06", "2026-08-20", 4)
+    );
+    expect(stats.players[0]?.presentCount).toBe(1);
+    expect(stats.walkin).toBe(1);
+  });
+});
+
+describe("attendance search / export", () => {
+  it("matche un nom sans accent", () => {
+    expect(registrationMatchesQuery("Béatrice", "Martin", "bea mar")).toBe(true);
+    expect(registrationMatchesQuery("Alain", "Dupont", "z")).toBe(false);
+  });
+
+  it("exporte un CSV", () => {
+    const csv = buildAttendanceExportCsv([
+      {
+        date: "2026-08-20",
+        siteLabel: "Voisins",
+        slotLabel: "Jeudi / 19h00",
+        displayName: "Alain Dupont",
+        kind: "enrolled",
+        alerts: ["unpaid"],
+      },
+    ]);
+    expect(csv).toContain("date,gymnase,creneau,nom,type,alertes");
+    expect(csv).toContain("Paiement");
+  });
+});

--- a/src/lib/attendance/calendar.ts
+++ b/src/lib/attendance/calendar.ts
@@ -1,0 +1,117 @@
+import { ATTENDANCE_TIMEZONE, YMD_RE } from "./constants";
+import type { IsoWeekday } from "@/lib/club-registration-config/slot-schedule";
+
+export function isYmd(value: string): boolean {
+  if (!YMD_RE.test(value)) {
+    return false;
+  }
+  const year = Number.parseInt(value.slice(0, 4), 10);
+  const month = Number.parseInt(value.slice(5, 7), 10);
+  const day = Number.parseInt(value.slice(8, 10), 10);
+  const utc = Date.UTC(year, month - 1, day);
+  const check = new Date(utc);
+  return (
+    check.getUTCFullYear() === year &&
+    check.getUTCMonth() === month - 1 &&
+    check.getUTCDate() === day
+  );
+}
+
+export function todayYmdInParis(now = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: ATTENDANCE_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+export function currentMinutesInParis(now = new Date()): number {
+  const parts = new Intl.DateTimeFormat("fr-FR", {
+    timeZone: ATTENDANCE_TIMEZONE,
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const hour = Number.parseInt(parts.find((part) => part.type === "hour")?.value ?? "0", 10);
+  const minute = Number.parseInt(parts.find((part) => part.type === "minute")?.value ?? "0", 10);
+  return hour * 60 + minute;
+}
+
+export function isoWeekdayFromYmd(ymd: string): IsoWeekday {
+  const year = Number.parseInt(ymd.slice(0, 4), 10);
+  const month = Number.parseInt(ymd.slice(5, 7), 10);
+  const day = Number.parseInt(ymd.slice(8, 10), 10);
+  const utcDay = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  return (utcDay === 0 ? 7 : utcDay) as IsoWeekday;
+}
+
+export function ymdFromTimestamp(value: unknown, timeZone = ATTENDANCE_TIMEZONE): string | null {
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === "string"
+        ? new Date(value)
+        : value &&
+            typeof value === "object" &&
+            "toDate" in value &&
+            typeof (value as { toDate: () => Date }).toDate === "function"
+          ? (value as { toDate: () => Date }).toDate()
+          : null;
+  if (!date || Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+export function addDaysYmd(ymd: string, days: number): string {
+  const year = Number.parseInt(ymd.slice(0, 4), 10);
+  const month = Number.parseInt(ymd.slice(5, 7), 10);
+  const day = Number.parseInt(ymd.slice(8, 10), 10);
+  const next = new Date(Date.UTC(year, month - 1, day + days));
+  return next.toISOString().slice(0, 10);
+}
+
+export function countIsoWeekdayOccurrences(
+  fromYmd: string,
+  toYmd: string,
+  weekday: IsoWeekday
+): number {
+  if (fromYmd > toYmd) {
+    return 0;
+  }
+  let count = 0;
+  let cursor = fromYmd;
+  while (cursor <= toYmd) {
+    if (isoWeekdayFromYmd(cursor) === weekday) {
+      count += 1;
+    }
+    cursor = addDaysYmd(cursor, 1);
+  }
+  return count;
+}
+
+const SEASON_LABEL_RE = /^(\d{4})\s*[-/]\s*(\d{2,4})$/;
+
+export function seasonBoundsYmd(seasonLabel: string): { start: string; end: string } {
+  const match = SEASON_LABEL_RE.exec(seasonLabel.trim());
+  const startYear = match ? Number.parseInt(match[1], 10) : 2025;
+  const year = Number.isFinite(startYear) ? startYear : 2025;
+  return {
+    start: `${year}-09-01`,
+    end: `${year + 1}-08-31`,
+  };
+}
+
+export function maxYmd(a: string, b: string): string {
+  return a >= b ? a : b;
+}
+
+export function minYmd(a: string, b: string): string {
+  return a <= b ? a : b;
+}

--- a/src/lib/attendance/constants.ts
+++ b/src/lib/attendance/constants.ts
@@ -1,0 +1,45 @@
+export const ATTENDANCE_MARKS_COLLECTION = "attendanceMarks";
+export const ATTENDANCE_LEADS_COLLECTION = "attendanceLeads";
+export const ATTENDANCE_TIMEZONE = "Europe/Paris";
+
+export const ATTENDANCE_MARK_KINDS = ["enrolled", "walkin", "guest"] as const;
+export type AttendanceMarkKind = (typeof ATTENDANCE_MARK_KINDS)[number];
+
+export const ATTENDANCE_LEAD_STATUSES = [
+  "open",
+  "contacted",
+  "converted",
+  "dismissed",
+] as const;
+export type AttendanceLeadStatus = (typeof ATTENDANCE_LEAD_STATUSES)[number];
+
+export const ATTENDANCE_ALERTS = ["unpaid", "certificate", "pps"] as const;
+export type AttendanceAlert = (typeof ATTENDANCE_ALERTS)[number];
+
+export const ATTENDANCE_ALERT_LABELS: Record<AttendanceAlert, string> = {
+  unpaid: "Paiement",
+  certificate: "Certificat",
+  pps: "PPS",
+};
+
+export const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export const MEMBER_SEARCH_LIMIT = 20;
+export const MEMBER_SEARCH_SCAN_LIMIT = 500;
+export const LEADS_PAGE_SIZE_DEFAULT = 50;
+
+export const ATTENDANCE_LEAD_STATUS_LABELS: Record<AttendanceLeadStatus, string> = {
+  open: "À relancer",
+  contacted: "Contacté",
+  converted: "Inscrit",
+  dismissed: "Classé",
+};
+
+export function isAttendanceLeadStatus(
+  value: string | null | undefined
+): value is AttendanceLeadStatus {
+  return (
+    typeof value === "string" &&
+    (ATTENDANCE_LEAD_STATUSES as readonly string[]).includes(value)
+  );
+}

--- a/src/lib/attendance/mark-id.ts
+++ b/src/lib/attendance/mark-id.ts
@@ -1,0 +1,30 @@
+import type { AttendanceMarkKind } from "./constants";
+
+export function attendanceSessionId(date: string, slotId: string): string {
+  return `${date}__${slotId}`;
+}
+
+export function attendancePersonKey(params: {
+  kind: AttendanceMarkKind;
+  registrationId?: string | undefined;
+  leadId?: string | undefined;
+}): string | null {
+  if (params.kind === "guest") {
+    return params.leadId ? `guest_${params.leadId}` : null;
+  }
+  return params.registrationId ? `reg_${params.registrationId}` : null;
+}
+
+export function buildAttendanceMarkId(params: {
+  date: string;
+  slotId: string;
+  kind: AttendanceMarkKind;
+  registrationId?: string | undefined;
+  leadId?: string | undefined;
+}): string | null {
+  const personKey = attendancePersonKey(params);
+  if (!personKey) {
+    return null;
+  }
+  return `${params.date}__${params.slotId}__${personKey}`;
+}

--- a/src/lib/attendance/roster.ts
+++ b/src/lib/attendance/roster.ts
@@ -1,0 +1,101 @@
+import { computeAgeAt } from "@/lib/club-registration/age";
+import type { AttendanceMark, AttendanceRosterPerson, AttendanceSessionPayload, AttendanceSlotOption } from "./types";
+import { attendanceAlertsFromRegistration } from "./alerts";
+import { attendancePersonKey } from "./mark-id";
+
+function readString(data: Record<string, unknown>, key: string): string {
+  const value = data[key];
+  return typeof value === "string" ? value : "";
+}
+
+export function displayNameFromParts(firstName: string, lastName: string): string {
+  return `${firstName} ${lastName}`.trim();
+}
+
+export function mapRegistrationToRosterPerson(
+  id: string,
+  data: Record<string, unknown>,
+  present: boolean,
+  addSlotRequested: boolean
+): AttendanceRosterPerson {
+  const firstName = readString(data, "firstName");
+  const lastName = readString(data, "lastName");
+  const birthDate = readString(data, "birthDate");
+  return {
+    personKey: `reg_${id}`,
+    kind: "enrolled",
+    registrationId: id,
+    firstName,
+    lastName,
+    displayName: displayNameFromParts(firstName, lastName) || id,
+    age: birthDate ? computeAgeAt(birthDate) : null,
+    alerts: attendanceAlertsFromRegistration(data),
+    present,
+    addSlotRequested,
+  };
+}
+
+export function extraPersonFromMark(mark: AttendanceMark): AttendanceRosterPerson {
+  const parts = mark.displayName.trim().split(/\s+/);
+  const firstName = parts[0] ?? mark.displayName;
+  const lastName = parts.slice(1).join(" ");
+  return {
+    personKey: attendancePersonKey(mark) ?? mark.id,
+    kind: mark.kind,
+    registrationId: mark.registrationId,
+    leadId: mark.leadId,
+    firstName,
+    lastName,
+    displayName: mark.displayName,
+    age: null,
+    alerts: [],
+    present: true,
+    addSlotRequested: mark.addSlotRequested === true,
+  };
+}
+
+export function buildSessionPayload(params: {
+  date: string;
+  slot: AttendanceSlotOption;
+  registrations: Array<{ id: string; data: Record<string, unknown> }>;
+  marks: AttendanceMark[];
+}): AttendanceSessionPayload {
+  const marksByReg = new Map<string, AttendanceMark>();
+  const extraMarks: AttendanceMark[] = [];
+  for (const mark of params.marks) {
+    if (mark.kind === "enrolled" && mark.registrationId) {
+      marksByReg.set(mark.registrationId, mark);
+    } else {
+      extraMarks.push(mark);
+    }
+  }
+
+  const roster = params.registrations
+    .map((item) => {
+      const mark = marksByReg.get(item.id);
+      return mapRegistrationToRosterPerson(
+        item.id,
+        item.data,
+        Boolean(mark),
+        mark?.addSlotRequested === true
+      );
+    })
+    .sort((a, b) => a.lastName.localeCompare(b.lastName, "fr") || a.firstName.localeCompare(b.firstName, "fr"));
+
+  const extras = extraMarks
+    .map(extraPersonFromMark)
+    .sort((a, b) => a.displayName.localeCompare(b.displayName, "fr"));
+
+  return {
+    date: params.date,
+    slot: params.slot,
+    roster,
+    extras,
+    counts: {
+      enrolled: roster.length,
+      presentEnrolled: roster.filter((person) => person.present).length,
+      walkin: extras.filter((person) => person.kind === "walkin").length,
+      guest: extras.filter((person) => person.kind === "guest").length,
+    },
+  };
+}

--- a/src/lib/attendance/schema.ts
+++ b/src/lib/attendance/schema.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { ATTENDANCE_LEAD_STATUSES, ATTENDANCE_MARK_KINDS, YMD_RE } from "./constants";
+
+export const attendanceDateSchema = z.string().regex(YMD_RE, "Date invalide");
+
+export const attendanceMarkBodySchema = z
+  .object({
+    date: attendanceDateSchema,
+    slotId: z.string().trim().min(1).max(120),
+    kind: z.enum(ATTENDANCE_MARK_KINDS),
+    registrationId: z.string().trim().min(1).max(120).optional(),
+    leadId: z.string().trim().min(1).max(120).optional(),
+    addSlotRequested: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.kind === "guest" && !data.leadId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["leadId"],
+        message: "leadId requis pour un essai",
+      });
+    }
+    if (data.kind !== "guest" && !data.registrationId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["registrationId"],
+        message: "registrationId requis",
+      });
+    }
+  });
+
+export const attendanceLeadCreateSchema = z.object({
+  date: attendanceDateSchema,
+  slotId: z.string().trim().min(1).max(120),
+  firstName: z.string().trim().min(1).max(80),
+  lastName: z.string().trim().min(1).max(80),
+  phone: z
+    .string()
+    .trim()
+    .min(8, "Téléphone trop court")
+    .max(20)
+    .regex(/^[0-9+().\s-]+$/, "Téléphone invalide"),
+  email: z.union([z.string().trim().email("Email invalide").max(200), z.literal("")]).optional(),
+});
+
+export const attendanceLeadPatchSchema = z.object({
+  status: z.enum(ATTENDANCE_LEAD_STATUSES),
+});
+
+export const attendanceAddSlotSchema = z.object({
+  date: attendanceDateSchema,
+  slotId: z.string().trim().min(1).max(120),
+  registrationId: z.string().trim().min(1).max(120),
+});

--- a/src/lib/attendance/search-members.ts
+++ b/src/lib/attendance/search-members.ts
@@ -1,0 +1,77 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { COLLECTION as REGISTRATIONS_COLLECTION } from "@/lib/club-registration/list-registrations";
+import { MEMBER_SEARCH_LIMIT, MEMBER_SEARCH_SCAN_LIMIT } from "./constants";
+import { attendanceAlertsFromRegistration, isRejectedRegistration } from "./alerts";
+import { displayNameFromParts } from "./roster";
+import type { AttendanceMemberSearchHit } from "./types";
+
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
+export function registrationMatchesQuery(
+  firstName: string,
+  lastName: string,
+  query: string
+): boolean {
+  const needle = normalizeSearchText(query);
+  if (needle.length < 2) {
+    return false;
+  }
+  const haystack = normalizeSearchText(`${firstName} ${lastName}`);
+  const tokens = needle.split(/\s+/).filter(Boolean);
+  return tokens.every((token) => haystack.includes(token));
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+export async function searchMembersNotOnSlot(
+  db: Firestore,
+  query: string,
+  slotId: string
+): Promise<AttendanceMemberSearchHit[]> {
+  const snap = await db
+    .collection(REGISTRATIONS_COLLECTION)
+    .orderBy("submittedAt", "desc")
+    .limit(MEMBER_SEARCH_SCAN_LIMIT)
+    .get();
+
+  const hits: AttendanceMemberSearchHit[] = [];
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    if (isRejectedRegistration(data)) {
+      continue;
+    }
+    const firstName = typeof data.firstName === "string" ? data.firstName : "";
+    const lastName = typeof data.lastName === "string" ? data.lastName : "";
+    if (!registrationMatchesQuery(firstName, lastName, query)) {
+      continue;
+    }
+    const slotIds = readStringArray(data.slotIds);
+    const alreadyOnSlot = slotIds.includes(slotId);
+    if (alreadyOnSlot) {
+      continue;
+    }
+    hits.push({
+      registrationId: doc.id,
+      firstName,
+      lastName,
+      displayName: displayNameFromParts(firstName, lastName) || doc.id,
+      alreadyOnSlot: false,
+      alerts: attendanceAlertsFromRegistration(data),
+    });
+    if (hits.length >= MEMBER_SEARCH_LIMIT) {
+      break;
+    }
+  }
+  return hits;
+}

--- a/src/lib/attendance/slots-for-date.ts
+++ b/src/lib/attendance/slots-for-date.ts
@@ -1,0 +1,112 @@
+import type { RegistrationConfigV1, RegistrationSiteSlot } from "@/lib/club-registration-config/types";
+import { resolveSlotSchedule } from "@/lib/club-registration-config/slot-schedule";
+import type { AttendanceSlotOption } from "./types";
+import { isoWeekdayFromYmd } from "./calendar";
+
+export function listSlotsForDate(
+  config: RegistrationConfigV1,
+  dateYmd: string,
+  nowMinutes: number
+): AttendanceSlotOption[] {
+  const weekday = isoWeekdayFromYmd(dateYmd);
+  const options: AttendanceSlotOption[] = [];
+
+  for (const site of config.sites) {
+    for (const slot of site.slots) {
+      if (!slot.enabled) {
+        continue;
+      }
+      const option = toSlotOption(site.id, site.label, site.gymnasiumName, slot, weekday);
+      if (option) {
+        options.push({ ...option, highlighted: false });
+      }
+    }
+  }
+
+  options.sort((a, b) => {
+    if (a.siteLabel !== b.siteLabel) {
+      return a.siteLabel.localeCompare(b.siteLabel, "fr");
+    }
+    return a.startMinutes - b.startMinutes;
+  });
+
+  const highlightId = pickHighlightedSlotId(options, nowMinutes);
+  return options.map((option) => ({
+    ...option,
+    highlighted: option.slotId === highlightId,
+  }));
+}
+
+function toSlotOption(
+  siteId: string,
+  siteLabel: string,
+  gymnasiumName: string | undefined,
+  slot: RegistrationSiteSlot,
+  weekday: number
+): Omit<AttendanceSlotOption, "highlighted"> | null {
+  const schedule = resolveSlotSchedule(slot);
+  if (!schedule || schedule.weekday !== weekday) {
+    return null;
+  }
+  return {
+    slotId: slot.id,
+    label: slot.label,
+    siteId,
+    siteLabel,
+    ...(gymnasiumName ? { gymnasiumName } : {}),
+    weekday: schedule.weekday,
+    startMinutes: schedule.startMinutes,
+    endMinutes: schedule.endMinutes,
+  };
+}
+
+export function pickHighlightedSlotId(
+  options: readonly Omit<AttendanceSlotOption, "highlighted">[],
+  nowMinutes: number
+): string | null {
+  if (options.length === 0) {
+    return null;
+  }
+  const notEnded = options.filter((slot) => nowMinutes < slot.endMinutes);
+  const pool = notEnded.length > 0 ? notEnded : options;
+  let best = pool[0];
+  let bestDelta = Math.abs(best.startMinutes - nowMinutes);
+  for (const slot of pool.slice(1)) {
+    const delta = Math.abs(slot.startMinutes - nowMinutes);
+    if (delta < bestDelta) {
+      best = slot;
+      bestDelta = delta;
+    }
+  }
+  return best?.slotId ?? null;
+}
+
+export function findSlotOption(
+  config: RegistrationConfigV1,
+  slotId: string,
+  dateYmd: string
+): AttendanceSlotOption | null {
+  const weekday = isoWeekdayFromYmd(dateYmd);
+  for (const site of config.sites) {
+    const slot = site.slots.find((item) => item.id === slotId);
+    if (!slot) {
+      continue;
+    }
+    const option = toSlotOption(site.id, site.label, site.gymnasiumName, slot, weekday);
+    if (!option) {
+      return {
+        slotId: slot.id,
+        label: slot.label,
+        siteId: site.id,
+        siteLabel: site.label,
+        ...(site.gymnasiumName ? { gymnasiumName: site.gymnasiumName } : {}),
+        weekday,
+        startMinutes: 0,
+        endMinutes: 0,
+        highlighted: false,
+      };
+    }
+    return { ...option, highlighted: false };
+  }
+  return null;
+}

--- a/src/lib/attendance/stats.ts
+++ b/src/lib/attendance/stats.ts
@@ -1,0 +1,115 @@
+import type {
+  AttendanceMark,
+  AttendancePlayerStat,
+  AttendanceSessionPayload,
+  AttendanceSlotStats,
+} from "./types";
+import {
+  countIsoWeekdayOccurrences,
+  maxYmd,
+  minYmd,
+  seasonBoundsYmd,
+  ymdFromTimestamp,
+} from "./calendar";
+import type { IsoWeekday } from "@/lib/club-registration-config/slot-schedule";
+import { ATTENDANCE_ALERT_LABELS, type AttendanceAlert } from "./constants";
+
+export function buildSlotStats(params: {
+  date: string;
+  slotId: string;
+  weekday: IsoWeekday;
+  seasonLabel: string;
+  registrations: Array<{ id: string; data: Record<string, unknown> }>;
+  marks: AttendanceMark[];
+}): AttendanceSlotStats {
+  const bounds = seasonBoundsYmd(params.seasonLabel);
+  const toDate = minYmd(params.date, bounds.end);
+  const enrolledMarks = params.marks.filter((mark) => mark.kind === "enrolled");
+  const presentByReg = new Map<string, number>();
+  for (const mark of enrolledMarks) {
+    if (!mark.registrationId || mark.date > params.date) {
+      continue;
+    }
+    presentByReg.set(mark.registrationId, (presentByReg.get(mark.registrationId) ?? 0) + 1);
+  }
+
+  const todayMarks = params.marks.filter((mark) => mark.date === params.date);
+  const players: AttendancePlayerStat[] = params.registrations.map((item) => {
+    const submitted = ymdFromTimestamp(item.data.submittedAt) ?? bounds.start;
+    const from = maxYmd(bounds.start, submitted);
+    const expectedCount = countIsoWeekdayOccurrences(from, toDate, params.weekday);
+    const presentCount = presentByReg.get(item.id) ?? 0;
+    const firstName = typeof item.data.firstName === "string" ? item.data.firstName : "";
+    const lastName = typeof item.data.lastName === "string" ? item.data.lastName : "";
+    return {
+      registrationId: item.id,
+      displayName: `${firstName} ${lastName}`.trim() || item.id,
+      presentCount,
+      expectedCount,
+      rate: expectedCount > 0 ? presentCount / expectedCount : null,
+    };
+  });
+
+  players.sort((a, b) => a.displayName.localeCompare(b.displayName, "fr"));
+
+  return {
+    date: params.date,
+    slotId: params.slotId,
+    enrolled: params.registrations.length,
+    presentEnrolled: todayMarks.filter((mark) => mark.kind === "enrolled").length,
+    walkin: todayMarks.filter((mark) => mark.kind === "walkin").length,
+    guest: todayMarks.filter((mark) => mark.kind === "guest").length,
+    players,
+  };
+}
+
+export function sessionToExportRows(session: AttendanceSessionPayload): Array<{
+  date: string;
+  siteLabel: string;
+  slotLabel: string;
+  displayName: string;
+  kind: string;
+  alerts: AttendanceAlert[];
+}> {
+  const present = [...session.roster.filter((person) => person.present), ...session.extras];
+  return present.map((person) => ({
+    date: session.date,
+    siteLabel: session.slot.siteLabel,
+    slotLabel: session.slot.label,
+    displayName: person.displayName,
+    kind: person.kind,
+    alerts: person.alerts,
+  }));
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function buildAttendanceExportCsv(rows: Array<{
+  date: string;
+  siteLabel: string;
+  slotLabel: string;
+  displayName: string;
+  kind: string;
+  alerts: AttendanceAlert[];
+}>): string {
+  const header = ["date", "gymnase", "creneau", "nom", "type", "alertes"];
+  const lines = [header.join(",")];
+  for (const row of rows) {
+    lines.push(
+      [
+        csvEscape(row.date),
+        csvEscape(row.siteLabel),
+        csvEscape(row.slotLabel),
+        csvEscape(row.displayName),
+        csvEscape(row.kind),
+        csvEscape(row.alerts.map((alert) => ATTENDANCE_ALERT_LABELS[alert]).join(" | ")),
+      ].join(",")
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/lib/attendance/store.ts
+++ b/src/lib/attendance/store.ts
@@ -1,0 +1,303 @@
+import type { DocumentData, Firestore, Query } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { COLLECTION as REGISTRATIONS_COLLECTION } from "@/lib/club-registration/list-registrations";
+import { isRejectedRegistration } from "./alerts";
+import {
+  ATTENDANCE_LEADS_COLLECTION,
+  ATTENDANCE_MARKS_COLLECTION,
+  LEADS_PAGE_SIZE_DEFAULT,
+  type AttendanceLeadStatus,
+  type AttendanceMarkKind,
+} from "./constants";
+import { attendanceSessionId, buildAttendanceMarkId } from "./mark-id";
+import type { AttendanceLead, AttendanceMark } from "./types";
+
+function readString(data: DocumentData, key: string): string {
+  const value = data[key];
+  return typeof value === "string" ? value : "";
+}
+
+export function mapMarkDoc(id: string, data: DocumentData): AttendanceMark {
+  const kind = data.kind as AttendanceMarkKind;
+  return {
+    id,
+    date: readString(data, "date"),
+    slotId: readString(data, "slotId"),
+    siteId: readString(data, "siteId"),
+    seasonLabel: readString(data, "seasonLabel"),
+    sessionId: readString(data, "sessionId"),
+    kind,
+    registrationId: data.registrationId ? String(data.registrationId) : undefined,
+    leadId: data.leadId ? String(data.leadId) : undefined,
+    displayName: readString(data, "displayName"),
+    markedAt: readString(data, "markedAt"),
+    markedByUid: readString(data, "markedByUid"),
+    addSlotRequested: data.addSlotRequested === true ? true : undefined,
+  };
+}
+
+export function mapLeadDoc(id: string, data: DocumentData): AttendanceLead {
+  const email = readString(data, "email");
+  return {
+    id,
+    firstName: readString(data, "firstName"),
+    lastName: readString(data, "lastName"),
+    phone: readString(data, "phone"),
+    ...(email ? { email } : {}),
+    sourceDate: readString(data, "sourceDate"),
+    sourceSlotId: readString(data, "sourceSlotId"),
+    sourceSiteId: readString(data, "sourceSiteId"),
+    createdAt: readString(data, "createdAt"),
+    createdByUid: readString(data, "createdByUid"),
+    status: data.status as AttendanceLeadStatus,
+  };
+}
+
+export async function listRegistrationsForSlot(
+  db: Firestore,
+  slotId: string
+): Promise<Array<{ id: string; data: Record<string, unknown> }>> {
+  const snap = await db
+    .collection(REGISTRATIONS_COLLECTION)
+    .where("slotIds", "array-contains", slotId)
+    .get();
+  return snap.docs
+    .map((doc) => ({ id: doc.id, data: doc.data() as Record<string, unknown> }))
+    .filter((item) => !isRejectedRegistration(item.data));
+}
+
+export async function getRegistrationData(
+  db: Firestore,
+  registrationId: string
+): Promise<Record<string, unknown> | null> {
+  const snap = await db.collection(REGISTRATIONS_COLLECTION).doc(registrationId).get();
+  if (!snap.exists) {
+    return null;
+  }
+  return snap.data() as Record<string, unknown>;
+}
+
+export async function listMarksForSession(
+  db: Firestore,
+  date: string,
+  slotId: string
+): Promise<AttendanceMark[]> {
+  const snap = await db
+    .collection(ATTENDANCE_MARKS_COLLECTION)
+    .where("slotId", "==", slotId)
+    .where("date", "==", date)
+    .get();
+  return snap.docs.map((doc) => mapMarkDoc(doc.id, doc.data()));
+}
+
+export async function listMarksForSlotSeason(
+  db: Firestore,
+  seasonLabel: string,
+  slotId: string
+): Promise<AttendanceMark[]> {
+  const snap = await db
+    .collection(ATTENDANCE_MARKS_COLLECTION)
+    .where("seasonLabel", "==", seasonLabel)
+    .where("slotId", "==", slotId)
+    .orderBy("date", "asc")
+    .get();
+  return snap.docs.map((doc) => mapMarkDoc(doc.id, doc.data()));
+}
+
+export async function upsertAttendanceMark(
+  db: Firestore,
+  params: {
+    date: string;
+    slotId: string;
+    siteId: string;
+    seasonLabel: string;
+    kind: AttendanceMarkKind;
+    registrationId?: string | undefined;
+    leadId?: string | undefined;
+    displayName: string;
+    markedByUid: string;
+    addSlotRequested?: boolean | undefined;
+  }
+): Promise<AttendanceMark> {
+  const id = buildAttendanceMarkId(params);
+  if (!id) {
+    throw new Error("Identifiant de présence invalide");
+  }
+  const now = new Date().toISOString();
+  const payload: Record<string, unknown> = {
+    date: params.date,
+    slotId: params.slotId,
+    siteId: params.siteId,
+    seasonLabel: params.seasonLabel,
+    sessionId: attendanceSessionId(params.date, params.slotId),
+    kind: params.kind,
+    displayName: params.displayName,
+    markedAt: now,
+    markedByUid: params.markedByUid,
+  };
+  if (params.registrationId) payload.registrationId = params.registrationId;
+  if (params.leadId) payload.leadId = params.leadId;
+  if (params.addSlotRequested) payload.addSlotRequested = true;
+
+  await db.collection(ATTENDANCE_MARKS_COLLECTION).doc(id).set(payload);
+  return mapMarkDoc(id, payload);
+}
+
+export async function deleteAttendanceMark(
+  db: Firestore,
+  markId: string
+): Promise<boolean> {
+  const ref = db.collection(ATTENDANCE_MARKS_COLLECTION).doc(markId);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    return false;
+  }
+  await ref.delete();
+  return true;
+}
+
+export async function createLeadWithGuestMark(
+  db: Firestore,
+  params: {
+    date: string;
+    slotId: string;
+    siteId: string;
+    seasonLabel: string;
+    firstName: string;
+    lastName: string;
+    phone: string;
+    email?: string | undefined;
+    createdByUid: string;
+  }
+): Promise<{ lead: AttendanceLead; mark: AttendanceMark }> {
+  const leadRef = db.collection(ATTENDANCE_LEADS_COLLECTION).doc();
+  const now = new Date().toISOString();
+  const displayName = `${params.firstName} ${params.lastName}`.trim();
+  const leadPayload: Record<string, unknown> = {
+    firstName: params.firstName,
+    lastName: params.lastName,
+    phone: params.phone,
+    sourceDate: params.date,
+    sourceSlotId: params.slotId,
+    sourceSiteId: params.siteId,
+    createdAt: now,
+    createdByUid: params.createdByUid,
+    status: "open",
+  };
+  if (params.email) {
+    leadPayload.email = params.email;
+  }
+
+  const markId = buildAttendanceMarkId({
+    date: params.date,
+    slotId: params.slotId,
+    kind: "guest",
+    leadId: leadRef.id,
+  });
+  if (!markId) {
+    throw new Error("Identifiant de présence invalide");
+  }
+
+  const markPayload: Record<string, unknown> = {
+    date: params.date,
+    slotId: params.slotId,
+    siteId: params.siteId,
+    seasonLabel: params.seasonLabel,
+    sessionId: attendanceSessionId(params.date, params.slotId),
+    kind: "guest",
+    leadId: leadRef.id,
+    displayName,
+    markedAt: now,
+    markedByUid: params.createdByUid,
+  };
+
+  const batch = db.batch();
+  batch.set(leadRef, leadPayload);
+  batch.set(db.collection(ATTENDANCE_MARKS_COLLECTION).doc(markId), markPayload);
+  await batch.commit();
+
+  return {
+    lead: mapLeadDoc(leadRef.id, leadPayload),
+    mark: mapMarkDoc(markId, markPayload),
+  };
+}
+
+export async function listLeads(
+  db: Firestore,
+  status?: AttendanceLeadStatus
+): Promise<AttendanceLead[]> {
+  let query: Query = db.collection(ATTENDANCE_LEADS_COLLECTION);
+  if (status) {
+    query = query.where("status", "==", status);
+  }
+  const snap = await query.orderBy("createdAt", "desc").limit(LEADS_PAGE_SIZE_DEFAULT).get();
+  return snap.docs.map((doc) => mapLeadDoc(doc.id, doc.data()));
+}
+
+export async function patchLeadStatus(
+  db: Firestore,
+  leadId: string,
+  status: AttendanceLeadStatus
+): Promise<AttendanceLead | null> {
+  const ref = db.collection(ATTENDANCE_LEADS_COLLECTION).doc(leadId);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    return null;
+  }
+  await ref.update({ status });
+  const updated = await ref.get();
+  return mapLeadDoc(leadId, updated.data() ?? {});
+}
+
+export async function addSlotToRegistration(
+  db: Firestore,
+  params: {
+    date: string;
+    slotId: string;
+    siteId: string;
+    seasonLabel: string;
+    registrationId: string;
+    displayName: string;
+    markedByUid: string;
+  }
+): Promise<{ slotAdded: boolean }> {
+  const regRef = db.collection(REGISTRATIONS_COLLECTION).doc(params.registrationId);
+  const markId = buildAttendanceMarkId({
+    date: params.date,
+    slotId: params.slotId,
+    kind: "enrolled",
+    registrationId: params.registrationId,
+  });
+  if (!markId) {
+    throw new Error("Identifiant de présence invalide");
+  }
+  const markRef = db.collection(ATTENDANCE_MARKS_COLLECTION).doc(markId);
+
+  await db.runTransaction(async (tx) => {
+    const registration = await tx.get(regRef);
+    if (!registration.exists) {
+      throw new Error("Dossier introuvable");
+    }
+    const data = registration.data() ?? {};
+    if (data.status === "rejected") {
+      throw new Error("Dossier refusé");
+    }
+    tx.update(regRef, { slotIds: FieldValue.arrayUnion(params.slotId) });
+    const now = new Date().toISOString();
+    tx.set(markRef, {
+      date: params.date,
+      slotId: params.slotId,
+      siteId: params.siteId,
+      seasonLabel: params.seasonLabel,
+      sessionId: attendanceSessionId(params.date, params.slotId),
+      kind: "enrolled",
+      registrationId: params.registrationId,
+      displayName: params.displayName,
+      markedAt: now,
+      markedByUid: params.markedByUid,
+      addSlotRequested: true,
+    });
+  });
+
+  return { slotAdded: true };
+}

--- a/src/lib/attendance/types.ts
+++ b/src/lib/attendance/types.ts
@@ -1,0 +1,97 @@
+import type { AttendanceAlert, AttendanceLeadStatus, AttendanceMarkKind } from "./constants";
+
+export type AttendanceMark = {
+  id: string;
+  date: string;
+  slotId: string;
+  siteId: string;
+  seasonLabel: string;
+  sessionId: string;
+  kind: AttendanceMarkKind;
+  registrationId?: string | undefined;
+  leadId?: string | undefined;
+  displayName: string;
+  markedAt: string;
+  markedByUid: string;
+  addSlotRequested?: boolean | undefined;
+};
+
+export type AttendanceLead = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  email?: string | undefined;
+  sourceDate: string;
+  sourceSlotId: string;
+  sourceSiteId: string;
+  createdAt: string;
+  createdByUid: string;
+  status: AttendanceLeadStatus;
+};
+
+export type AttendanceSlotOption = {
+  slotId: string;
+  label: string;
+  siteId: string;
+  siteLabel: string;
+  gymnasiumName?: string | undefined;
+  weekday: number;
+  startMinutes: number;
+  endMinutes: number;
+  highlighted: boolean;
+};
+
+export type AttendanceRosterPerson = {
+  personKey: string;
+  kind: AttendanceMarkKind;
+  registrationId?: string | undefined;
+  leadId?: string | undefined;
+  firstName: string;
+  lastName: string;
+  displayName: string;
+  age: number | null;
+  alerts: AttendanceAlert[];
+  present: boolean;
+  addSlotRequested: boolean;
+};
+
+export type AttendanceSessionPayload = {
+  date: string;
+  slot: AttendanceSlotOption;
+  roster: AttendanceRosterPerson[];
+  extras: AttendanceRosterPerson[];
+  counts: {
+    enrolled: number;
+    presentEnrolled: number;
+    walkin: number;
+    guest: number;
+  };
+};
+
+export type AttendanceMemberSearchHit = {
+  registrationId: string;
+  firstName: string;
+  lastName: string;
+  displayName: string;
+  alreadyOnSlot: boolean;
+  alerts: AttendanceAlert[];
+};
+
+export type AttendancePlayerStat = {
+  registrationId: string;
+  displayName: string;
+  presentCount: number;
+  expectedCount: number;
+  rate: number | null;
+};
+
+export type AttendanceSlotStats = {
+  date: string;
+  slotId: string;
+  enrolled: number;
+  presentEnrolled: number;
+  walkin: number;
+  guest: number;
+  players: AttendancePlayerStat[];
+};

--- a/src/lib/attendance/urls.test.ts
+++ b/src/lib/attendance/urls.test.ts
@@ -1,0 +1,11 @@
+import { attendancePickerHref, attendanceSessionHref } from "./urls";
+
+describe("attendance urls", () => {
+  it("construit le picker et la séance", () => {
+    expect(attendancePickerHref()).toBe("/club/presences");
+    expect(attendancePickerHref("2026-08-20")).toBe("/club/presences?date=2026-08-20");
+    expect(attendanceSessionHref("2026-08-20", "voisins-jeu-1900-adultes-elite")).toBe(
+      "/club/presences/seance?date=2026-08-20&slot=voisins-jeu-1900-adultes-elite"
+    );
+  });
+});

--- a/src/lib/attendance/urls.ts
+++ b/src/lib/attendance/urls.ts
@@ -1,0 +1,17 @@
+import { isYmd } from "./calendar";
+
+export function attendancePickerHref(date?: string): string {
+  if (date && isYmd(date)) {
+    return `/club/presences?date=${encodeURIComponent(date)}`;
+  }
+  return "/club/presences";
+}
+
+export function attendanceSessionHref(date: string, slotId: string): string {
+  const params = new URLSearchParams({ date, slot: slotId });
+  return `/club/presences/seance?${params.toString()}`;
+}
+
+export function readAttendanceDateParam(value: string | null, fallback: string): string {
+  return value && isYmd(value) ? value : fallback;
+}

--- a/src/lib/auth/audit-logger.ts
+++ b/src/lib/auth/audit-logger.ts
@@ -103,4 +103,9 @@ export const AUDIT_ACTIONS = {
   APP_SUGGESTION_CREATED: "app.suggestion.created",
   APP_SUGGESTION_UPDATED: "app.suggestion.updated",
   APP_SUGGESTION_COMMENT_ADDED: "app.suggestion.comment_added",
+  ATTENDANCE_MARKED: "attendance.marked",
+  ATTENDANCE_UNMARKED: "attendance.unmarked",
+  ATTENDANCE_LEAD_CREATED: "attendance.lead.created",
+  ATTENDANCE_LEAD_UPDATED: "attendance.lead.updated",
+  ATTENDANCE_SLOT_ADDED: "attendance.slot.added",
 } as const;

--- a/src/lib/club-registration-config/default-config.ts
+++ b/src/lib/club-registration-config/default-config.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/pricing/catalog/sqyping-2025";
 import { PRICING_CATALOG_VERSION } from "@/lib/pricing/types";
 import { inferLinkedSectionIdsFromSite } from "./site-section-links";
+import { withResolvedSlotSchedule } from "./repair-slot-schedules";
 import {
   buildDefaultPricingProfilesRecord,
 } from "./pricing-profiles";
@@ -251,15 +252,17 @@ export function buildDefaultRegistrationConfig(): RegistrationConfigV1 {
         : {}),
       linkedSectionIds: inferLinkedSectionIdsFromSite(site),
       sortOrder: index,
-      slots: site.slots.map((slot, slotIndex) => ({
-        id: slot.id,
-        label: slot.label,
-        sortOrder: slotIndex,
-        enabled: true,
-        ...(slot.schoolPickupSchool
-          ? { schoolPickupSchool: slot.schoolPickupSchool }
-          : {}),
-      })),
+      slots: site.slots.map((slot, slotIndex) =>
+        withResolvedSlotSchedule({
+          id: slot.id,
+          label: slot.label,
+          sortOrder: slotIndex,
+          enabled: true,
+          ...(slot.schoolPickupSchool
+            ? { schoolPickupSchool: slot.schoolPickupSchool }
+            : {}),
+        })
+      ),
     })),
     competitions: COMPETITION_OPTIONS.map((comp) => ({
       id: comp.id,

--- a/src/lib/club-registration-config/export-import.test.ts
+++ b/src/lib/club-registration-config/export-import.test.ts
@@ -39,6 +39,10 @@ describe("export / import round-trip", () => {
     if (result.ok) {
       expect(result.config.meta.catalogVersion).toBe(config.meta.catalogVersion);
       expect(buildConfigExport(result.config).schemaVersion).toBe("1.0.0");
+      const firstSlot = result.config.sites[0]?.slots[0];
+      expect(firstSlot?.weekday).toBeDefined();
+      expect(firstSlot?.startMinutes).toBeDefined();
+      expect(firstSlot?.endMinutes).toBeDefined();
     }
   });
 });

--- a/src/lib/club-registration-config/normalize-sort-orders.ts
+++ b/src/lib/club-registration-config/normalize-sort-orders.ts
@@ -4,6 +4,7 @@ import { repairPricingProfiles } from "./pricing-profiles";
 import { repairSiteLinkedSectionIds } from "./site-section-links";
 import { repairPricingDevices } from "./pricing-devices";
 import { repairChampYonCatalog } from "./repair-champ-yon-catalog";
+import { repairSlotSchedules } from "./repair-slot-schedules";
 import { sortBySortOrder } from "./sort-order";
 
 /** Normalise sortOrder pour les configs importées ou legacy (créneaux sans ordre). */
@@ -36,9 +37,11 @@ export function normalizeRegistrationConfigSortOrders(
     }),
   };
 
-  return repairPricingProfiles(
-    repairPricingDevices(
-      repairChampYonCatalog(repairAidRulesForm(repairSiteLinkedSectionIds(withSortOrders)))
+  return repairSlotSchedules(
+    repairPricingProfiles(
+      repairPricingDevices(
+        repairChampYonCatalog(repairAidRulesForm(repairSiteLinkedSectionIds(withSortOrders)))
+      )
     )
   );
 }

--- a/src/lib/club-registration-config/repair-slot-schedules.ts
+++ b/src/lib/club-registration-config/repair-slot-schedules.ts
@@ -1,0 +1,28 @@
+import type { RegistrationConfigV1, RegistrationSiteSlot } from "./types";
+import { resolveSlotSchedule } from "./slot-schedule";
+
+export function withResolvedSlotSchedule(
+  slot: RegistrationSiteSlot
+): RegistrationSiteSlot {
+  const resolved = resolveSlotSchedule(slot);
+  if (!resolved) {
+    return slot;
+  }
+  return {
+    ...slot,
+    weekday: resolved.weekday,
+    startMinutes: resolved.startMinutes,
+    endMinutes: resolved.endMinutes,
+  };
+}
+
+/** Complète weekday / horaires des créneaux absents des configs legacy. */
+export function repairSlotSchedules(config: RegistrationConfigV1): RegistrationConfigV1 {
+  return {
+    ...config,
+    sites: config.sites.map((site) => ({
+      ...site,
+      slots: site.slots.map(withResolvedSlotSchedule),
+    })),
+  };
+}

--- a/src/lib/club-registration-config/schema.ts
+++ b/src/lib/club-registration-config/schema.ts
@@ -7,6 +7,7 @@ import { repairPricingProfiles } from "./pricing-profiles";
 import { repairJerseyConfig } from "./repair-jersey";
 import { repairPricingDevices } from "./pricing-devices";
 import { repairChampYonCatalog } from "./repair-champ-yon-catalog";
+import { repairSlotSchedules } from "./repair-slot-schedules";
 
 const pricingProfileBehaviorSchema = z.enum(["classic_like", "handisport", "sport_adapte"]);
 
@@ -37,6 +38,9 @@ const registrationSiteSlotSchema = z.object({
   sortOrder: z.number().int().min(0).default(0),
   schoolPickupSchool: z.string().trim().min(1).max(200).optional(),
   enabled: z.boolean(),
+  weekday: z.number().int().min(1).max(7).optional(),
+  startMinutes: z.number().int().min(0).max(23 * 60 + 59).optional(),
+  endMinutes: z.number().int().min(1).max(23 * 60 + 59).optional(),
 });
 
 /** Chaîne optionnelle : vide ou espaces → `undefined` (champ masqué côté formulaire). */
@@ -265,7 +269,8 @@ export const registrationConfigV1Schema = z
   .transform((config) => repairPricingProfiles(config as RegistrationConfigV1))
   .transform((config) => repairJerseyConfig(config as RegistrationConfigV1))
   .transform((config) => repairChampYonCatalog(config as RegistrationConfigV1))
-  .transform((config) => repairPricingDevices(config as RegistrationConfigV1));
+  .transform((config) => repairPricingDevices(config as RegistrationConfigV1))
+  .transform((config) => repairSlotSchedules(config as RegistrationConfigV1));
 
 export const registrationConfigExportSchema = z.object({
   schemaVersion: z.literal(REGISTRATION_CONFIG_SCHEMA_VERSION),

--- a/src/lib/club-registration-config/slot-schedule.test.ts
+++ b/src/lib/club-registration-config/slot-schedule.test.ts
@@ -1,0 +1,57 @@
+import { CLUB_REGISTRATION_SITES } from "@/lib/club-registration/constants";
+import {
+  formatMinutesAsLabel,
+  parseSlotScheduleFromId,
+  parseSlotScheduleFromLabel,
+  parseTimeInput,
+  resolveSlotSchedule,
+} from "./slot-schedule";
+
+describe("slot-schedule", () => {
+  it("parse un libellé club (jour + plage)", () => {
+    expect(
+      parseSlotScheduleFromLabel("Lundi / 17h00 – 18h30 / Jeunes Loisirs")
+    ).toEqual({ weekday: 1, startMinutes: 17 * 60, endMinutes: 18 * 60 + 30 });
+  });
+
+  it("parse un id slug (jour + heure de début, durée 90 min)", () => {
+    expect(parseSlotScheduleFromId("voisins-lun-1730-jeunes-loisirs")).toEqual({
+      weekday: 1,
+      startMinutes: 17 * 60 + 30,
+      endMinutes: 19 * 60,
+    });
+  });
+
+  it("préfère le libellé à l'id quand les deux existent", () => {
+    expect(
+      resolveSlotSchedule({
+        id: "voisins-lun-1730-jeunes-loisirs",
+        label: "Lundi / 17h00 – 18h30 / Jeunes Loisirs",
+      })
+    ).toEqual({ weekday: 1, startMinutes: 17 * 60, endMinutes: 18 * 60 + 30 });
+  });
+
+  it("conserve un horaire déjà structuré", () => {
+    expect(
+      resolveSlotSchedule({
+        id: "custom",
+        label: "Créneau libre",
+        weekday: 3,
+        startMinutes: 16 * 60,
+        endMinutes: 17 * 60 + 30,
+      })
+    ).toEqual({ weekday: 3, startMinutes: 16 * 60, endMinutes: 17 * 60 + 30 });
+  });
+
+  it("parse tous les créneaux du catalogue par défaut", () => {
+    const slots = CLUB_REGISTRATION_SITES.flatMap((site) => site.slots);
+    const unresolved = slots.filter((slot) => resolveSlotSchedule(slot) == null);
+    expect(unresolved.map((slot) => slot.id)).toEqual([]);
+  });
+
+  it("formate et parse une saisie HH:MM", () => {
+    expect(formatMinutesAsLabel(17 * 60 + 5)).toBe("17h05");
+    expect(parseTimeInput("09:30")).toBe(9 * 60 + 30);
+    expect(parseTimeInput("25:00")).toBeNull();
+  });
+});

--- a/src/lib/club-registration-config/slot-schedule.ts
+++ b/src/lib/club-registration-config/slot-schedule.ts
@@ -1,0 +1,173 @@
+/**
+ * Horaires structurés des créneaux d'entraînement (ISO weekday + minutes depuis minuit).
+ * Permet de lister les créneaux d'un jour calendaire sans parser le libellé à chaque requête.
+ */
+
+export type IsoWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type SlotSchedule = {
+  weekday: IsoWeekday;
+  startMinutes: number;
+  endMinutes: number;
+};
+
+export const ISO_WEEKDAY_LABELS: Record<IsoWeekday, string> = {
+  1: "Lundi",
+  2: "Mardi",
+  3: "Mercredi",
+  4: "Jeudi",
+  5: "Vendredi",
+  6: "Samedi",
+  7: "Dimanche",
+};
+
+const WEEKDAY_FROM_FR: Record<string, IsoWeekday> = {
+  lundi: 1,
+  mardi: 2,
+  mercredi: 3,
+  jeudi: 4,
+  vendredi: 5,
+  samedi: 6,
+  dimanche: 7,
+};
+
+const WEEKDAY_FROM_TOKEN: Record<string, IsoWeekday> = {
+  lun: 1,
+  mar: 2,
+  mer: 3,
+  jeu: 4,
+  ven: 5,
+  sam: 6,
+  dim: 7,
+};
+
+const LABEL_RE =
+  /^(lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche)\s*\/\s*(\d{1,2})h(\d{2})\s*[–\-—−]\s*(\d{1,2})h(\d{2})/i;
+
+const ID_RE = /(?:^|-)(lun|mar|mer|jeu|ven|sam|dim)-(\d{3,4})(?:-|$)/i;
+
+const MINUTES_IN_DAY = 24 * 60;
+const DEFAULT_DURATION_MINUTES = 90;
+
+export function isIsoWeekday(value: unknown): value is IsoWeekday {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 7
+  );
+}
+
+export function isValidDayMinutes(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value < MINUTES_IN_DAY
+  );
+}
+
+export function minutesFromHourMinute(hour: number, minute: number): number {
+  return hour * 60 + minute;
+}
+
+export function formatMinutesAsLabel(minutes: number): string {
+  const hour = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  return `${hour}h${minute.toString().padStart(2, "0")}`;
+}
+
+export function formatMinutesAsInput(minutes: number): string {
+  const hour = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  return `${hour.toString().padStart(2, "0")}:${minute.toString().padStart(2, "0")}`;
+}
+
+export function parseTimeInput(value: string): number | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  const hour = Number.parseInt(match[1], 10);
+  const minute = Number.parseInt(match[2], 10);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return null;
+  }
+  return minutesFromHourMinute(hour, minute);
+}
+
+function parseHhMm(hourRaw: string, minuteRaw: string): number | null {
+  const hour = Number.parseInt(hourRaw, 10);
+  const minute = Number.parseInt(minuteRaw, 10);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+    return null;
+  }
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return null;
+  }
+  return minutesFromHourMinute(hour, minute);
+}
+
+export function parseSlotScheduleFromLabel(label: string): SlotSchedule | null {
+  const match = LABEL_RE.exec(label.trim());
+  if (!match) {
+    return null;
+  }
+  const weekday = WEEKDAY_FROM_FR[match[1].toLowerCase()];
+  if (!weekday) {
+    return null;
+  }
+  const startMinutes = parseHhMm(match[2], match[3]);
+  const endMinutes = parseHhMm(match[4], match[5]);
+  if (startMinutes == null || endMinutes == null || endMinutes <= startMinutes) {
+    return null;
+  }
+  return { weekday, startMinutes, endMinutes };
+}
+
+export function parseSlotScheduleFromId(id: string): SlotSchedule | null {
+  const match = ID_RE.exec(id);
+  if (!match) {
+    return null;
+  }
+  const weekday = WEEKDAY_FROM_TOKEN[match[1].toLowerCase()];
+  if (!weekday) {
+    return null;
+  }
+  const padded = match[2].length === 3 ? `0${match[2]}` : match[2];
+  const startMinutes = parseHhMm(padded.slice(0, 2), padded.slice(2, 4));
+  if (startMinutes == null) {
+    return null;
+  }
+  const endMinutes = Math.min(startMinutes + DEFAULT_DURATION_MINUTES, MINUTES_IN_DAY - 1);
+  if (endMinutes <= startMinutes) {
+    return null;
+  }
+  return { weekday, startMinutes, endMinutes };
+}
+
+export function resolveSlotSchedule(slot: {
+  id: string;
+  label: string;
+  weekday?: number | undefined;
+  startMinutes?: number | undefined;
+  endMinutes?: number | undefined;
+}): SlotSchedule | null {
+  if (
+    isIsoWeekday(slot.weekday) &&
+    isValidDayMinutes(slot.startMinutes) &&
+    isValidDayMinutes(slot.endMinutes) &&
+    slot.endMinutes > slot.startMinutes
+  ) {
+    return {
+      weekday: slot.weekday,
+      startMinutes: slot.startMinutes,
+      endMinutes: slot.endMinutes,
+    };
+  }
+  return parseSlotScheduleFromLabel(slot.label) ?? parseSlotScheduleFromId(slot.id);
+}
+
+export function formatSlotScheduleSummary(schedule: SlotSchedule): string {
+  return `${ISO_WEEKDAY_LABELS[schedule.weekday]} ${formatMinutesAsLabel(schedule.startMinutes)}–${formatMinutesAsLabel(schedule.endMinutes)}`;
+}

--- a/src/lib/club-registration-config/types.ts
+++ b/src/lib/club-registration-config/types.ts
@@ -41,6 +41,12 @@ export type RegistrationSiteSlot = {
   sortOrder: number;
   schoolPickupSchool?: string | undefined;
   enabled: boolean;
+  /** Jour ISO (1 = lundi … 7 = dimanche). */
+  weekday?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | undefined;
+  /** Minutes depuis minuit (début). */
+  startMinutes?: number | undefined;
+  /** Minutes depuis minuit (fin, exclusive du lendemain). */
+  endMinutes?: number | undefined;
 };
 
 export type RegistrationSite = {

--- a/src/lib/navigation/home-content.test.ts
+++ b/src/lib/navigation/home-content.test.ts
@@ -18,6 +18,7 @@ function navOptionsForRole(role: UserRole) {
       role === USER_ROLES.BOARD_MEMBER,
     isAssistantSecretary: role === USER_ROLES.ASSISTANT_SECRETARY,
     isSecretary: role === USER_ROLES.SECRETARY,
+    isBoardMember: role === USER_ROLES.BOARD_MEMBER,
     canAccessSpreadsheet:
       role === USER_ROLES.ADMIN ||
       role === USER_ROLES.SECRETARY ||
@@ -47,16 +48,16 @@ describe("buildRoleHomeContent", () => {
       expect(content.eyebrow.length).toBeGreaterThan(0);
       expect(content.subtitle.length).toBeGreaterThan(0);
       expect(content.sections.length).toBeGreaterThan(0);
-      expect(content.sections.every((section) => section.items.length > 0)).toBe(
-        true
-      );
+      expect(
+        content.sections.every((section) => section.items.length > 0),
+      ).toBe(true);
     }
   });
 
   it("surfaces every navigation destination as a home card", () => {
     for (const role of Object.values(USER_ROLES)) {
       const missing = expectedNavHrefs(role).filter(
-        (href) => !listHomeCardHrefs(buildRoleHomeContent(role)).includes(href)
+        (href) => !listHomeCardHrefs(buildRoleHomeContent(role)).includes(href),
       );
       expect({ role, missing }).toEqual({ role, missing: [] });
     }
@@ -71,17 +72,21 @@ describe("buildRoleHomeContent", () => {
         "/joueurs",
         "/club/adhesions-tableau",
         "/club/inscription",
-      ])
+      ]),
     );
     expect(hrefs).not.toContain("/club/demandes-adhesion");
     expect(hrefs).not.toContain("/admin");
   });
 
-  it("keeps board members on the player journey plus the spreadsheet", () => {
+  it("keeps board members on the player journey plus spreadsheet and attendance", () => {
     const content = buildRoleHomeContent(USER_ROLES.BOARD_MEMBER);
-    expect(content.sections.map((section) => section.id)).toEqual(["adhesions"]);
+    expect(content.sections.map((section) => section.id)).toEqual([
+      "adhesions",
+    ]);
     expect(listHomeCardHrefs(content)).toEqual([
       "/club/adhesions-tableau",
+      "/club/presences",
+      "/club/presences/essais",
       "/club/inscription",
       "/club/mes-inscriptions",
     ]);

--- a/src/lib/navigation/home-content.ts
+++ b/src/lib/navigation/home-content.ts
@@ -7,11 +7,7 @@ export const HOME_HERO_IMAGE_ALT =
   "Joueuses et joueurs de SQY Ping — visuel du site sqyping.fr";
 
 export type HomeLinkColor =
-  | "primary"
-  | "secondary"
-  | "success"
-  | "info"
-  | "warning";
+  "primary" | "secondary" | "success" | "info" | "warning";
 
 export type HomeLinkCard = LayoutNavigationItem & {
   description: string;
@@ -50,7 +46,8 @@ const HOME_LINK_META: Record<
     color: "secondary",
   },
   "/disponibilites": {
-    description: "Saisir les disponibilités par journée et suivre les réponses.",
+    description:
+      "Saisir les disponibilités par journée et suivre les réponses.",
     cta: "Gérer les disponibilités",
     color: "info",
   },
@@ -70,7 +67,8 @@ const HOME_LINK_META: Record<
     color: "secondary",
   },
   "/club/adhesions-tableau": {
-    description: "Vue d'ensemble de tous les dossiers, avec tri, filtres et export.",
+    description:
+      "Vue d'ensemble de tous les dossiers, avec tri, filtres et export.",
     cta: "Ouvrir le tableau",
     color: "info",
   },
@@ -85,7 +83,8 @@ const HOME_LINK_META: Record<
     color: "info",
   },
   "/club/inscription": {
-    description: "Créer un dossier d'adhésion pour vous, un proche ou un membre du club.",
+    description:
+      "Créer un dossier d'adhésion pour vous, un proche ou un membre du club.",
     cta: "Ouvrir le formulaire",
     color: "primary",
   },
@@ -95,7 +94,8 @@ const HOME_LINK_META: Record<
     color: "primary",
   },
   "/club/idees": {
-    description: "Proposer une évolution ou signaler un problème sur l'application.",
+    description:
+      "Proposer une évolution ou signaler un problème sur l'application.",
     cta: "Ouvrir idées & remontées",
     color: "warning",
   },
@@ -103,6 +103,16 @@ const HOME_LINK_META: Record<
     description: "Saisir les licences FFTT et suivre les encaissements.",
     cta: "Ouvrir l'espace licences",
     color: "success",
+  },
+  "/club/presences": {
+    description: "Pointer les présences d'entraînement et consulter les taux.",
+    cta: "Ouvrir le pointage",
+    color: "info",
+  },
+  "/club/presences/essais": {
+    description: "Relancer les personnes venues essayer un entraînement.",
+    cta: "Ouvrir les essais",
+    color: "warning",
   },
 };
 
@@ -137,7 +147,7 @@ const TITLE = "Bienvenue sur TeamUp";
 function intro(
   eyebrow: string,
   subtitle: string,
-  sections: HomeDashboardSection[]
+  sections: HomeDashboardSection[],
 ): RoleHomeContent {
   return { eyebrow, title: TITLE, subtitle, sections };
 }
@@ -153,26 +163,29 @@ function playerHome(): RoleHomeContent {
         description: "Créer un dossier et suivre ceux déjà transmis au club.",
         items: cards([LAYOUT_NAV.nouvelleAdhesion, LAYOUT_NAV.mesDossiers]),
       },
-    ]
+    ],
   );
 }
 
 function boardMemberHome(): RoleHomeContent {
   return intro(
     "Espace membre du bureau",
-    "Même parcours qu'un adhérent, avec la vue d'ensemble des dossiers du club.",
+    "Même parcours qu'un adhérent, avec le tableau des dossiers et le pointage des entraînements.",
     [
       {
         id: "adhesions",
         title: "Adhésions",
-        description: "Vos dossiers personnels et le tableau de tous les adhérents.",
+        description:
+          "Vos dossiers, le tableau du club et les présences aux entraînements.",
         items: cards([
           LAYOUT_NAV.tableauAdhesions,
+          LAYOUT_NAV.presences,
+          LAYOUT_NAV.presencesEssais,
           LAYOUT_NAV.nouvelleAdhesion,
           LAYOUT_NAV.mesDossiers,
         ]),
       },
-    ]
+    ],
   );
 }
 
@@ -184,7 +197,8 @@ function assistantSecretaryHome(): RoleHomeContent {
       {
         id: "adhesions",
         title: "Adhésions",
-        description: "Consultation des dossiers du club et suivi de vos propres inscriptions.",
+        description:
+          "Consultation des dossiers du club et suivi de vos propres inscriptions.",
         items: cards([
           LAYOUT_NAV.tableauAdhesions,
           LAYOUT_NAV.validationsLicence,
@@ -192,7 +206,7 @@ function assistantSecretaryHome(): RoleHomeContent {
           LAYOUT_NAV.mesDossiers,
         ]),
       },
-    ]
+    ],
   );
 }
 
@@ -226,10 +240,11 @@ function coachHome(): RoleHomeContent {
       {
         id: "club",
         title: "Vie du club",
-        description: "Remontées sur l'application.",
-        items: cards([LAYOUT_NAV.boiteIdees]),
+        description:
+          "Présences aux entraînements et remontées sur l'application.",
+        items: cards([LAYOUT_NAV.presences, LAYOUT_NAV.boiteIdees]),
       },
-    ]
+    ],
   );
 }
 
@@ -250,16 +265,21 @@ function secretaryHome(): RoleHomeContent {
             LAYOUT_NAV.apercuFormulaire,
             LAYOUT_NAV.validationsLicence,
             LAYOUT_NAV.mesDossiers,
-          ])
+          ]),
         ),
       },
       {
         id: "club",
         title: "Vie du club",
-        description: "Remontées sur l'application.",
-        items: cards([LAYOUT_NAV.boiteIdees]),
+        description:
+          "Présences aux entraînements et remontées sur l'application.",
+        items: cards([
+          LAYOUT_NAV.presences,
+          LAYOUT_NAV.presencesEssais,
+          LAYOUT_NAV.boiteIdees,
+        ]),
       },
-    ]
+    ],
   );
 }
 
@@ -292,16 +312,21 @@ function adminHome(): RoleHomeContent {
             LAYOUT_NAV.apercuFormulaire,
             LAYOUT_NAV.validationsLicence,
             LAYOUT_NAV.mesDossiers,
-          ])
+          ]),
         ),
       },
       {
         id: "club",
         title: "Vie du club",
-        description: "Administration de la plateforme et remontées.",
-        items: cards([LAYOUT_NAV.administration, LAYOUT_NAV.boiteIdees]),
+        description: "Présences, administration de la plateforme et remontées.",
+        items: cards([
+          LAYOUT_NAV.presences,
+          LAYOUT_NAV.presencesEssais,
+          LAYOUT_NAV.administration,
+          LAYOUT_NAV.boiteIdees,
+        ]),
       },
-    ]
+    ],
   );
 }
 
@@ -324,6 +349,6 @@ export function buildRoleHomeContent(role: UserRole): RoleHomeContent {
 
 export function listHomeCardHrefs(content: RoleHomeContent): string[] {
   return content.sections.flatMap((section) =>
-    section.items.map((item) => item.href)
+    section.items.map((item) => item.href),
   );
 }


### PR DESCRIPTION
## Summary
- Pointage tablette par créneau (`/club/presences`), roster issu des dossiers d’adhésion, essais hors club et file de relance.
- Accessible aux rôles admin, secrétaire, membre du bureau et coach (file des essais : admin, secrétaire, bureau).
- Collections `attendanceMarks` / `attendanceLeads` (Admin SDK, deny-all client), horaires structurés sur les créneaux, ADR-0006.

## Test plan
- [ ] Coach / secrétaire / membre du bureau : ouvrir `/club/presences`, choisir un créneau du jour, pointer / dépointer un adhérent.
- [ ] Ajouter un adhérent hors créneau (walk-in) et un essai (identité + téléphone).
- [ ] Admin / secrétaire / bureau : `/club/presences/essais` change le statut d’une relance ; le coach n’y a pas accès.
- [ ] Onglet taux + export CSV d’une séance.
- [ ] Secrétaire adjoint et joueur : pas d’entrée Présences, 403 API.


Made with [Cursor](https://cursor.com)