### PR TITLE
feat(club): vue remplissage des créneaux et fermeture des inscriptions

### DIFF
--- a/docs/technical/adr/0007-slot-occupancy.md
+++ b/docs/technical/adr/0007-slot-occupancy.md
@@ -1,0 +1,57 @@
+# ADR-0007: Capacité et remplissage des créneaux d’entraînement
+
+## Statut
+
+Accepté — 2026-08-21, amendé 2026-08-21 (fermeture à la demande)
+
+## Contexte
+
+Les créneaux vivent dans le catalogue d’inscription (`clubRegistrationConfig.sites[].slots`). Les inscrits sont les dossiers `clubRegistrations` dont `slotIds` contient le créneau (hors refusés), y compris les walk-in ajoutés depuis le pointage (`arrayUnion`).
+
+Le staff a besoin d’une vue synthétique du remplissage (taux + liste) pour piloter les effectifs. Le blocage des inscriptions est une **fermeture à la demande** (`enrollmentsClosed`), distincte de la jauge `capacity`.
+
+`exactSlotCount` des règles tarifaires (`PricingDevice`) n’est pas une capacité de salle : c’est une contrainte de pricing (ex. exactement un créneau).
+
+## Décision
+
+1. **Champ observationnel** : `capacity` optionnel (entier ≥ 1) sur chaque `RegistrationSiteSlot`. Absent = pas de taux, seulement le compteur d’inscrits.
+2. **Capacité sans enforcement** : le wizard et l’API d’inscription n’utilisent pas `capacity` pour refuser une inscription. Un créneau « plein » reste signalé dans l’UI staff (page Créneaux).
+3. **Fermeture à la demande** : flag `enrollmentsClosed` sur le créneau. Pilotage admin / secrétaire (page Créneaux et Campagnes & tarifs).
+4. **Blocage** : une personne sans rôle prioritaire (anonyme, joueur, secrétaire adjoint) ne peut pas sélectionner ni soumettre un créneau fermé. Bypass : admin, secrétaire, coach, membre du bureau. Le walk-in pointage n’est pas bloqué ; l’info « Inscriptions fermées » y est affichée.
+5. **Libellé formulaire / pointage** : uniquement « Inscriptions fermées ». Pas de taux de remplissage dans le wizard ni au choix de créneau du pointage.
+6. **Population** : même règle que le pointage (dossiers non refusés, source `clubRegistrations`, jamais `players`). Liste d’inscrits : mêmes alertes (paiement, certificat, PPS) via le mapping roster existant.
+7. **Domaine** : lecture via `/api/club/slots/occupancy*` et `src/lib/club-slot-occupancy/`. Pas de nouvelle collection. Accès occupancy = opérateurs de présence. Édition capacité / fermeture = `ADMIN`, `SECRETARY`.
+8. **Taux** : `enrolledCount / capacity` lorsque `capacity` est défini. Surcharge visuelle si `enrolledCount > capacity`.
+
+## Conséquences
+
+### Positives
+- Une seule source de vérité pour la capacité, déjà dans le catalogue publié.
+- Le pointage et le remplissage partagent l’effectif, y compris les walk-in.
+- Le staff ferme quand il le décide, sans lier le geste au seul compteur.
+
+### Négatives
+- Tant que les capacités ne sont pas saisies, la page Créneaux n’affiche que des compteurs.
+- Un scan des dossiers à chaque ouverture de la vue remplissage (pas de compteurs dénormalisés).
+- Un créneau plein mais non fermé reste inscriptible pour les familles.
+
+### Neutres
+- `enabled` continue de masquer le créneau dans le formulaire ; ce n’est pas un substitut à `enrollmentsClosed`.
+
+## Alternatives considérées
+
+### Alternative 1: capacité en nombre de tables
+- **Pourquoi rejetée** : le besoin V1 est un max d’inscrits simple. Les tables pourront s’ajouter plus tard sans retirer `capacity`.
+
+### Alternative 2: fermeture automatique dès `enrolledCount >= capacity`
+- **Pourquoi rejetée** : le produit a choisi la fermeture à la demande.
+
+### Alternative 3: réutiliser `exactSlotCount`
+- **Pourquoi rejetée** : contrainte tarifaire (nombre de créneaux choisis), pas une jauge de salle.
+
+## Références
+
+- `.cursor/rules/80-club-platform-extension.mdc`
+- `docs/technical/adr/0006-training-attendance.md`
+- `src/lib/club-slot-occupancy/`
+- `src/lib/club-registration-config/slot-enrollments.ts`

--- a/src/app/api/club/registration/route.ts
+++ b/src/app/api/club/registration/route.ts
@@ -23,6 +23,7 @@ import {
   ensureRegistrationConfigSeeded,
   getActiveRegistrationConfig,
 } from "@/lib/club-registration-config/store";
+import { canBypassSlotEnrollmentClose } from "@/lib/club-registration-config/slot-enrollments";
 import { createRegistrationWithIdempotency } from "@/lib/club-registration/create-registration-with-idempotency";
 import {
   findRegistrationLicenseConflicts,
@@ -139,7 +140,8 @@ export async function POST(req: Request) {
     const json = (await req.json()) ?? {};
     await ensureRegistrationConfigSeeded();
     const activeConfig = await getActiveRegistrationConfig();
-    const parsed = buildRegistrationPayloadSchema(activeConfig).safeParse(json);
+    const allowClosedSlots = canBypassSlotEnrollmentClose(role);
+    const parsed = buildRegistrationPayloadSchema(activeConfig, { allowClosedSlots }).safeParse(json);
 
     if (!parsed.success) {
       const first = parsed.error.flatten();
@@ -153,7 +155,7 @@ export async function POST(req: Request) {
       ? stripSubmitterEmailFromRegistrationPayload(parsed.data, decoded.email)
       : parsed.data;
 
-    const payloadCheck = buildRegistrationPayloadSchema(activeConfig).safeParse(payload);
+    const payloadCheck = buildRegistrationPayloadSchema(activeConfig, { allowClosedSlots }).safeParse(payload);
     if (!payloadCheck.success) {
       const first = payloadCheck.error.flatten();
       return jsonNoStore(

--- a/src/app/api/club/slots/occupancy/[slotId]/enrollments-closed/route.ts
+++ b/src/app/api/club/slots/occupancy/[slotId]/enrollments-closed/route.ts
@@ -1,0 +1,67 @@
+export const runtime = "nodejs";
+
+import { z } from "zod";
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import {
+  invalidOriginResponse,
+  requireRegistrationManager,
+} from "@/lib/club-registration-config/api-auth";
+import { patchSlotEnrollmentsClosed } from "@/lib/club-registration-config/store";
+
+type RouteContext = { params: Promise<{ slotId: string }> };
+
+const bodySchema = z.object({
+  closed: z.boolean(),
+});
+
+/** PATCH /api/club/slots/occupancy/[slotId]/enrollments-closed */
+export async function PATCH(req: Request, context: RouteContext) {
+  if (!validateOrigin(req)) {
+    return invalidOriginResponse();
+  }
+
+  const auth = await requireRegistrationManager();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { slotId } = await context.params;
+  const trimmed = slotId.trim();
+  if (!trimmed) {
+    return jsonNoStore({ error: "Créneau requis" }, { status: 400 });
+  }
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return jsonNoStore({ error: "JSON invalide" }, { status: 400 });
+  }
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+  }
+
+  try {
+    const result = await patchSlotEnrollmentsClosed(
+      trimmed,
+      parsed.data.closed,
+      auth.session.uid
+    );
+    if (result === "not_found") {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_SLOT_ENROLLMENTS_TOGGLED, auth.session.uid, {
+      resource: "clubRegistrationConfig.slot",
+      resourceId: trimmed,
+      details: { closed: parsed.data.closed },
+      success: true,
+    });
+    return jsonNoStore({ slotId: trimmed, enrollmentsClosed: parsed.data.closed });
+  } catch (error) {
+    console.error("[api/club/slots/occupancy enrollments-closed PATCH]", error);
+    return jsonNoStore({ error: "Impossible de mettre à jour les adhésions du créneau" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/slots/occupancy/[slotId]/route.ts
+++ b/src/app/api/club/slots/occupancy/[slotId]/route.ts
@@ -1,0 +1,46 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { listRegistrationsForSlot } from "@/lib/attendance/store";
+import {
+  buildOccupancyGroups,
+  findOccupancySlot,
+  mapRegistrationToOccupancyPerson,
+  sortOccupancyPeople,
+} from "@/lib/club-slot-occupancy/build-occupancy";
+import { countEnrollmentsBySlotId } from "@/lib/club-slot-occupancy/count-enrollments";
+
+type RouteContext = { params: Promise<{ slotId: string }> };
+
+/** GET /api/club/slots/occupancy/[slotId] — inscrits d'un créneau. */
+export async function GET(_req: Request, context: RouteContext) {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { slotId } = await context.params;
+  const trimmed = slotId.trim();
+  if (!trimmed) {
+    return jsonNoStore({ error: "Créneau requis" }, { status: 400 });
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const registrations = await listRegistrationsForSlot(auth.session.db, trimmed);
+    const groups = buildOccupancyGroups(config, countEnrollmentsBySlotId(registrations));
+    const slot = findOccupancySlot(groups, trimmed);
+    if (!slot) {
+      return jsonNoStore({ error: "Créneau introuvable" }, { status: 404 });
+    }
+    const enrolled = sortOccupancyPeople(
+      registrations.map((item) => mapRegistrationToOccupancyPerson(item.id, item.data))
+    );
+    return jsonNoStore({ slot, enrolled });
+  } catch (error) {
+    console.error("[api/club/slots/occupancy/[slotId] GET]", error);
+    return jsonNoStore({ error: "Impossible de charger les inscrits du créneau" }, { status: 500 });
+  }
+}

--- a/src/app/api/club/slots/occupancy/route.ts
+++ b/src/app/api/club/slots/occupancy/route.ts
@@ -1,0 +1,31 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireAttendanceOperator } from "@/lib/attendance/api-auth";
+import { isClubRegistrationManager } from "@/lib/club-registration/registration-access";
+import { buildOccupancyGroups } from "@/lib/club-slot-occupancy/build-occupancy";
+import { countEnrollmentsBySlotId } from "@/lib/club-slot-occupancy/count-enrollments";
+import { listAllNonRejectedRegistrations } from "@/lib/club-slot-occupancy/store";
+
+/** GET /api/club/slots/occupancy — synthèse de remplissage de tous les créneaux. */
+export async function GET() {
+  const auth = await requireAttendanceOperator();
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  try {
+    const config = await getActiveRegistrationConfig();
+    const registrations = await listAllNonRejectedRegistrations(auth.session.db);
+    const groups = buildOccupancyGroups(config, countEnrollmentsBySlotId(registrations));
+    return jsonNoStore({
+      seasonLabel: config.meta.seasonLabel,
+      groups,
+      canManageEnrollments: isClubRegistrationManager(auth.session.role),
+    });
+  } catch (error) {
+    console.error("[api/club/slots/occupancy GET]", error);
+    return jsonNoStore({ error: "Impossible de charger le remplissage des créneaux" }, { status: 500 });
+  }
+}

--- a/src/app/club/creneaux/page.tsx
+++ b/src/app/club/creneaux/page.tsx
@@ -1,0 +1,14 @@
+import { AuthGuard } from "@/components/AuthGuard";
+import { SlotOccupancyClient } from "@/components/club-slot-occupancy/SlotOccupancyClient";
+import { ATTENDANCE_OPERATOR_ROLES } from "@/lib/attendance/access";
+
+export default function ClubCreneauxPage() {
+  return (
+    <AuthGuard
+      allowedRoles={[...ATTENDANCE_OPERATOR_ROLES]}
+      redirectWhenUnauthorized="/joueur"
+    >
+      <SlotOccupancyClient />
+    </AuthGuard>
+  );
+}

--- a/src/app/club/inscription/page.tsx
+++ b/src/app/club/inscription/page.tsx
@@ -4,6 +4,7 @@ import { Box, CircularProgress, Container } from "@mui/material";
 import { ClubRegistrationWizard } from "@/components/club-registration/ClubRegistrationWizard";
 import { useAuth } from "@/hooks/useAuth";
 import { isClubRegistrationManager } from "@/lib/club-registration/registration-access";
+import { canBypassSlotEnrollmentClose } from "@/lib/club-registration-config/slot-enrollments";
 
 /**
  * Page d'inscription au club (parcours hybride).
@@ -33,6 +34,7 @@ export default function ClubInscriptionPage() {
         isRegistrationManager={
           user?.role != null && isClubRegistrationManager(user.role)
         }
+        canSelectClosedSlots={canBypassSlotEnrollmentClose(user?.role)}
       />
     </Container>
   );

--- a/src/components/attendance/AttendanceSlotPicker.tsx
+++ b/src/components/attendance/AttendanceSlotPicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import type { AttendanceSlotOption } from "@/lib/attendance/types";
 import { formatMinutesAsLabel } from "@/lib/club-registration-config/slot-schedule";
+import { SLOT_ENROLLMENTS_CLOSED_LABEL } from "@/lib/club-registration-config/slot-enrollments";
 
 type Props = {
   slots: AttendanceSlotOption[];
@@ -85,6 +86,9 @@ export function AttendanceSlotPicker({
                     </Typography>
                     {slot.highlighted ? (
                       <Chip size="small" label="Proche de maintenant" />
+                    ) : null}
+                    {slot.enrollmentsClosed ? (
+                      <Chip size="small" color="warning" label={SLOT_ENROLLMENTS_CLOSED_LABEL} />
                     ) : null}
                   </Stack>
                 </Button>

--- a/src/components/club-registration-config/SiteSlotEditorCard.tsx
+++ b/src/components/club-registration-config/SiteSlotEditorCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { ConfigEditorDragHandleProps } from "./ConfigEditorLayout";
 import {
   FormControl,
@@ -21,6 +22,7 @@ import {
 } from "@/lib/club-registration-config/slot-schedule";
 import { ConfigEditorCollapsibleItem, ConfigEditorOptionPanel } from "./ConfigEditorLayout";
 import { ConfigEditorRemoveAction } from "./ConfigEditorRemoveAction";
+import { SlotEnrollmentsConfirmDialog } from "./SlotEnrollmentsConfirmDialog";
 import { slotItemDecor } from "./config-editor-item-decor";
 import { slotSummaryMeta } from "./config-editor-summary-meta";
 import { configEditorSwitchLabelSx } from "./config-editor-layout";
@@ -48,6 +50,8 @@ export function SiteSlotEditorCard({
   dragHandleProps,
   isDragging = false,
 }: Props) {
+  const [enrollmentsConfirmOpen, setEnrollmentsConfirmOpen] = useState(false);
+  const [pendingEnrollmentsClosed, setPendingEnrollmentsClosed] = useState(false);
   const schoolPickupEnabled = Boolean(slot.schoolPickupSchool);
   const weekday = isIsoWeekday(slot.weekday) ? slot.weekday : 1;
   const startInput = formatMinutesAsInput(slot.startMinutes ?? 17 * 60);
@@ -117,6 +121,27 @@ export function SiteSlotEditorCard({
         />
       </Stack>
 
+      <TextField
+        label="Capacité (inscrits)"
+        type="number"
+        size="small"
+        value={slot.capacity ?? ""}
+        onChange={(e) => {
+          const raw = e.target.value.trim();
+          if (raw === "") {
+            onChange({ capacity: undefined });
+            return;
+          }
+          const parsed = Number.parseInt(raw, 10);
+          if (Number.isInteger(parsed) && parsed >= 1) {
+            onChange({ capacity: parsed });
+          }
+        }}
+        helperText="Nombre max d'inscrits pour le taux de remplissage. N'empêche pas les inscriptions."
+        slotProps={{ htmlInput: { min: 1, step: 1 } }}
+        sx={{ maxWidth: 280 }}
+      />
+
       <ConfigEditorOptionPanel title="Récupération scolaire">
         <FormControlLabel
           sx={configEditorSwitchLabelSx}
@@ -144,6 +169,30 @@ export function SiteSlotEditorCard({
           />
         ) : null}
       </ConfigEditorOptionPanel>
+
+      <FormControlLabel
+        sx={configEditorSwitchLabelSx}
+        control={
+          <Switch
+            checked={slot.enrollmentsClosed === true}
+            onChange={(e) => {
+              setPendingEnrollmentsClosed(e.target.checked);
+              setEnrollmentsConfirmOpen(true);
+            }}
+          />
+        }
+        label="Fermer les adhésions sur ce créneau"
+      />
+      <SlotEnrollmentsConfirmDialog
+        open={enrollmentsConfirmOpen}
+        closing={pendingEnrollmentsClosed}
+        slotLabel={slot.label}
+        onCancel={() => setEnrollmentsConfirmOpen(false)}
+        onConfirm={() => {
+          setEnrollmentsConfirmOpen(false);
+          onChange({ enrollmentsClosed: pendingEnrollmentsClosed ? true : undefined });
+        }}
+      />
 
       <FormControlLabel
         sx={configEditorSwitchLabelSx}

--- a/src/components/club-registration-config/SlotEnrollmentsConfirmDialog.tsx
+++ b/src/components/club-registration-config/SlotEnrollmentsConfirmDialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+
+type Props = {
+  open: boolean;
+  closing: boolean;
+  busy?: boolean;
+  error?: string | null | undefined;
+  slotLabel?: string | undefined;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+function slotPhrase(slotLabel: string | undefined): string {
+  const trimmed = slotLabel?.trim();
+  return trimmed ? ` sur « ${trimmed} »` : " sur ce créneau";
+}
+
+export function SlotEnrollmentsConfirmDialog({
+  open,
+  closing,
+  busy = false,
+  error,
+  slotLabel,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const title = closing ? "Fermer les adhésions ?" : "Réouvrir les adhésions ?";
+  const confirmLabel = closing ? "Fermer les adhésions" : "Réouvrir les adhésions";
+  const pendingLabel = closing ? "Fermeture..." : "Ouverture...";
+  const description = closing
+    ? `Marquer les adhésions comme fermées${slotPhrase(slotLabel)} ?`
+    : `Marquer les adhésions comme ouvertes${slotPhrase(slotLabel)} ?`;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (!busy) onCancel();
+      }}
+      aria-labelledby="slot-enrollments-confirm-title"
+      aria-describedby="slot-enrollments-confirm-desc"
+      aria-busy={busy}
+    >
+      <DialogTitle id="slot-enrollments-confirm-title">{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="slot-enrollments-confirm-desc">{description}</DialogContentText>
+        {error ? (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        ) : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} disabled={busy}>
+          Annuler
+        </Button>
+        <Button
+          variant="contained"
+          color={closing ? "warning" : "primary"}
+          onClick={onConfirm}
+          disabled={busy}
+          autoFocus
+          startIcon={busy ? <CircularProgress size={16} color="inherit" /> : undefined}
+        >
+          {busy ? pendingLabel : confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/club-registration-config/config-editor-item-decor.tsx
+++ b/src/components/club-registration-config/config-editor-item-decor.tsx
@@ -1,4 +1,4 @@
-import { VisibilityOff } from "@mui/icons-material";
+import { Lock, VisibilityOff } from "@mui/icons-material";
 import type { SvgIconComponent } from "@mui/icons-material";
 import type { PricingProfileDefinition, RegistrationCompetition, RegistrationConfigV1, RegistrationSection, RegistrationSiteSlot } from "@/lib/club-registration-config/types";
 import {
@@ -44,6 +44,9 @@ export const siteItemDecor: ConfigEditorItemDecor = {
 };
 
 export function slotItemDecor(slot: RegistrationSiteSlot): ConfigEditorItemDecor {
+  if (slot.enrollmentsClosed) {
+    return { accent: "warning", Icon: Lock };
+  }
   if (!slot.enabled) {
     return { accent: "warning", Icon: VisibilityOff };
   }

--- a/src/components/club-registration-config/config-editor-summary-meta.ts
+++ b/src/components/club-registration-config/config-editor-summary-meta.ts
@@ -4,6 +4,7 @@ import {
   formatSlotScheduleSummary,
   resolveSlotSchedule,
 } from "@/lib/club-registration-config/slot-schedule";
+import { SLOT_ENROLLMENTS_CLOSED_LABEL } from "@/lib/club-registration-config/slot-enrollments";
 import { centsToEuroInput } from "./config-editor-utils";
 
 export function sectionSummaryMeta(
@@ -27,6 +28,8 @@ export function slotSummaryMeta(
     weekday?: number | undefined;
     startMinutes?: number | undefined;
     endMinutes?: number | undefined;
+    capacity?: number | undefined;
+    enrollmentsClosed?: boolean | undefined;
     id?: string;
     label?: string;
   }
@@ -42,6 +45,10 @@ export function slotSummaryMeta(
   if (schedule) {
     parts.push(formatSlotScheduleSummary(schedule));
   }
+  if (typeof slot.capacity === "number") {
+    parts.push(`${slot.capacity} places`);
+  }
+  if (slot.enrollmentsClosed) parts.push(SLOT_ENROLLMENTS_CLOSED_LABEL);
   if (!slot.enabled) parts.push("Inactif");
   if (slot.schoolPickupSchool) parts.push("Récup. scolaire");
   return parts.length > 0 ? parts.join(" · ") : undefined;

--- a/src/components/club-registration/ClubRegistrationWizard.tsx
+++ b/src/components/club-registration/ClubRegistrationWizard.tsx
@@ -79,11 +79,14 @@ type Props = {
   accountEmail: string | null;
   /** Admin / secrétariat : inscription pour un tiers, pas de préremplissage contact. */
   isRegistrationManager?: boolean;
+  /** Admin, secrétaire, coach, bureau : peuvent inscrire sur un créneau fermé. */
+  canSelectClosedSlots?: boolean;
 };
 
 export function ClubRegistrationWizard({
   accountEmail,
   isRegistrationManager = false,
+  canSelectClosedSlots = false,
 }: Props) {
   const { config: loadedConfig, loading: configLoading } = useRegistrationConfig();
   const config = loadedConfig ?? getDefaultRegistrationConfig();
@@ -128,8 +131,8 @@ export function ClubRegistrationWizard({
   }, [activeStep, sequence.length]);
 
   const stepValidity = useMemo<(string | null)[]>(
-    () => sequence.map((id) => validateStepById(id, draft, config)),
-    [config, draft, sequence]
+    () => sequence.map((id) => validateStepById(id, draft, config, { allowClosedSlots: canSelectClosedSlots })),
+    [canSelectClosedSlots, config, draft, sequence]
   );
 
   const completedStepsCount = useMemo(
@@ -270,6 +273,7 @@ export function ClubRegistrationWizard({
     sequence,
     storage,
     accountEmail,
+    allowClosedSlots: canSelectClosedSlots,
     buildPayload,
     setActiveStep,
     stepErrorAlertRef,
@@ -277,7 +281,7 @@ export function ClubRegistrationWizard({
 
   const revealStepValidationError = useCallback(
     (stepId: RegistrationStepId) => {
-      const result = validateStep(stepId, draft, config);
+      const result = validateStep(stepId, draft, config, { allowClosedSlots: canSelectClosedSlots });
       if (result.valid) return true;
       setSubmitError(result.message);
       scrollToFormTarget(result.focusSelector, {
@@ -290,7 +294,7 @@ export function ClubRegistrationWizard({
       });
       return false;
     },
-    [config, draft, setSubmitError, stepErrorAlertRef]
+    [canSelectClosedSlots, config, draft, setSubmitError, stepErrorAlertRef]
   );
 
   /* Auto-save à chaque changement de draft. */
@@ -481,7 +485,7 @@ export function ClubRegistrationWizard({
       }
       for (let s = activeStep; s < to; s++) {
         const stepId = sequence[s];
-        const result = validateStep(stepId, draft, config);
+        const result = validateStep(stepId, draft, config, { allowClosedSlots: canSelectClosedSlots });
         if (!result.valid) {
           setActiveStep(s);
           setSubmitError(result.message);
@@ -498,7 +502,7 @@ export function ClubRegistrationWizard({
       }
       setActiveStep(to);
     },
-    [activeStep, clearSubmitFeedback, config, draft, sequence, setSubmitError]
+    [activeStep, canSelectClosedSlots, clearSubmitFeedback, config, draft, sequence, setSubmitError]
   );
 
   /** Navigation vers une étape par son identifiant symbolique (utilisée par
@@ -583,7 +587,8 @@ export function ClubRegistrationWizard({
                           activeStep,
                           sequence,
                           draft,
-                          config
+                          config,
+                          { allowClosedSlots: canSelectClosedSlots }
                         )
                       }
                       onClick={() => handleGoToStep(index)}
@@ -628,7 +633,8 @@ export function ClubRegistrationWizard({
                         activeStep,
                         sequence,
                         draft,
-                        config
+                        config,
+                        { allowClosedSlots: canSelectClosedSlots }
                       )
                     }
                     onClick={() => handleGoToStep(index)}
@@ -757,6 +763,7 @@ export function ClubRegistrationWizard({
               {currentStepId === "practice" && (
                 <PracticeStep
                   draft={draft}
+                  canSelectClosedSlots={canSelectClosedSlots}
                   onChange={actions.patchFields}
                 />
               )}

--- a/src/components/club-registration/PracticeSlotPicker.tsx
+++ b/src/components/club-registration/PracticeSlotPicker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -7,6 +8,7 @@ import {
   Alert,
   Box,
   Checkbox,
+  Chip,
   FormControlLabel,
   FormGroup,
   Stack,
@@ -18,6 +20,11 @@ import {
   sanitizeSchoolPickupSlotIdsFromConfig,
 } from "@/lib/club-registration-config/helpers";
 import { registrationSiteGymnasiumLabel } from "@/lib/club-registration-config/site-display";
+import {
+  isSlotEnrollmentsClosed,
+  omitClosedSlotsFromSelection,
+  SLOT_ENROLLMENTS_CLOSED_LABEL,
+} from "@/lib/club-registration-config/slot-enrollments";
 import { useRegistrationConfigValue } from "@/hooks/useRegistrationConfig";
 import type { RegistrationDraft } from "./registration-defaults";
 
@@ -26,6 +33,7 @@ type Props = {
   expandedSiteIds: Set<string>;
   onExpandedSiteIdsChange: (next: Set<string>) => void;
   onChange: (patch: Partial<RegistrationDraft>) => void;
+  canSelectClosedSlots?: boolean;
 };
 
 export function PracticeSlotPicker({
@@ -33,12 +41,34 @@ export function PracticeSlotPicker({
   expandedSiteIds,
   onExpandedSiteIdsChange,
   onChange,
+  canSelectClosedSlots = false,
 }: Props) {
   const config = useRegistrationConfigValue();
   const sites = getEnabledSites(config);
   const schoolPickupCopy = config.uiCopy.schoolPickupService;
 
-  const toggleSlot = (id: string) => {
+  useEffect(() => {
+    if (canSelectClosedSlots) {
+      return;
+    }
+    const nextSlotIds = omitClosedSlotsFromSelection(config, draft.slotIds);
+    if (nextSlotIds.length === draft.slotIds.length) {
+      return;
+    }
+    onChange({
+      slotIds: nextSlotIds,
+      schoolPickupSlotIds: sanitizeSchoolPickupSlotIdsFromConfig(
+        config,
+        nextSlotIds,
+        draft.schoolPickupSlotIds
+      ),
+    });
+  }, [canSelectClosedSlots, config, draft.schoolPickupSlotIds, draft.slotIds, onChange]);
+
+  const toggleSlot = (id: string, closed: boolean) => {
+    if (closed && !canSelectClosedSlots) {
+      return;
+    }
     const slotSet = new Set(draft.slotIds);
     const pickupSet = new Set(draft.schoolPickupSlotIds);
     if (slotSet.has(id)) {
@@ -114,6 +144,8 @@ export function PracticeSlotPicker({
                 .map((slot) => {
                 const isSelected = draft.slotIds.includes(slot.id);
                 const wantsSchoolPickup = draft.schoolPickupSlotIds.includes(slot.id);
+                const closed = isSlotEnrollmentsClosed(slot);
+                const blocked = closed && !canSelectClosedSlots;
 
                 return (
                   <Box key={slot.id} sx={{ mb: slot.schoolPickupSchool ? 1.5 : 0 }}>
@@ -121,10 +153,18 @@ export function PracticeSlotPicker({
                       control={
                         <Checkbox
                           checked={isSelected}
-                          onChange={() => toggleSlot(slot.id)}
+                          disabled={blocked}
+                          onChange={() => toggleSlot(slot.id, closed)}
                         />
                       }
-                      label={slot.label}
+                      label={
+                        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                          <Typography component="span">{slot.label}</Typography>
+                          {closed ? (
+                            <Chip size="small" color="warning" label={SLOT_ENROLLMENTS_CLOSED_LABEL} />
+                          ) : null}
+                        </Stack>
+                      }
                     />
                     {isSelected && slot.schoolPickupSchool ? (
                       <Box sx={{ pl: 4, mt: 0.5 }}>

--- a/src/components/club-registration/PracticeStep.tsx
+++ b/src/components/club-registration/PracticeStep.tsx
@@ -32,6 +32,7 @@ import { getCompetitionsRequiringAvailabilityCommitment } from "@/lib/club-regis
 type Props = {
   draft: RegistrationDraft;
   onChange: (patch: Partial<RegistrationDraft>) => void;
+  canSelectClosedSlots?: boolean;
 };
 
 function siteIdsMatchingMainSection(
@@ -69,7 +70,7 @@ function formatCompetitionAddonEuros(priceCents: number): string {
  * Villepreux, etc.). Les sections « handisport » et « sport-adapté » restent
  * proposées dans la même liste.
  */
-export function PracticeStep({ draft, onChange }: Props) {
+export function PracticeStep({ draft, onChange, canSelectClosedSlots = false }: Props) {
   const config = useRegistrationConfigValue();
   const sectionOptions = getEnabledSections(config);
   const youthCompetitions = config.competitions.filter(
@@ -182,6 +183,7 @@ export function PracticeStep({ draft, onChange }: Props) {
         expandedSiteIds={expandedSiteIds}
         onExpandedSiteIdsChange={setExpandedSiteIds}
         onChange={onChange}
+        canSelectClosedSlots={canSelectClosedSlots}
       />
 
       <Typography

--- a/src/components/club-registration/club-registration-wizard-steps.ts
+++ b/src/components/club-registration/club-registration-wizard-steps.ts
@@ -3,7 +3,7 @@ import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/def
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import type { RegistrationStepId } from "@/lib/club-registration/field-to-step";
 import type { RegistrationDraft } from "./registration-defaults";
-import { validateStepById } from "./step-validation";
+import { validateStepById, type StepValidationOptions } from "./step-validation";
 
 export const STEP_TITLES: Record<RegistrationStepId, string> = {
   audience: "Pour qui ?",
@@ -67,11 +67,12 @@ export function canNavigateToRegistrationStep(
   activeStep: number,
   sequence: ReadonlyArray<RegistrationStepId>,
   draft: RegistrationDraft,
-  config: RegistrationConfigV1 = getDefaultRegistrationConfig()
+  config: RegistrationConfigV1 = getDefaultRegistrationConfig(),
+  options: StepValidationOptions = {}
 ): boolean {
   if (targetIndex <= activeStep) return true;
   for (let s = activeStep; s < targetIndex; s++) {
-    if (validateStepById(sequence[s], draft, config) !== null) return false;
+    if (validateStepById(sequence[s], draft, config, options) !== null) return false;
   }
   return true;
 }

--- a/src/components/club-registration/membership-requests/membership-request-detail-shared.ts
+++ b/src/components/club-registration/membership-requests/membership-request-detail-shared.ts
@@ -1,5 +1,6 @@
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { getEnabledSites } from "@/lib/club-registration-config/helpers";
+import { SLOT_ENROLLMENTS_CLOSED_LABEL } from "@/lib/club-registration-config/slot-enrollments";
 import { formatRegistrationSiteLabel } from "@/lib/club-registration-config/site-display";
 import {
   syncPaymentAidsWithReductionTypes,
@@ -74,7 +75,9 @@ export function buildSlotOptions(config: RegistrationConfigV1) {
       .filter((slot) => slot.enabled)
       .map((slot) => ({
         value: slot.id,
-        label: `${formatRegistrationSiteLabel(site)} — ${slot.label}`,
+        label: slot.enrollmentsClosed
+          ? `${formatRegistrationSiteLabel(site)} — ${slot.label} (${SLOT_ENROLLMENTS_CLOSED_LABEL})`
+          : `${formatRegistrationSiteLabel(site)} — ${slot.label}`,
       }))
   );
 }

--- a/src/components/club-registration/recap-step-utils.tsx
+++ b/src/components/club-registration/recap-step-utils.tsx
@@ -9,6 +9,7 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import { SectionCard } from "@/components/ui";
 import { getEnabledSections, getEnabledSites } from "@/lib/club-registration-config/helpers";
+import { SLOT_ENROLLMENTS_CLOSED_LABEL } from "@/lib/club-registration-config/slot-enrollments";
 import { formatRegistrationSiteLabel } from "@/lib/club-registration-config/site-display";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { MEDICAL_CERTIFICATE_DECLARATION_LABELS } from "@/lib/club-registration/medical-declaration-labels";
@@ -77,7 +78,11 @@ export function findSectionLabel(config: RegistrationConfigV1, id: string): stri
 export function findSlotLabel(config: RegistrationConfigV1, id: string): string {
   for (const site of getEnabledSites(config)) {
     const found = site.slots.find((s) => s.id === id);
-    if (found) return `${formatRegistrationSiteLabel(site)} — ${found.label}`;
+    if (found) {
+      return found.enrollmentsClosed
+        ? `${formatRegistrationSiteLabel(site)} — ${found.label} (${SLOT_ENROLLMENTS_CLOSED_LABEL})`
+        : `${formatRegistrationSiteLabel(site)} — ${found.label}`;
+    }
   }
   return id;
 }

--- a/src/components/club-registration/step-validation.ts
+++ b/src/components/club-registration/step-validation.ts
@@ -14,6 +14,7 @@ import { validatePaymentDraft } from "@/lib/club-registration/payment/validate-p
 import { validateAdminAids } from "@/lib/club-registration/validate-admin-aids";
 import { isValidFrenchPhoneSurface } from "@/lib/club-registration/phone-fr";
 import type { RegistrationDraft } from "./registration-defaults";
+import { getClosedEnabledSlotIds } from "@/lib/club-registration-config/slot-enrollments";
 
 export type StepValidationResult =
   | { valid: true }
@@ -65,10 +66,15 @@ function getMedicalFocusSelector(draft: RegistrationDraft): string {
   return "#medical-dossier-section";
 }
 
+export type StepValidationOptions = {
+  allowClosedSlots?: boolean;
+};
+
 export function validateStep(
   stepId: RegistrationStepId,
   draft: RegistrationDraft,
-  config: RegistrationConfigV1 = getDefaultRegistrationConfig()
+  config: RegistrationConfigV1 = getDefaultRegistrationConfig(),
+  options: StepValidationOptions = {}
 ): StepValidationResult {
   if (stepId === "audience") {
     if (!draft.birthDate) {
@@ -230,6 +236,15 @@ export function validateStep(
     if (draft.slotIds.length === 0) {
       return invalid("Sélectionnez au moins un créneau.", '[data-field="slotIds"]');
     }
+    if (!options.allowClosedSlots) {
+      const closedSlotIds = getClosedEnabledSlotIds(config);
+      if (draft.slotIds.some((id) => closedSlotIds.has(id))) {
+        return invalid(
+          "Les inscriptions sont fermées sur un créneau sélectionné.",
+          '[data-field="slotIds"]'
+        );
+      }
+    }
     if (draft.wantsCompetitorExtras && !draft.competitionJerseySize) {
       return invalid(
         "Indiquez une taille de maillot pour la section compétiteur.",
@@ -341,8 +356,9 @@ export function validateStep(
 export function validateStepById(
   stepId: RegistrationStepId,
   draft: RegistrationDraft,
-  config: RegistrationConfigV1 = getDefaultRegistrationConfig()
+  config: RegistrationConfigV1 = getDefaultRegistrationConfig(),
+  options: StepValidationOptions = {}
 ): string | null {
-  const result = validateStep(stepId, draft, config);
+  const result = validateStep(stepId, draft, config, options);
   return result.valid ? null : result.message;
 }

--- a/src/components/club-registration/useRegistrationWizardSubmit.ts
+++ b/src/components/club-registration/useRegistrationWizardSubmit.ts
@@ -25,6 +25,7 @@ export function useRegistrationWizardSubmit(params: {
   sequence: RegistrationStepId[];
   storage: DraftStorage;
   accountEmail: string | null;
+  allowClosedSlots?: boolean;
   buildPayload: () => ClubRegistrationPayload | null;
   setActiveStep: (step: number | ((prev: number) => number)) => void;
   stepErrorAlertRef: RefObject<HTMLDivElement | null>;
@@ -35,6 +36,7 @@ export function useRegistrationWizardSubmit(params: {
     sequence,
     storage,
     accountEmail,
+    allowClosedSlots = false,
     buildPayload,
     setActiveStep,
     stepErrorAlertRef,
@@ -103,7 +105,7 @@ export function useRegistrationWizardSubmit(params: {
     });
     for (let i = 0; i < sequence.length - 1; i++) {
       const stepId = sequence[i];
-      const result = validateStep(stepId, draft, config);
+      const result = validateStep(stepId, draft, config, { allowClosedSlots });
       if (!result.valid) {
         logRegistrationWizardDebug("handleSubmit: validateStep échoué", {
           stepIndex: i,
@@ -135,7 +137,7 @@ export function useRegistrationWizardSubmit(params: {
       setSubmitError("Certaines informations obligatoires sont manquantes.");
       return;
     }
-    const parsed = buildRegistrationPayloadSchema(config).safeParse(payload);
+    const parsed = buildRegistrationPayloadSchema(config, { allowClosedSlots }).safeParse(payload);
     if (!parsed.success) {
       const flat = parsed.error.flatten().fieldErrors as Record<
         string,
@@ -169,6 +171,7 @@ export function useRegistrationWizardSubmit(params: {
     await performSubmit(payload, attemptId);
   }, [
     accountEmail,
+    allowClosedSlots,
     buildPayload,
     config,
     draft,

--- a/src/components/club-slot-occupancy/SlotEnrollmentsToggle.tsx
+++ b/src/components/club-slot-occupancy/SlotEnrollmentsToggle.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@mui/material";
+import { SlotEnrollmentsConfirmDialog } from "@/components/club-registration-config/SlotEnrollmentsConfirmDialog";
+
+type Props = {
+  closed: boolean;
+  busy: boolean;
+  slotLabel?: string | undefined;
+  onToggle: () => void | Promise<void>;
+};
+
+export function SlotEnrollmentsToggle({ closed, busy, slotLabel, onToggle }: Props) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [intentClosing, setIntentClosing] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const submitting = busy || pending;
+  const label = closed ? "Réouvrir les adhésions" : "Fermer les adhésions";
+
+  return (
+    <>
+      <Button
+        variant={closed ? "contained" : "outlined"}
+        color={closed ? "warning" : "primary"}
+        size="small"
+        disabled={submitting}
+        onClick={(event) => {
+          event.stopPropagation();
+          setIntentClosing(!closed);
+          setError(null);
+          setConfirmOpen(true);
+        }}
+        aria-label={label}
+      >
+        {label}
+      </Button>
+      <SlotEnrollmentsConfirmDialog
+        open={confirmOpen}
+        closing={intentClosing}
+        busy={submitting}
+        error={error}
+        slotLabel={slotLabel}
+        onCancel={() => {
+          if (!submitting) setConfirmOpen(false);
+        }}
+        onConfirm={() => {
+          if (submitting) return;
+          void (async () => {
+            setPending(true);
+            setError(null);
+            try {
+              await onToggle();
+              setConfirmOpen(false);
+            } catch (err) {
+              setError(err instanceof Error ? err.message : "Impossible de mettre à jour les adhésions");
+            } finally {
+              setPending(false);
+            }
+          })();
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/club-slot-occupancy/SlotFillStatusChip.tsx
+++ b/src/components/club-slot-occupancy/SlotFillStatusChip.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Chip, Tooltip } from "@mui/material";
+import type { SlotFillStatus } from "@/lib/club-slot-occupancy/types";
+import { SLOT_FILL_STATUS_HELP, SLOT_FILL_STATUS_LABELS } from "@/lib/club-slot-occupancy/types";
+
+type ChipColor = "success" | "info" | "warning" | "error" | "default";
+
+function fillColor(status: SlotFillStatus): ChipColor {
+  if (status === "over") return "error";
+  if (status === "full") return "warning";
+  if (status === "near") return "info";
+  if (status === "ok") return "success";
+  return "default";
+}
+
+type Props = {
+  status: SlotFillStatus;
+  label?: string;
+};
+
+export function SlotFillStatusChip({ status, label }: Props) {
+  const text = label ?? SLOT_FILL_STATUS_LABELS[status];
+  const help = SLOT_FILL_STATUS_HELP[status];
+  return (
+    <Tooltip title={help} enterDelay={300}>
+      <Chip
+        size="small"
+        color={fillColor(status)}
+        label={text}
+        aria-label={`${text}. ${help}`}
+      />
+    </Tooltip>
+  );
+}

--- a/src/components/club-slot-occupancy/SlotOccupancyClient.tsx
+++ b/src/components/club-slot-occupancy/SlotOccupancyClient.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Alert, Box, CircularProgress, Container, Stack, Typography } from "@mui/material";
+import { PageHeader } from "@/components/ui";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import {
+  defaultExpandedSiteIds,
+  filterOccupancyGroups,
+  patchOccupancyEnrollmentsClosed,
+  type OccupancyStatusFilter,
+} from "@/lib/club-slot-occupancy/filter-groups";
+import type { SlotOccupancySummary } from "@/lib/club-slot-occupancy/types";
+import { SlotOccupancyEnrolledDrawer } from "./SlotOccupancyEnrolledDrawer";
+import { SlotOccupancyFilters } from "./SlotOccupancyFilters";
+import { SlotOccupancySiteGroupCard } from "./SlotOccupancySiteGroupCard";
+import { useSlotOccupancy } from "./useSlotOccupancy";
+
+export function SlotOccupancyClient() {
+  const { groups, setGroups, seasonLabel, canManageEnrollments, loading, error } =
+    useSlotOccupancy();
+  const [selected, setSelected] = useState<SlotOccupancySummary | null>(null);
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<OccupancyStatusFilter>("all");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+  const [busySlotId, setBusySlotId] = useState<string | null>(null);
+  const didInitExpand = useRef(false);
+
+  const visibleGroups = useMemo(
+    () => filterOccupancyGroups(groups, { status, query }),
+    [groups, status, query]
+  );
+
+  useEffect(() => {
+    if (groups.length === 0 || didInitExpand.current) {
+      return;
+    }
+    setExpandedIds(defaultExpandedSiteIds(groups));
+    didInitExpand.current = true;
+  }, [groups]);
+
+  useEffect(() => {
+    if (!didInitExpand.current) {
+      return;
+    }
+    const filtering = status !== "all" || query.trim().length > 0;
+    if (!filtering) {
+      return;
+    }
+    setExpandedIds(new Set(visibleGroups.map((group) => group.siteId)));
+  }, [status, query, visibleGroups]);
+
+  const applyEnrollmentsClosed = useCallback((slotId: string, closed: boolean) => {
+    setGroups((prev) => patchOccupancyEnrollmentsClosed(prev, slotId, closed));
+    setSelected((prev) => (prev && prev.slotId === slotId ? { ...prev, enrollmentsClosed: closed } : prev));
+  }, [setGroups]);
+
+  const onToggleEnrollments = useCallback(
+    async (slot: SlotOccupancySummary) => {
+      const nextClosed = !slot.enrollmentsClosed;
+      setBusySlotId(slot.slotId);
+      try {
+        const res = await fetch(
+          `/api/club/slots/occupancy/${encodeURIComponent(slot.slotId)}/enrollments-closed`,
+          {
+            method: "PATCH",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ closed: nextClosed }),
+          }
+        );
+        const json = await readJsonResponse<{ error?: string }>(res);
+        if (!res.ok) {
+          throw new Error(json.error ?? "Impossible de mettre à jour les adhésions");
+        }
+        applyEnrollmentsClosed(slot.slotId, nextClosed);
+      } catch (err) {
+        throw err instanceof Error ? err : new Error("Impossible de mettre à jour les adhésions");
+      } finally {
+        setBusySlotId(null);
+      }
+    },
+    [applyEnrollmentsClosed]
+  );
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 2, md: 3 } }}>
+      <PageHeader
+        eyebrow="Créneaux"
+        title="Remplissage des créneaux"
+        subtitle={
+          seasonLabel
+            ? `Effectifs ${seasonLabel} : taux de remplissage et liste des inscrits.`
+            : "Taux de remplissage et liste des inscrits."
+        }
+        marginBottom={3}
+      />
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Alert severity="error">{error}</Alert>
+      ) : (
+        <Stack spacing={2}>
+          <SlotOccupancyFilters
+            query={query}
+            onQueryChange={setQuery}
+            status={status}
+            onStatusChange={setStatus}
+          />
+          {visibleGroups.length === 0 ? (
+            <Typography color="text.secondary">Aucun créneau ne correspond aux filtres.</Typography>
+          ) : (
+            <Stack spacing={1.5}>
+              {visibleGroups.map((group) => (
+                <SlotOccupancySiteGroupCard
+                  key={group.siteId}
+                  group={group}
+                  expanded={expandedIds.has(group.siteId)}
+                  onExpandedChange={(expanded) => {
+                    setExpandedIds((prev) => {
+                      const next = new Set(prev);
+                      if (expanded) next.add(group.siteId);
+                      else next.delete(group.siteId);
+                      return next;
+                    });
+                  }}
+                  onOpenSlot={setSelected}
+                  canManageEnrollments={canManageEnrollments}
+                  busySlotId={busySlotId}
+                  onToggleEnrollments={onToggleEnrollments}
+                />
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      )}
+      <SlotOccupancyEnrolledDrawer
+        slot={selected}
+        onClose={() => setSelected(null)}
+        canManageEnrollments={canManageEnrollments}
+        enrollmentsBusy={selected != null && busySlotId === selected.slotId}
+        onToggleEnrollments={onToggleEnrollments}
+      />
+    </Container>
+  );
+}

--- a/src/components/club-slot-occupancy/SlotOccupancyEnrolledDrawer.tsx
+++ b/src/components/club-slot-occupancy/SlotOccupancyEnrolledDrawer.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Drawer,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Close } from "@mui/icons-material";
+import { AttendanceAlertChips } from "@/components/attendance/AttendanceAlertChips";
+import { SLOT_ENROLLMENTS_CLOSED_LABEL } from "@/lib/club-registration-config/slot-enrollments";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import type {
+  SlotOccupancyEnrolledPerson,
+  SlotOccupancySummary,
+} from "@/lib/club-slot-occupancy/types";
+import { SlotEnrollmentsToggle } from "./SlotEnrollmentsToggle";
+
+type Props = {
+  slot: SlotOccupancySummary | null;
+  onClose: () => void;
+  canManageEnrollments: boolean;
+  enrollmentsBusy: boolean;
+  onToggleEnrollments: (slot: SlotOccupancySummary) => void | Promise<void>;
+};
+
+type DetailPayload = {
+  enrolled?: SlotOccupancyEnrolledPerson[];
+  error?: string;
+};
+
+export function SlotOccupancyEnrolledDrawer({
+  slot,
+  onClose,
+  canManageEnrollments,
+  enrollmentsBusy,
+  onToggleEnrollments,
+}: Props) {
+  const [enrolled, setEnrolled] = useState<SlotOccupancyEnrolledPerson[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    if (!slot) {
+      setEnrolled([]);
+      setError(null);
+      setFilter("");
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/club/slots/occupancy/${encodeURIComponent(slot.slotId)}`);
+        const json = await readJsonResponse<DetailPayload>(res);
+        if (!res.ok || !json.enrolled) {
+          throw new Error(json.error ?? "Impossible de charger les inscrits");
+        }
+        if (!cancelled) setEnrolled(json.enrolled);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Erreur");
+          setEnrolled([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [slot]);
+
+  const needle = filter.trim().toLowerCase();
+  const visible = needle
+    ? enrolled.filter((person) => person.displayName.toLowerCase().includes(needle))
+    : enrolled;
+
+  return (
+    <Drawer
+      anchor="right"
+      open={slot != null}
+      onClose={onClose}
+      PaperProps={{ sx: { width: { xs: "100%", sm: 420 } } }}
+    >
+      {slot ? (
+        <Stack spacing={2} sx={{ p: 2.5, height: "100%" }}>
+          <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1}>
+            <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+              <Typography variant="h6" component="h2">
+                {slot.label}
+              </Typography>
+              {slot.scheduleLabel ? (
+                <Typography variant="body2" color="text.secondary">
+                  {slot.scheduleLabel}
+                </Typography>
+              ) : null}
+              <Typography variant="body2" color="text.secondary">
+                {slot.capacity != null
+                  ? `${slot.enrolledCount} / ${slot.capacity} inscrits`
+                  : `${slot.enrolledCount} inscrit${slot.enrolledCount > 1 ? "s" : ""}`}
+              </Typography>
+              {slot.enrollmentsClosed ? (
+                <Chip
+                  size="small"
+                  color="warning"
+                  label={SLOT_ENROLLMENTS_CLOSED_LABEL}
+                  sx={{ alignSelf: "flex-start", mt: 0.5 }}
+                />
+              ) : null}
+              {canManageEnrollments ? (
+                <Box sx={{ pt: 0.5 }}>
+                  <SlotEnrollmentsToggle
+                    closed={slot.enrollmentsClosed}
+                    busy={enrollmentsBusy}
+                    slotLabel={slot.label}
+                    onToggle={() => onToggleEnrollments(slot)}
+                  />
+                </Box>
+              ) : null}
+            </Stack>
+            <IconButton aria-label="Fermer la liste des inscrits" onClick={onClose}>
+              <Close />
+            </IconButton>
+          </Stack>
+          <TextField
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filtrer la liste…"
+            size="small"
+            fullWidth
+            inputProps={{ "aria-label": "Filtrer les inscrits" }}
+          />
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+              <CircularProgress />
+            </Box>
+          ) : error ? (
+            <Typography color="error">{error}</Typography>
+          ) : visible.length === 0 ? (
+            <Typography color="text.secondary">Aucun inscrit sur ce créneau.</Typography>
+          ) : (
+            <Stack spacing={1.25} sx={{ overflow: "auto", pb: 2 }}>
+              {visible.map((person) => (
+                <Box
+                  key={person.personKey}
+                  sx={{
+                    border: 1,
+                    borderColor: "divider",
+                    borderRadius: 2,
+                    p: 1.5,
+                  }}
+                >
+                  <Typography variant="subtitle1" component="p" sx={{ fontWeight: 600 }}>
+                    {person.displayName}
+                    {person.age != null ? (
+                      <Typography
+                        component="span"
+                        color="text.secondary"
+                        sx={{ ml: 1, fontSize: "0.9rem", fontWeight: 400 }}
+                      >
+                        {person.age} ans
+                      </Typography>
+                    ) : null}
+                  </Typography>
+                  <AttendanceAlertChips alerts={person.alerts} />
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      ) : null}
+    </Drawer>
+  );
+}

--- a/src/components/club-slot-occupancy/SlotOccupancyFilters.tsx
+++ b/src/components/club-slot-occupancy/SlotOccupancyFilters.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Chip, Stack, TextField, Tooltip } from "@mui/material";
+import { FilterCard } from "@/components/ui";
+import {
+  OCCUPANCY_STATUS_FILTER_OPTIONS,
+  type OccupancyStatusFilter,
+} from "@/lib/club-slot-occupancy/filter-groups";
+
+type Props = {
+  query: string;
+  onQueryChange: (value: string) => void;
+  status: OccupancyStatusFilter;
+  onStatusChange: (value: OccupancyStatusFilter) => void;
+};
+
+export function SlotOccupancyFilters({
+  query,
+  onQueryChange,
+  status,
+  onStatusChange,
+}: Props) {
+  return (
+    <FilterCard marginBottom={0}>
+      <Stack spacing={1.5}>
+        <TextField
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Lieu, jour ou créneau…"
+          size="small"
+          fullWidth
+          inputProps={{ "aria-label": "Filtrer les créneaux" }}
+        />
+        <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+          {OCCUPANCY_STATUS_FILTER_OPTIONS.map((option) => {
+            const selected = status === option.value;
+            return (
+              <Tooltip key={option.value} title={option.help} enterDelay={300}>
+                <Chip
+                  label={option.label}
+                  size="small"
+                  clickable
+                  color={selected ? "primary" : "default"}
+                  variant={selected ? "filled" : "outlined"}
+                  onClick={() => onStatusChange(option.value)}
+                  aria-pressed={selected}
+                  aria-label={`${option.label}. ${option.help}`}
+                />
+              </Tooltip>
+            );
+          })}
+        </Stack>
+      </Stack>
+    </FilterCard>
+  );
+}

--- a/src/components/club-slot-occupancy/SlotOccupancyRow.tsx
+++ b/src/components/club-slot-occupancy/SlotOccupancyRow.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Box, Chip, LinearProgress, Stack, Typography } from "@mui/material";
+import type { SlotFillStatus, SlotOccupancySummary } from "@/lib/club-slot-occupancy/types";
+import { SLOT_FILL_STATUS_HELP, SLOT_FILL_STATUS_LABELS } from "@/lib/club-slot-occupancy/types";
+import { slotFillPercent } from "@/lib/club-slot-occupancy/fill-rate";
+import { SLOT_ENROLLMENTS_CLOSED_LABEL } from "@/lib/club-registration-config/slot-enrollments";
+import { SlotEnrollmentsToggle } from "./SlotEnrollmentsToggle";
+import { SlotFillStatusChip } from "./SlotFillStatusChip";
+
+type Props = {
+  slot: SlotOccupancySummary;
+  onOpen: (slot: SlotOccupancySummary) => void;
+  canManageEnrollments: boolean;
+  enrollmentsBusy: boolean;
+  onToggleEnrollments: (slot: SlotOccupancySummary) => void | Promise<void>;
+};
+
+function fillColor(status: SlotFillStatus): "success" | "info" | "warning" | "error" | "default" {
+  if (status === "over") return "error";
+  if (status === "full") return "warning";
+  if (status === "near") return "info";
+  if (status === "ok") return "success";
+  return "default";
+}
+
+function countLabel(slot: SlotOccupancySummary): string {
+  if (slot.capacity == null) {
+    return `${slot.enrolledCount} inscrit${slot.enrolledCount > 1 ? "s" : ""}`;
+  }
+  return `${slot.enrolledCount} / ${slot.capacity}`;
+}
+
+export function SlotOccupancyRow({
+  slot,
+  onOpen,
+  canManageEnrollments,
+  enrollmentsBusy,
+  onToggleEnrollments,
+}: Props) {
+  const percent = slotFillPercent(slot.rate);
+  const color = fillColor(slot.status);
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: slot.status === "over" ? "error.main" : slot.enrollmentsClosed ? "warning.main" : "divider",
+        bgcolor: "background.paper",
+        borderRadius: 2,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        component="button"
+        type="button"
+        onClick={() => onOpen(slot)}
+        aria-label={`${slot.label}. ${countLabel(slot)}. ${SLOT_FILL_STATUS_LABELS[slot.status]}. ${SLOT_FILL_STATUS_HELP[slot.status]}. ${slot.enrollmentsClosed ? `${SLOT_ENROLLMENTS_CLOSED_LABEL}. ` : ""}Voir les inscrits`}
+        sx={{
+          display: "block",
+          width: "100%",
+          textAlign: "left",
+          border: 0,
+          bgcolor: "transparent",
+          p: 1.5,
+          cursor: "pointer",
+          "&:hover": { bgcolor: "action.hover" },
+          "&:focus-visible": { outline: 2, outlineColor: "primary.main", outlineOffset: -2 },
+        }}
+      >
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="flex-start" justifyContent="space-between">
+            <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+              <Typography variant="subtitle1" component="p" sx={{ fontWeight: 600, lineHeight: 1.25 }}>
+                {slot.label}
+              </Typography>
+              {slot.scheduleLabel ? (
+                <Typography variant="body2" color="text.secondary">
+                  {slot.scheduleLabel}
+                </Typography>
+              ) : null}
+            </Stack>
+            <Stack direction="row" spacing={0.75} flexWrap="wrap" justifyContent="flex-end">
+              {!slot.enabled ? <Chip size="small" label="Inactif" /> : null}
+              {slot.enrollmentsClosed ? (
+                <Chip size="small" color="warning" label={SLOT_ENROLLMENTS_CLOSED_LABEL} />
+              ) : null}
+              <SlotFillStatusChip status={slot.status} />
+            </Stack>
+          </Stack>
+          <Stack direction="row" spacing={1.5} alignItems="center">
+            <Typography variant="body2" sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+              {countLabel(slot)}
+            </Typography>
+            {percent != null ? (
+              <LinearProgress
+                variant="determinate"
+                value={percent}
+                color={color === "default" ? "primary" : color}
+                sx={{ flex: 1, height: 8, borderRadius: 1 }}
+                aria-label={`Remplissage ${percent} pour cent`}
+              />
+            ) : (
+              <Box sx={{ flex: 1 }} />
+            )}
+          </Stack>
+        </Stack>
+      </Box>
+      {canManageEnrollments ? (
+        <Box sx={{ px: 1.5, pb: 1.5 }}>
+          <SlotEnrollmentsToggle
+            closed={slot.enrollmentsClosed}
+            busy={enrollmentsBusy}
+            slotLabel={slot.label}
+            onToggle={() => onToggleEnrollments(slot)}
+          />
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/club-slot-occupancy/SlotOccupancySiteGroupCard.tsx
+++ b/src/components/club-slot-occupancy/SlotOccupancySiteGroupCard.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Chip,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { occupancyGroupStats } from "@/lib/club-slot-occupancy/filter-groups";
+import type { SlotOccupancySiteGroup, SlotOccupancySummary } from "@/lib/club-slot-occupancy/types";
+import { SlotFillStatusChip } from "./SlotFillStatusChip";
+import { SlotOccupancyRow } from "./SlotOccupancyRow";
+
+type Props = {
+  group: SlotOccupancySiteGroup;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  onOpenSlot: (slot: SlotOccupancySummary) => void;
+  canManageEnrollments: boolean;
+  busySlotId: string | null;
+  onToggleEnrollments: (slot: SlotOccupancySummary) => void | Promise<void>;
+};
+
+function creneauxLabel(count: number): string {
+  return `${count} créneau${count > 1 ? "x" : ""}`;
+}
+
+export function SlotOccupancySiteGroupCard({
+  group,
+  expanded,
+  onExpandedChange,
+  onOpenSlot,
+  canManageEnrollments,
+  busySlotId,
+  onToggleEnrollments,
+}: Props) {
+  const stats = occupancyGroupStats(group);
+  const summaryId = `occupancy-site-${group.siteId}`;
+
+  return (
+    <Accordion
+      disableGutters
+      expanded={expanded}
+      onChange={(_, next) => onExpandedChange(next)}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls={`${summaryId}-content`}
+        id={summaryId}
+      >
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          justifyContent="space-between"
+          sx={{ width: "100%", pr: 1 }}
+        >
+          <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+            <Typography fontWeight={600}>{group.siteLabel}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {[group.gymnasiumName, creneauxLabel(stats.total)].filter(Boolean).join(" · ")}
+            </Typography>
+          </Stack>
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" justifyContent="flex-end">
+            {stats.enrollmentsClosed > 0 ? (
+              <Chip
+                size="small"
+                color="warning"
+                label={`${stats.enrollmentsClosed} fermé${stats.enrollmentsClosed > 1 ? "s" : ""}`}
+              />
+            ) : null}
+            {stats.over > 0 ? (
+              <SlotFillStatusChip
+                status="over"
+                label={`${stats.over} surcharge${stats.over > 1 ? "s" : ""}`}
+              />
+            ) : null}
+            {stats.full > 0 ? (
+              <SlotFillStatusChip
+                status="full"
+                label={`${stats.full} complet${stats.full > 1 ? "s" : ""}`}
+              />
+            ) : null}
+            {stats.near > 0 ? (
+              <SlotFillStatusChip
+                status="near"
+                label={`${stats.near} presque complet${stats.near > 1 ? "s" : ""}`}
+              />
+            ) : null}
+          </Stack>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>
+        {group.slots.length === 0 ? (
+          <Typography color="text.secondary">Aucun créneau sur ce lieu.</Typography>
+        ) : (
+          <Stack spacing={1.25}>
+            {group.slots.map((slot) => (
+              <SlotOccupancyRow
+                key={slot.slotId}
+                slot={slot}
+                onOpen={onOpenSlot}
+                canManageEnrollments={canManageEnrollments}
+                enrollmentsBusy={busySlotId === slot.slotId}
+                onToggleEnrollments={onToggleEnrollments}
+              />
+            ))}
+          </Stack>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/src/components/club-slot-occupancy/useSlotOccupancy.ts
+++ b/src/components/club-slot-occupancy/useSlotOccupancy.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { readJsonResponse } from "@/lib/http/read-json-response";
+import type { SlotOccupancySiteGroup } from "@/lib/club-slot-occupancy/types";
+
+type OccupancyPayload = {
+  seasonLabel?: string;
+  groups?: SlotOccupancySiteGroup[];
+  canManageEnrollments?: boolean;
+  error?: string;
+};
+
+export function useSlotOccupancy() {
+  const [groups, setGroups] = useState<SlotOccupancySiteGroup[]>([]);
+  const [seasonLabel, setSeasonLabel] = useState<string | null>(null);
+  const [canManageEnrollments, setCanManageEnrollments] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/club/slots/occupancy");
+      const json = await readJsonResponse<OccupancyPayload>(res);
+      if (!res.ok || !json.groups) {
+        throw new Error(json.error ?? "Impossible de charger le remplissage");
+      }
+      setGroups(json.groups);
+      setSeasonLabel(json.seasonLabel ?? null);
+      setCanManageEnrollments(json.canManageEnrollments === true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur");
+      setGroups([]);
+      setCanManageEnrollments(false);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { groups, setGroups, seasonLabel, canManageEnrollments, loading, error, reload: load };
+}

--- a/src/components/layout-navigation.test.ts
+++ b/src/components/layout-navigation.test.ts
@@ -57,6 +57,7 @@ describe("buildLayoutNavigation", () => {
       "/club/mes-inscriptions",
       "/club/adhesions-tableau",
       "/club/presences",
+      "/club/creneaux",
       "/club/presences/essais",
     ]);
   });
@@ -83,6 +84,7 @@ describe("buildLayoutNavigation", () => {
       "/",
       "/club/demandes-adhesion",
       "/club/presences",
+      "/club/creneaux",
       "/club/idees",
     ]);
     expect(nav.groups).toHaveLength(1);
@@ -102,6 +104,7 @@ describe("buildLayoutNavigation", () => {
     expect(nav.primary.map((item) => item.href)).toEqual([
       "/",
       "/club/presences",
+      "/club/creneaux",
       "/compositions",
       "/disponibilites",
       "/club/adhesions-tableau",
@@ -137,6 +140,7 @@ describe("buildLayoutNavigation", () => {
     expect(nav.groups[1]?.items.map((item) => item.href)).toEqual([
       "/club/adhesions-tableau",
       "/club/presences",
+      "/club/creneaux",
       "/club/presences/essais",
       "/club/parametrage-inscription",
       "/club/inscription",

--- a/src/components/layout-navigation.tsx
+++ b/src/components/layout-navigation.tsx
@@ -18,6 +18,7 @@ import {
   TipsAndUpdates,
   Tune,
   VerifiedUser,
+  ViewWeek,
 } from "@mui/icons-material";
 
 export interface LayoutNavigationItem {
@@ -109,6 +110,11 @@ const NAV = {
     href: "/club/presences",
     icon: <EventAvailable />,
   },
+  creneaux: {
+    label: "Créneaux",
+    href: "/club/creneaux",
+    icon: <ViewWeek />,
+  },
   presencesEssais: {
     label: "Essais présence",
     href: "/club/presences/essais",
@@ -179,7 +185,7 @@ export function buildLayoutNavigation(
       primary.push(NAV.tableauAdhesions);
     }
     if (isBoardMember) {
-      primary.push(NAV.presences, NAV.presencesEssais);
+      primary.push(NAV.presences, NAV.creneaux, NAV.presencesEssais);
     }
     if (isAssistantSecretary) {
       primary.push(NAV.validationsLicence);
@@ -193,6 +199,7 @@ export function buildLayoutNavigation(
         NAV.accueilStaff,
         NAV.dossiersAValider,
         NAV.presences,
+        NAV.creneaux,
         NAV.boiteIdees,
       ],
       groups: [
@@ -237,6 +244,7 @@ export function buildLayoutNavigation(
           items: [
             NAV.tableauAdhesions,
             NAV.presences,
+            NAV.creneaux,
             NAV.presencesEssais,
             NAV.campagnesTarifs,
             NAV.apercuFormulaire,
@@ -251,6 +259,7 @@ export function buildLayoutNavigation(
     primary: [
       NAV.accueilStaff,
       NAV.presences,
+      NAV.creneaux,
       NAV.compositions,
       NAV.disponibilites,
       NAV.tableauAdhesions,

--- a/src/lib/attendance/attendance.test.ts
+++ b/src/lib/attendance/attendance.test.ts
@@ -82,6 +82,7 @@ describe("attendance roster", () => {
         startMinutes: 19 * 60,
         endMinutes: 20 * 60 + 45,
         highlighted: true,
+        enrollmentsClosed: false,
       },
       registrations: [
         {

--- a/src/lib/attendance/slots-for-date.ts
+++ b/src/lib/attendance/slots-for-date.ts
@@ -57,6 +57,7 @@ function toSlotOption(
     weekday: schedule.weekday,
     startMinutes: schedule.startMinutes,
     endMinutes: schedule.endMinutes,
+    enrollmentsClosed: slot.enrollmentsClosed === true,
   };
 }
 
@@ -104,6 +105,7 @@ export function findSlotOption(
         startMinutes: 0,
         endMinutes: 0,
         highlighted: false,
+        enrollmentsClosed: slot.enrollmentsClosed === true,
       };
     }
     return { ...option, highlighted: false };

--- a/src/lib/attendance/types.ts
+++ b/src/lib/attendance/types.ts
@@ -40,6 +40,7 @@ export type AttendanceSlotOption = {
   startMinutes: number;
   endMinutes: number;
   highlighted: boolean;
+  enrollmentsClosed: boolean;
 };
 
 export type AttendanceRosterPerson = {

--- a/src/lib/auth/audit-logger.ts
+++ b/src/lib/auth/audit-logger.ts
@@ -92,6 +92,7 @@ export const AUDIT_ACTIONS = {
   CLUB_REGISTRATION_DELETED: "club.registration.deleted",
   CLUB_REGISTRATION_CONFIG_PUBLISHED: "club.registration.config_published",
   CLUB_REGISTRATION_CONFIG_IMPORTED: "club.registration.config_imported",
+  CLUB_REGISTRATION_SLOT_ENROLLMENTS_TOGGLED: "club.registration.slot_enrollments_toggled",
   TEAM_CREATED: "team.created",
   TEAM_UPDATED: "team.updated",
   TEAM_DELETED: "team.deleted",

--- a/src/lib/club-registration-config/export-import.test.ts
+++ b/src/lib/club-registration-config/export-import.test.ts
@@ -1,6 +1,7 @@
 import { buildDefaultRegistrationConfig } from "./default-config";
 import { normalizeRegistrationConfigSortOrders } from "./normalize-sort-orders";
 import { registrationConfigV1Schema } from "./schema";
+import { applySlotEnrollmentsClosed } from "./slot-enrollments";
 import { validateRegistrationConfigCrossRefs } from "./validate-config";
 import {
   buildConfigExport,
@@ -26,6 +27,67 @@ describe("registration config schema", () => {
       expect(parsed.data.sites[0]?.gymnasiumName).toBeUndefined();
       const normalized = normalizeRegistrationConfigSortOrders(parsed.data);
       expect(normalized.sites[0]).not.toHaveProperty("gymnasiumName");
+    }
+  });
+
+  it("accepte une capacité entière >= 1 sur un créneau", () => {
+    const config = buildDefaultRegistrationConfig();
+    const sites = config.sites.map((site, index) =>
+      index === 0
+        ? {
+            ...site,
+            slots: site.slots.map((slot, slotIndex) =>
+              slotIndex === 0 ? { ...slot, capacity: 24 } : slot
+            ),
+          }
+        : site
+    );
+    const parsed = registrationConfigV1Schema.safeParse({ ...config, sites });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.sites[0]?.slots[0]?.capacity).toBe(24);
+    }
+  });
+
+  it("rejette une capacité nulle, décimale ou trop grande", () => {
+    const config = buildDefaultRegistrationConfig();
+    const withCapacity = (capacity: number) => {
+      const sites = config.sites.map((site, index) =>
+        index === 0
+          ? {
+              ...site,
+              slots: site.slots.map((slot, slotIndex) =>
+                slotIndex === 0 ? { ...slot, capacity } : slot
+              ),
+            }
+          : site
+      );
+      return registrationConfigV1Schema.safeParse({ ...config, sites });
+    };
+    expect(withCapacity(0).success).toBe(false);
+    expect(withCapacity(1.5).success).toBe(false);
+    expect(withCapacity(501).success).toBe(false);
+  });
+
+  it("accepte et normalise la fermeture des adhésions d'un créneau", () => {
+    const config = buildDefaultRegistrationConfig();
+    const slotId = config.sites[0]?.slots[0]?.id;
+    expect(slotId).toBeTruthy();
+    if (!slotId) {
+      return;
+    }
+    const closed = applySlotEnrollmentsClosed(config, slotId, true);
+    expect(closed).not.toBeNull();
+    const parsed = registrationConfigV1Schema.safeParse(closed);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.sites[0]?.slots[0]?.enrollmentsClosed).toBe(true);
+      const reopened = applySlotEnrollmentsClosed(parsed.data, slotId, false);
+      expect(reopened).not.toBeNull();
+      if (reopened) {
+        const normalized = normalizeRegistrationConfigSortOrders(reopened);
+        expect(normalized.sites[0]?.slots[0]?.enrollmentsClosed).toBeUndefined();
+      }
     }
   });
 });

--- a/src/lib/club-registration-config/normalize-sort-orders.ts
+++ b/src/lib/club-registration-config/normalize-sort-orders.ts
@@ -29,10 +29,17 @@ export function normalizeRegistrationConfigSortOrders(
           ...slot,
           sortOrder: slot.sortOrder ?? slotIndex,
         }))
-      ).map((slot, slotIndex) => ({
-        ...slot,
-        sortOrder: slotIndex,
-      })),
+      ).map((slot, slotIndex) => {
+        const { capacity, enrollmentsClosed, ...slotRest } = slot;
+        return {
+          ...slotRest,
+          sortOrder: slotIndex,
+          ...(typeof capacity === "number" && Number.isInteger(capacity) && capacity >= 1
+            ? { capacity }
+            : {}),
+          ...(enrollmentsClosed === true ? { enrollmentsClosed: true } : {}),
+        };
+      }),
     };
     }),
   };

--- a/src/lib/club-registration-config/schema.ts
+++ b/src/lib/club-registration-config/schema.ts
@@ -41,6 +41,8 @@ const registrationSiteSlotSchema = z.object({
   weekday: z.number().int().min(1).max(7).optional(),
   startMinutes: z.number().int().min(0).max(23 * 60 + 59).optional(),
   endMinutes: z.number().int().min(1).max(23 * 60 + 59).optional(),
+  capacity: z.number().int().min(1).max(500).optional(),
+  enrollmentsClosed: z.boolean().optional(),
 });
 
 /** Chaîne optionnelle : vide ou espaces → `undefined` (champ masqué côté formulaire). */

--- a/src/lib/club-registration-config/slot-enrollments.test.ts
+++ b/src/lib/club-registration-config/slot-enrollments.test.ts
@@ -1,0 +1,34 @@
+import { USER_ROLES } from "@/lib/auth/roles";
+import { buildDefaultRegistrationConfig } from "./default-config";
+import {
+  applySlotEnrollmentsClosed,
+  canBypassSlotEnrollmentClose,
+  omitClosedSlotsFromSelection,
+} from "./slot-enrollments";
+
+describe("slot enrollments close", () => {
+  it("autorise admin, secrétaire, coach et bureau, pas le secrétaire adjoint", () => {
+    expect(canBypassSlotEnrollmentClose(USER_ROLES.ADMIN)).toBe(true);
+    expect(canBypassSlotEnrollmentClose(USER_ROLES.SECRETARY)).toBe(true);
+    expect(canBypassSlotEnrollmentClose(USER_ROLES.COACH)).toBe(true);
+    expect(canBypassSlotEnrollmentClose(USER_ROLES.BOARD_MEMBER)).toBe(true);
+    expect(canBypassSlotEnrollmentClose(USER_ROLES.ASSISTANT_SECRETARY)).toBe(false);
+    expect(canBypassSlotEnrollmentClose(USER_ROLES.PLAYER)).toBe(false);
+    expect(canBypassSlotEnrollmentClose(null)).toBe(false);
+  });
+
+  it("retire les créneaux fermés d'une sélection famille", () => {
+    const config = buildDefaultRegistrationConfig();
+    const slotId = config.sites[0]?.slots[0]?.id;
+    expect(slotId).toBeTruthy();
+    if (!slotId) {
+      return;
+    }
+    const closed = applySlotEnrollmentsClosed(config, slotId, true);
+    expect(closed).not.toBeNull();
+    if (!closed) {
+      return;
+    }
+    expect(omitClosedSlotsFromSelection(closed, [slotId, "other"])).toEqual(["other"]);
+  });
+});

--- a/src/lib/club-registration-config/slot-enrollments.ts
+++ b/src/lib/club-registration-config/slot-enrollments.ts
@@ -1,0 +1,73 @@
+import { hasAnyRole, USER_ROLES, type UserRole } from "@/lib/auth/roles";
+import { getEnabledSlots } from "./helpers";
+import type { RegistrationConfigV1, RegistrationSiteSlot } from "./types";
+
+export const SLOT_ENROLLMENTS_CLOSED_LABEL = "Inscriptions fermées";
+
+export const SLOT_ENROLLMENT_CLOSE_BYPASS_ROLES = [
+  USER_ROLES.ADMIN,
+  USER_ROLES.SECRETARY,
+  USER_ROLES.COACH,
+  USER_ROLES.BOARD_MEMBER,
+] as const;
+
+export function canBypassSlotEnrollmentClose(role: UserRole | null | undefined): boolean {
+  return role != null && hasAnyRole(role, SLOT_ENROLLMENT_CLOSE_BYPASS_ROLES);
+}
+
+export function isSlotEnrollmentsClosed(
+  slot: Pick<RegistrationSiteSlot, "enrollmentsClosed">
+): boolean {
+  return slot.enrollmentsClosed === true;
+}
+
+export function getClosedEnabledSlotIds(config: RegistrationConfigV1): ReadonlySet<string> {
+  return new Set(
+    getEnabledSlots(config)
+      .filter((slot) => isSlotEnrollmentsClosed(slot))
+      .map((slot) => slot.id)
+  );
+}
+
+export function omitClosedSlotsFromSelection(
+  config: RegistrationConfigV1,
+  slotIds: readonly string[]
+): string[] {
+  const closed = getClosedEnabledSlotIds(config);
+  return slotIds.filter((id) => !closed.has(id));
+}
+
+function withEnrollmentsClosed(
+  slot: RegistrationSiteSlot,
+  closed: boolean
+): RegistrationSiteSlot {
+  const next = { ...slot };
+  if (closed) {
+    next.enrollmentsClosed = true;
+  } else {
+    delete next.enrollmentsClosed;
+  }
+  return next;
+}
+
+export function applySlotEnrollmentsClosed(
+  config: RegistrationConfigV1,
+  slotId: string,
+  closed: boolean
+): RegistrationConfigV1 | null {
+  let found = false;
+  const sites = config.sites.map((site) => ({
+    ...site,
+    slots: site.slots.map((slot) => {
+      if (slot.id !== slotId) {
+        return slot;
+      }
+      found = true;
+      return withEnrollmentsClosed(slot, closed);
+    }),
+  }));
+  if (!found) {
+    return null;
+  }
+  return { ...config, sites };
+}

--- a/src/lib/club-registration-config/store.ts
+++ b/src/lib/club-registration-config/store.ts
@@ -2,6 +2,7 @@ import { getFirestoreAdmin } from "@/lib/firebase-admin";
 import { getDefaultRegistrationConfig } from "./default-config";
 import { normalizeRegistrationConfigSortOrders } from "./normalize-sort-orders";
 import { registrationConfigV1Schema } from "./schema";
+import { applySlotEnrollmentsClosed } from "./slot-enrollments";
 import type { RegistrationConfigV1 } from "./types";
 
 export const REGISTRATION_CONFIG_COLLECTION = "clubRegistrationConfig";
@@ -158,4 +159,54 @@ export async function getRegistrationConfigByCatalogVersion(
     return defaultConfig;
   }
   return active;
+}
+
+export async function patchSlotEnrollmentsClosed(
+  slotId: string,
+  closed: boolean,
+  updatedBy: string
+): Promise<"updated" | "not_found"> {
+  const activeDoc = await getRegistrationConfigDoc(REGISTRATION_CONFIG_ACTIVE_ID);
+  const draftDoc = await getRegistrationConfigDoc(REGISTRATION_CONFIG_DRAFT_ID);
+  const activeConfig = activeDoc?.config ?? getDefaultRegistrationConfig();
+  const nextActive = applySlotEnrollmentsClosed(activeConfig, slotId, closed);
+  if (!nextActive) {
+    return "not_found";
+  }
+
+  const db = getFirestoreAdmin();
+  const now = new Date().toISOString();
+  const normalizedActive = normalizeRegistrationConfigSortOrders(nextActive);
+  const activePayload: Record<string, unknown> = {
+    config: normalizedActive,
+    updatedAt: now,
+    updatedBy,
+  };
+  if (activeDoc?.publishedAt) {
+    activePayload.publishedAt = activeDoc.publishedAt;
+  }
+  if (activeDoc?.publishedBy) {
+    activePayload.publishedBy = activeDoc.publishedBy;
+  }
+
+  const batch = db.batch();
+  batch.set(
+    db.collection(REGISTRATION_CONFIG_COLLECTION).doc(REGISTRATION_CONFIG_ACTIVE_ID),
+    activePayload
+  );
+
+  const draftConfig = draftDoc?.config ?? nextActive;
+  const nextDraft = applySlotEnrollmentsClosed(draftConfig, slotId, closed) ?? draftConfig;
+  batch.set(
+    db.collection(REGISTRATION_CONFIG_COLLECTION).doc(REGISTRATION_CONFIG_DRAFT_ID),
+    {
+      config: normalizeRegistrationConfigSortOrders(nextDraft),
+      updatedAt: now,
+      updatedBy,
+    },
+    { merge: true }
+  );
+
+  await batch.commit();
+  return "updated";
 }

--- a/src/lib/club-registration-config/types.ts
+++ b/src/lib/club-registration-config/types.ts
@@ -47,6 +47,10 @@ export type RegistrationSiteSlot = {
   startMinutes?: number | undefined;
   /** Minutes depuis minuit (fin, exclusive du lendemain). */
   endMinutes?: number | undefined;
+  /** Max d'inscrits pour le taux de remplissage (informatif, n'empêche pas les inscriptions). */
+  capacity?: number | undefined;
+  /** Inscriptions fermées sur ce créneau. */
+  enrollmentsClosed?: boolean | undefined;
 };
 
 export type RegistrationSite = {

--- a/src/lib/club-registration/build-payload-schema.ts
+++ b/src/lib/club-registration/build-payload-schema.ts
@@ -6,6 +6,7 @@ import {
   getEnabledSectionIds,
   getSchoolPickupSlotIds,
 } from "@/lib/club-registration-config/helpers";
+import { getClosedEnabledSlotIds } from "@/lib/club-registration-config/slot-enrollments";
 import { getToggleAidRules } from "@/lib/club-registration-config/aid-rules";
 import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
 import { preprocessRegistrationPayloadInput } from "./reduction-reference-codes";
@@ -69,7 +70,10 @@ function asNonEmptyTuple(ids: string[]): [string, ...string[]] {
   return ids as [string, ...string[]];
 }
 
-export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
+export function buildRegistrationPayloadSchema(
+  config: RegistrationConfigV1,
+  options: { allowClosedSlots?: boolean } = {}
+) {
   const sectionIds = asNonEmptyTuple(getEnabledSectionIds(config));
   const competitionIds = asNonEmptyTuple(getEnabledCompetitionIds(config));
   const reductionIds = asNonEmptyTuple(getEnabledReductionIds(config));
@@ -145,6 +149,18 @@ export function buildRegistrationPayloadSchema(config: RegistrationConfigV1) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: "Créneau inconnu",
+            path: ["slotIds"],
+          });
+          return;
+        }
+      }
+
+      if (!options.allowClosedSlots) {
+        const closedSlotIds = getClosedEnabledSlotIds(config);
+        if (data.slotIds.some((id) => closedSlotIds.has(id))) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Les inscriptions sont fermées sur un créneau sélectionné.",
             path: ["slotIds"],
           });
           return;

--- a/src/lib/club-registration/schema.test.ts
+++ b/src/lib/club-registration/schema.test.ts
@@ -1,7 +1,9 @@
 import { APPLICANT_NOTES_MAX_LENGTH } from "./applicant-notes";
-import { clubRegistrationPayloadSchema } from "./schema";
+import { buildRegistrationPayloadSchema, clubRegistrationPayloadSchema } from "./schema";
 import { inferMedicalDossierFromDeclaration } from "./medical-dossier";
 import { isAtLeast65At, isMinorAt } from "./age";
+import { buildDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import { applySlotEnrollmentsClosed } from "@/lib/club-registration-config/slot-enrollments";
 
 /**
  * Helper qui construit un payload valide minimal pour un adulte qui s'inscrit lui-même,
@@ -372,6 +374,22 @@ describe("clubRegistrationPayloadSchema", () => {
   it("refuse un payload sans créneau", () => {
     const r = clubRegistrationPayloadSchema.safeParse(buildPayload({ slotIds: [] }));
     expect(r.success).toBe(false);
+  });
+
+  it("refuse un créneau dont les inscriptions sont fermées", () => {
+    const config = buildDefaultRegistrationConfig();
+    const slotId = "voisins-mar-2030-adultes-loisirs";
+    const closedConfig = applySlotEnrollmentsClosed(config, slotId, true);
+    expect(closedConfig).not.toBeNull();
+    if (!closedConfig) {
+      return;
+    }
+    const blocked = buildRegistrationPayloadSchema(closedConfig).safeParse(buildPayload({ slotIds: [slotId] }));
+    expect(blocked.success).toBe(false);
+    const allowed = buildRegistrationPayloadSchema(closedConfig, { allowClosedSlots: true }).safeParse(
+      buildPayload({ slotIds: [slotId] })
+    );
+    expect(allowed.success).toBe(true);
   });
 
   it("accepte schoolPickupSlotIds pour un créneau éligible sélectionné", () => {

--- a/src/lib/club-slot-occupancy/build-occupancy.ts
+++ b/src/lib/club-slot-occupancy/build-occupancy.ts
@@ -1,0 +1,99 @@
+import { mapRegistrationToRosterPerson } from "@/lib/attendance/roster";
+import type { RegistrationConfigV1 } from "@/lib/club-registration-config/types";
+import {
+  formatSlotScheduleSummary,
+  resolveSlotSchedule,
+} from "@/lib/club-registration-config/slot-schedule";
+import { sortBySortOrder } from "@/lib/club-registration-config/sort-order";
+import { computeSlotFill } from "./fill-rate";
+import type {
+  SlotOccupancyEnrolledPerson,
+  SlotOccupancySiteGroup,
+  SlotOccupancySummary,
+} from "./types";
+
+function compareOccupancySlots(a: SlotOccupancySummary, b: SlotOccupancySummary): number {
+  const weekdayA = a.weekday ?? 99;
+  const weekdayB = b.weekday ?? 99;
+  if (weekdayA !== weekdayB) {
+    return weekdayA - weekdayB;
+  }
+  const startA = a.startMinutes ?? 24 * 60;
+  const startB = b.startMinutes ?? 24 * 60;
+  if (startA !== startB) {
+    return startA - startB;
+  }
+  return a.label.localeCompare(b.label, "fr");
+}
+
+export function buildOccupancyGroups(
+  config: RegistrationConfigV1,
+  counts: Map<string, number>
+): SlotOccupancySiteGroup[] {
+  return sortBySortOrder(config.sites).map((site) => {
+    const slots: SlotOccupancySummary[] = site.slots.map((slot) => {
+      const schedule = resolveSlotSchedule(slot);
+      const fill = computeSlotFill(counts.get(slot.id) ?? 0, slot.capacity);
+      return {
+        slotId: slot.id,
+        label: slot.label,
+        siteId: site.id,
+        siteLabel: site.label,
+        gymnasiumName: site.gymnasiumName,
+        weekday: schedule?.weekday ?? null,
+        startMinutes: schedule?.startMinutes ?? null,
+        endMinutes: schedule?.endMinutes ?? null,
+        scheduleLabel: schedule ? formatSlotScheduleSummary(schedule) : null,
+        enabled: slot.enabled,
+        enrollmentsClosed: slot.enrollmentsClosed === true,
+        ...fill,
+      };
+    });
+    slots.sort(compareOccupancySlots);
+    return {
+      siteId: site.id,
+      siteLabel: site.label,
+      gymnasiumName: site.gymnasiumName,
+      slots,
+    };
+  });
+}
+
+export function findOccupancySlot(
+  groups: SlotOccupancySiteGroup[],
+  slotId: string
+): SlotOccupancySummary | null {
+  for (const group of groups) {
+    const slot = group.slots.find((item) => item.slotId === slotId);
+    if (slot) {
+      return slot;
+    }
+  }
+  return null;
+}
+
+export function mapRegistrationToOccupancyPerson(
+  id: string,
+  data: Record<string, unknown>
+): SlotOccupancyEnrolledPerson {
+  const roster = mapRegistrationToRosterPerson(id, data, false, false);
+  return {
+    personKey: roster.personKey,
+    registrationId: id,
+    firstName: roster.firstName,
+    lastName: roster.lastName,
+    displayName: roster.displayName,
+    age: roster.age,
+    alerts: roster.alerts,
+  };
+}
+
+export function sortOccupancyPeople(
+  people: SlotOccupancyEnrolledPerson[]
+): SlotOccupancyEnrolledPerson[] {
+  return [...people].sort(
+    (a, b) =>
+      a.lastName.localeCompare(b.lastName, "fr") ||
+      a.firstName.localeCompare(b.firstName, "fr")
+  );
+}

--- a/src/lib/club-slot-occupancy/count-enrollments.ts
+++ b/src/lib/club-slot-occupancy/count-enrollments.ts
@@ -1,0 +1,24 @@
+export function readSlotIds(data: Record<string, unknown>): string[] {
+  const value = data.slotIds;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+export function countEnrollmentsBySlotId(
+  registrations: Array<{ data: Record<string, unknown> }>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of registrations) {
+    const seen = new Set<string>();
+    for (const slotId of readSlotIds(item.data)) {
+      if (seen.has(slotId)) {
+        continue;
+      }
+      seen.add(slotId);
+      counts.set(slotId, (counts.get(slotId) ?? 0) + 1);
+    }
+  }
+  return counts;
+}

--- a/src/lib/club-slot-occupancy/fill-rate.ts
+++ b/src/lib/club-slot-occupancy/fill-rate.ts
@@ -1,0 +1,37 @@
+import type { SlotFillSnapshot, SlotFillStatus } from "./types";
+
+/** Seuil à partir duquel un créneau est « presque complet » (sans l'être). */
+export const NEAR_FULL_RATIO = 0.8;
+
+export function computeSlotFill(
+  enrolledCount: number,
+  capacity: number | undefined
+): SlotFillSnapshot {
+  if (capacity == null) {
+    return {
+      enrolledCount,
+      capacity: undefined,
+      rate: null,
+      status: "unset",
+    };
+  }
+
+  const rate = capacity > 0 ? enrolledCount / capacity : null;
+  let status: SlotFillStatus = "ok";
+  if (enrolledCount > capacity) {
+    status = "over";
+  } else if (enrolledCount === capacity) {
+    status = "full";
+  } else if (rate != null && rate >= NEAR_FULL_RATIO) {
+    status = "near";
+  }
+
+  return { enrolledCount, capacity, rate, status };
+}
+
+export function slotFillPercent(rate: number | null): number | null {
+  if (rate == null || !Number.isFinite(rate)) {
+    return null;
+  }
+  return Math.min(100, Math.round(rate * 100));
+}

--- a/src/lib/club-slot-occupancy/filter-groups.ts
+++ b/src/lib/club-slot-occupancy/filter-groups.ts
@@ -1,0 +1,81 @@
+import { SLOT_FILL_STATUS_HELP, type SlotFillStatus, type SlotOccupancySiteGroup } from "./types";
+
+export type OccupancyStatusFilter = "all" | SlotFillStatus;
+
+export const OCCUPANCY_STATUS_FILTER_OPTIONS: {
+  value: OccupancyStatusFilter;
+  label: string;
+  help: string;
+}[] = [
+  {
+    value: "all",
+    label: "Tous",
+    help: "Tous les créneaux, quel que soit le remplissage.",
+  },
+  { value: "over", label: "Surcharge", help: SLOT_FILL_STATUS_HELP.over },
+  { value: "full", label: "Complet", help: SLOT_FILL_STATUS_HELP.full },
+  { value: "near", label: "Presque complet", help: SLOT_FILL_STATUS_HELP.near },
+  { value: "ok", label: "Places dispo", help: SLOT_FILL_STATUS_HELP.ok },
+  { value: "unset", label: "Non paramétré", help: SLOT_FILL_STATUS_HELP.unset },
+];
+
+export type OccupancyGroupStats = {
+  total: number;
+  over: number;
+  full: number;
+  near: number;
+  enrollmentsClosed: number;
+};
+
+export function occupancyGroupStats(group: SlotOccupancySiteGroup): OccupancyGroupStats {
+  return {
+    total: group.slots.length,
+    over: group.slots.filter((slot) => slot.status === "over").length,
+    full: group.slots.filter((slot) => slot.status === "full").length,
+    near: group.slots.filter((slot) => slot.status === "near").length,
+    enrollmentsClosed: group.slots.filter((slot) => slot.enrollmentsClosed).length,
+  };
+}
+
+export function defaultExpandedSiteIds(groups: readonly SlotOccupancySiteGroup[]): Set<string> {
+  return new Set(
+    groups.filter((group) => group.slots.some((slot) => slot.status === "over")).map((group) => group.siteId)
+  );
+}
+
+export function patchOccupancyEnrollmentsClosed(
+  groups: readonly SlotOccupancySiteGroup[],
+  slotId: string,
+  enrollmentsClosed: boolean
+): SlotOccupancySiteGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    slots: group.slots.map((slot) =>
+      slot.slotId === slotId ? { ...slot, enrollmentsClosed } : slot
+    ),
+  }));
+}
+
+export function filterOccupancyGroups(
+  groups: readonly SlotOccupancySiteGroup[],
+  options: { status: OccupancyStatusFilter; query: string }
+): SlotOccupancySiteGroup[] {
+  const needle = options.query.trim().toLowerCase();
+  return groups
+    .map((group) => ({
+      ...group,
+      slots: group.slots.filter((slot) => {
+        if (options.status !== "all" && slot.status !== options.status) {
+          return false;
+        }
+        if (!needle) {
+          return true;
+        }
+        const haystack = [slot.label, slot.scheduleLabel ?? "", group.siteLabel, group.gymnasiumName ?? ""]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(needle);
+      }),
+    }))
+    .filter((group) => group.slots.length > 0);
+}

--- a/src/lib/club-slot-occupancy/index.ts
+++ b/src/lib/club-slot-occupancy/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./fill-rate";
+export * from "./count-enrollments";
+export * from "./build-occupancy";
+export * from "./filter-groups";

--- a/src/lib/club-slot-occupancy/occupancy.test.ts
+++ b/src/lib/club-slot-occupancy/occupancy.test.ts
@@ -1,0 +1,178 @@
+import {
+  buildOccupancyGroups,
+  findOccupancySlot,
+  mapRegistrationToOccupancyPerson,
+  sortOccupancyPeople,
+} from "./build-occupancy";
+import { countEnrollmentsBySlotId, readSlotIds } from "./count-enrollments";
+import {
+  defaultExpandedSiteIds,
+  filterOccupancyGroups,
+  occupancyGroupStats,
+  OCCUPANCY_STATUS_FILTER_OPTIONS,
+  patchOccupancyEnrollmentsClosed,
+} from "./filter-groups";
+import { computeSlotFill, slotFillPercent } from "./fill-rate";
+import { buildDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+
+describe("computeSlotFill", () => {
+  it("laisse le taux vide sans capacité", () => {
+    expect(computeSlotFill(12, undefined)).toEqual({
+      enrolledCount: 12,
+      capacity: undefined,
+      rate: null,
+      status: "unset",
+    });
+    expect(slotFillPercent(null)).toBeNull();
+  });
+
+  it("calcule le taux et l'état ok / complet / surcharge", () => {
+    expect(computeSlotFill(10, 20)).toEqual({
+      enrolledCount: 10,
+      capacity: 20,
+      rate: 0.5,
+      status: "ok",
+    });
+    expect(computeSlotFill(16, 20).status).toBe("near");
+    expect(computeSlotFill(19, 20).status).toBe("near");
+    expect(computeSlotFill(20, 20).status).toBe("full");
+    expect(computeSlotFill(21, 20)).toMatchObject({
+      status: "over",
+      rate: 1.05,
+    });
+    expect(slotFillPercent(1.05)).toBe(100);
+    expect(slotFillPercent(0.333)).toBe(33);
+  });
+});
+
+describe("countEnrollmentsBySlotId", () => {
+  it("compte un dossier par créneau et ignore les ids dupliqués", () => {
+    const counts = countEnrollmentsBySlotId([
+      { data: { slotIds: ["a", "b"] } },
+      { data: { slotIds: ["a", "a"] } },
+      { data: { slotIds: [] } },
+      { data: {} },
+    ]);
+    expect(counts.get("a")).toBe(2);
+    expect(counts.get("b")).toBe(1);
+    expect(readSlotIds({ slotIds: ["x", 1, ""] })).toEqual(["x"]);
+  });
+});
+
+describe("buildOccupancyGroups", () => {
+  it("attache le compteur et la capacité du catalogue", () => {
+    const config = buildDefaultRegistrationConfig();
+    const firstSite = config.sites[0];
+    const firstSlot = firstSite?.slots[0];
+    expect(firstSite && firstSlot).toBeTruthy();
+    if (!firstSite || !firstSlot) {
+      return;
+    }
+    firstSlot.capacity = 18;
+    const groups = buildOccupancyGroups(
+      config,
+      new Map([[firstSlot.id, 20]])
+    );
+    const found = findOccupancySlot(groups, firstSlot.id);
+    expect(found).toMatchObject({
+      slotId: firstSlot.id,
+      siteId: firstSite.id,
+      enrolledCount: 20,
+      capacity: 18,
+      status: "over",
+      enrollmentsClosed: false,
+    });
+    expect(findOccupancySlot(groups, "inconnu")).toBeNull();
+  });
+});
+
+describe("occupancy people", () => {
+  it("trie par nom et reprend les alertes du pointage", () => {
+    const leo = mapRegistrationToOccupancyPerson("r2", {
+      firstName: "Léo",
+      lastName: "Martin",
+      birthDate: "2014-01-01",
+      status: "paid",
+      paymentStatus: "paid",
+      medicalCertificateDeclaration: "under_40_all_no",
+      ppsFollowUpStatus: "not_applicable",
+    });
+    const ana = mapRegistrationToOccupancyPerson("r1", {
+      firstName: "Ana",
+      lastName: "Dupont",
+      status: "submitted",
+      paymentStatus: "waiting_payment",
+      medicalCertificateDeclaration: "adult_certificate_required",
+      medicalCertificateStatus: "required_not_received",
+      birthDate: "1990-01-01",
+    });
+    expect(ana.alerts).toEqual(["unpaid", "certificate"]);
+    expect(sortOccupancyPeople([leo, ana]).map((person) => person.displayName)).toEqual([
+      "Ana Dupont",
+      "Léo Martin",
+    ]);
+  });
+});
+
+describe("filterOccupancyGroups", () => {
+  const groups = buildOccupancyGroups(buildDefaultRegistrationConfig(), new Map());
+
+  it("reflète le catalogue club (plusieurs lieux, dizaines de créneaux)", () => {
+    const slotCount = groups.reduce((sum, group) => sum + group.slots.length, 0);
+    expect(groups.length).toBeGreaterThanOrEqual(5);
+    expect(slotCount).toBeGreaterThanOrEqual(30);
+  });
+
+  it("filtre par statut et par texte, et n'ouvre par défaut que les surcharges", () => {
+    const first = groups[0];
+    expect(first).toBeTruthy();
+    if (!first) {
+      return;
+    }
+    const overloaded = {
+      ...first,
+      slots: first.slots.map((slot, index) =>
+        index === 0 ? { ...slot, status: "over" as const, enrolledCount: 20, capacity: 10, rate: 2 } : slot
+      ),
+    };
+    const withOver = [overloaded, ...groups.slice(1)];
+    expect(defaultExpandedSiteIds(withOver)).toEqual(new Set([first.siteId]));
+    expect(occupancyGroupStats(overloaded).over).toBe(1);
+
+    const byStatus = filterOccupancyGroups(withOver, { status: "over", query: "" });
+    expect(byStatus).toHaveLength(1);
+    expect(byStatus[0]?.slots).toHaveLength(1);
+
+    const needle = first.siteLabel.slice(0, 6).toLowerCase();
+    const byQuery = filterOccupancyGroups(groups, { status: "all", query: needle });
+    expect(byQuery.some((group) => group.siteId === first.siteId)).toBe(true);
+  });
+
+  it("met à jour le marquage de fermeture des adhésions", () => {
+    const first = groups[0]?.slots[0];
+    expect(first).toBeTruthy();
+    if (!first) {
+      return;
+    }
+    const patched = patchOccupancyEnrollmentsClosed(groups, first.slotId, true);
+    const patchedGroup = patched[0];
+    expect(patchedGroup?.slots[0]?.enrollmentsClosed).toBe(true);
+    expect(patchedGroup).toBeTruthy();
+    if (!patchedGroup) {
+      return;
+    }
+    expect(occupancyGroupStats(patchedGroup).enrollmentsClosed).toBeGreaterThanOrEqual(1);
+  });
+
+  it("explique chaque filtre de statut", () => {
+    const helps = Object.fromEntries(
+      OCCUPANCY_STATUS_FILTER_OPTIONS.map((option) => [option.value, option.help])
+    );
+    expect(helps.all).toMatch(/tous les créneaux/i);
+    expect(helps.over).toMatch(/plus d'inscrits que la capacité/i);
+    expect(helps.full).toMatch(/autant d'inscrits/i);
+    expect(helps.near).toMatch(/80 %/i);
+    expect(helps.ok).toMatch(/80 %/i);
+    expect(helps.unset).toMatch(/aucune capacité/i);
+  });
+});

--- a/src/lib/club-slot-occupancy/store.ts
+++ b/src/lib/club-slot-occupancy/store.ts
@@ -1,0 +1,38 @@
+import { isRejectedRegistration } from "@/lib/attendance/alerts";
+import { COLLECTION as REGISTRATIONS_COLLECTION } from "@/lib/club-registration/list-registrations";
+import { FieldPath, type Firestore, type QueryDocumentSnapshot } from "firebase-admin/firestore";
+
+const SCAN_PAGE_SIZE = 500;
+
+export async function listAllNonRejectedRegistrations(
+  db: Firestore
+): Promise<Array<{ id: string; data: Record<string, unknown> }>> {
+  const results: Array<{ id: string; data: Record<string, unknown> }> = [];
+  let lastDoc: QueryDocumentSnapshot | undefined;
+
+  while (true) {
+    let query = db
+      .collection(REGISTRATIONS_COLLECTION)
+      .orderBy(FieldPath.documentId())
+      .limit(SCAN_PAGE_SIZE);
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+    const snap = await query.get();
+    if (snap.empty) {
+      break;
+    }
+    for (const doc of snap.docs) {
+      const data = doc.data() as Record<string, unknown>;
+      if (!isRejectedRegistration(data)) {
+        results.push({ id: doc.id, data });
+      }
+    }
+    if (snap.size < SCAN_PAGE_SIZE) {
+      break;
+    }
+    lastDoc = snap.docs[snap.docs.length - 1];
+  }
+
+  return results;
+}

--- a/src/lib/club-slot-occupancy/types.ts
+++ b/src/lib/club-slot-occupancy/types.ts
@@ -1,0 +1,59 @@
+import type { AttendanceAlert } from "@/lib/attendance/constants";
+
+export const SLOT_FILL_STATUSES = ["ok", "near", "full", "over", "unset"] as const;
+export type SlotFillStatus = (typeof SLOT_FILL_STATUSES)[number];
+
+export type SlotFillSnapshot = {
+  enrolledCount: number;
+  capacity: number | undefined;
+  rate: number | null;
+  status: SlotFillStatus;
+};
+
+export type SlotOccupancySummary = SlotFillSnapshot & {
+  slotId: string;
+  label: string;
+  siteId: string;
+  siteLabel: string;
+  gymnasiumName?: string | undefined;
+  weekday: number | null;
+  startMinutes: number | null;
+  endMinutes: number | null;
+  scheduleLabel: string | null;
+  enabled: boolean;
+  enrollmentsClosed: boolean;
+};
+
+export type SlotOccupancySiteGroup = {
+  siteId: string;
+  siteLabel: string;
+  gymnasiumName?: string | undefined;
+  slots: SlotOccupancySummary[];
+};
+
+export type SlotOccupancyEnrolledPerson = {
+  personKey: string;
+  registrationId: string;
+  firstName: string;
+  lastName: string;
+  displayName: string;
+  age: number | null;
+  alerts: AttendanceAlert[];
+};
+
+export const SLOT_FILL_STATUS_LABELS: Record<SlotFillStatus, string> = {
+  ok: "Places disponibles",
+  near: "Presque complet",
+  full: "Complet",
+  over: "Surcharge",
+  unset: "Capacité non paramétrée",
+};
+
+export const SLOT_FILL_STATUS_HELP: Record<SlotFillStatus, string> = {
+  ok: "Moins de 80 % de la capacité du créneau.",
+  near: "Au moins 80 % de la capacité, sans l'atteindre (ex. 17 inscrits pour 20 places).",
+  full: "Autant d'inscrits que la capacité du créneau.",
+  over: "Plus d'inscrits que la capacité du créneau (ex. 22 inscrits pour 20 places).",
+  unset: "Aucune capacité n'a été saisie pour ce créneau dans le paramétrage.",
+};
+

--- a/src/lib/navigation/home-content.test.ts
+++ b/src/lib/navigation/home-content.test.ts
@@ -86,6 +86,7 @@ describe("buildRoleHomeContent", () => {
     expect(listHomeCardHrefs(content)).toEqual([
       "/club/adhesions-tableau",
       "/club/presences",
+      "/club/creneaux",
       "/club/presences/essais",
       "/club/inscription",
       "/club/mes-inscriptions",

--- a/src/lib/navigation/home-content.ts
+++ b/src/lib/navigation/home-content.ts
@@ -109,6 +109,11 @@ const HOME_LINK_META: Record<
     cta: "Ouvrir le pointage",
     color: "info",
   },
+  "/club/creneaux": {
+    description: "Taux de remplissage des créneaux et liste des inscrits.",
+    cta: "Voir les créneaux",
+    color: "info",
+  },
   "/club/presences/essais": {
     description: "Relancer les personnes venues essayer un entraînement.",
     cta: "Ouvrir les essais",
@@ -180,6 +185,7 @@ function boardMemberHome(): RoleHomeContent {
         items: cards([
           LAYOUT_NAV.tableauAdhesions,
           LAYOUT_NAV.presences,
+          LAYOUT_NAV.creneaux,
           LAYOUT_NAV.presencesEssais,
           LAYOUT_NAV.nouvelleAdhesion,
           LAYOUT_NAV.mesDossiers,
@@ -242,7 +248,7 @@ function coachHome(): RoleHomeContent {
         title: "Vie du club",
         description:
           "Présences aux entraînements et remontées sur l'application.",
-        items: cards([LAYOUT_NAV.presences, LAYOUT_NAV.boiteIdees]),
+        items: cards([LAYOUT_NAV.presences, LAYOUT_NAV.creneaux, LAYOUT_NAV.boiteIdees]),
       },
     ],
   );
@@ -275,6 +281,7 @@ function secretaryHome(): RoleHomeContent {
           "Présences aux entraînements et remontées sur l'application.",
         items: cards([
           LAYOUT_NAV.presences,
+          LAYOUT_NAV.creneaux,
           LAYOUT_NAV.presencesEssais,
           LAYOUT_NAV.boiteIdees,
         ]),
@@ -321,6 +328,7 @@ function adminHome(): RoleHomeContent {
         description: "Présences, administration de la plateforme et remontées.",
         items: cards([
           LAYOUT_NAV.presences,
+          LAYOUT_NAV.creneaux,
           LAYOUT_NAV.presencesEssais,
           LAYOUT_NAV.administration,
           LAYOUT_NAV.boiteIdees,


### PR DESCRIPTION
## Summary
- Page `/club/creneaux` : remplissage des créneaux (taux, liste des inscrits) pour les mêmes rôles que le pointage.
- Fermeture à la demande (admin / secrétaire), avec confirmation ; les familles (et le secrétaire adjoint) ne peuvent plus s’inscrire sur un créneau fermé.
- Bypass pour admin, secrétaire, coach et membre du bureau. Walk-in non bloqué, mention « Inscriptions fermées » affichée.

## Test plan
- [ ] Ouvrir `/club/creneaux` en coach : voir le remplissage, pas le bouton fermer.
- [ ] En admin/secrétaire : fermer/réouvrir un créneau (popin + spinner) ; même action depuis Campagnes & tarifs.
- [ ] Formulaire d’inscription famille : créneau fermé visible, case grisée, soumission refusée.
- [ ] Connecté en coach/bureau : pouvoir encore cocher un créneau fermé.
- [ ] Pointage walk-in : créneau fermé sélectionnable, pastille « Inscriptions fermées ».


Made with [Cursor](https://cursor.com)