### PR TITLE
feat(championship): effectif saisonnier et transition FFTT 2026-2027

### DIFF
--- a/docs/technical/adr/0008-season-championship-roster.md
+++ b/docs/technical/adr/0008-season-championship-roster.md
@@ -1,0 +1,62 @@
+# ADR-0008: Effectif championnat saisonnier et miroir FFTT
+
+## Statut
+
+Accepté — 2026-08-22
+
+## Contexte
+
+La collection `players` mélange un miroir de l’API FFTT (liste club + détails licence) et des données club : participation championnat, équipes préférées, Discord, fauteuil, joueurs temporaires, agrégats de brûlage.
+
+À la transition de saison, la FFTT continue d’attribuer d’anciens adhérents à SQY tant qu’ils n’ont pas repris de licence (club ou ailleurs), tout en les sortant de `getJoueursByClub`. Les booléens `participation.*` survivent donc hors effectif réel. Les dossiers d’adhésion (`clubRegistrations`) disent qui est membre et ce qu’il a demandé, mais ce n’est pas un roster FFTT.
+
+Le championnat 2026-2027 doit se baser sur l’intention des dossiers (paiement et licence visibles, non bloquants), pas sur les reliquats `players.participation`.
+
+## Décision
+
+1. **`players`** : miroir FFTT uniquement, plus `listedInClub` / `lastSeenInClubListAt`. La synchro quotidienne n’écrit plus les champs club. `getJoueursByClub` peut encore renvoyer des affiliés SQY **sans** licence de saison (`typeLicence` null). Licence saison = type T/P/A renvoyé par `getJoueurDetailsByLicence` ; un ancien T/P/A doit être écrasé quand le détail est vide. Les fiches **hors liste club** sont quand même rafraîchies (nom de club, type) pour distinguer mutation et licence saison manquante.
+2. **`seasons/{seasonLabel}/championshipPlayers/{personKey}`** : effectif championnat de la saison (`meta.seasonLabel`, 1er septembre → 31 août, comme ADR-0006). Seed automatique depuis les dossiers non refusés avec `championnat_equipe` et/ou `championnat_paris`. `coachExcluded` est sticky. Ajout coach sans intention dossier autorisé.
+3. **Paiement et licence** : informatifs (`paymentStatus`, `licensePresence`). L’entraîneur les voit ; ils n’excluent pas du pool.
+4. **Clé personne** : licence FFTT si connue, sinon `reg_{registrationId}`. Fusion vers la licence quand elle arrive.
+5. **`playerClubProfiles/{personKey}`** : Discord et fauteuil, durables hors saison.
+6. **Temporaires** : documents du roster saison (`isTemporary`), plus des fiches `players` fictives.
+7. **Écritures** : seed et recalcul via Admin SDK ; toggles participation via API (`ADMIN`/`COACH`). Lectures roster : `ADMIN`/`COACH`.
+8. Ouverture de saison = changement de `seasonLabel` publié. Action « Recalculer l’effectif » sur l’onglet admin Synchronisation FFTT.
+
+## Conséquences
+
+### Positives
+
+- Le pool compositions / dispos ne reprend plus les 188 affiliés SQY sans licence saison.
+- Un adhérent payé sans liste club (ex. Deshayes) peut apparaître, avec un chip d’alerte.
+- Le brûlage est recalculable par saison.
+
+### Négatives
+
+- Join roster + `players` + profils à chaque chargement.
+- Les compositions 2025-2026 restent sur l’ancien modèle (hors migration historique).
+
+### Neutres
+
+- Critérium fédéral / championnat jeunes hors UI compositions de cette vague.
+- Pas de purge physique des documents `players` hors liste club.
+
+## Alternatives considérées
+
+### Alternative 1: se fier uniquement à `players`
+
+- **Pourquoi rejetée** : affiliation FFTT résiduelle ≠ licencié de saison ≠ adhérent club.
+
+### Alternative 2: se fier uniquement aux dossiers
+
+- **Pourquoi rejetée** : pas de points / type de licence ; loisirs et dossiers incomplets.
+
+### Alternative 3: garder `participation` sur `players` avec un reset annuel
+
+- **Pourquoi rejetée** : la synchro `merge` ne reset pas ; le modèle reste couplé au miroir FFTT.
+
+## Références
+
+- `.cursor/rules/80-club-platform-extension.mdc`
+- `docs/technical/adr/0006-training-attendance.md`
+- `src/lib/shared/player-sync.ts`

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -467,6 +467,16 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "championshipPlayers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -305,6 +305,21 @@ service cloud.firestore {
     }
 
     // ============================================
+    // Collections: seasons / championshipPlayers, playerClubProfiles
+    // ============================================
+    // Effectif championnat saisonnier + profils durables (Discord, fauteuil).
+    // Lectures / écritures via Admin SDK (routes /api/club/championship/*).
+    match /seasons/{seasonId} {
+      allow read, write: if false;
+      match /championshipPlayers/{personKey} {
+        allow read, write: if false;
+      }
+    }
+    match /playerClubProfiles/{personKey} {
+      allow read, write: if false;
+    }
+
+    // ============================================
     // Règle par défaut : refuser tout accès non explicitement autorisé
     // ============================================
     match /{document=**} {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -40,10 +40,12 @@ import {
 } from "@/components/admin/DiscordAvailabilitySection";
 import { LocationsManagementSection } from "@/components/admin/LocationsManagementSection";
 import { SyncOperationCard } from "@/components/admin/SyncOperationCard";
+import { ChampionshipRosterSyncCard } from "@/components/admin/ChampionshipRosterSyncCard";
 import { CoachRequestsSection } from "@/components/admin/CoachRequestsSection";
 import { UsersManagementTable } from "@/components/admin/UsersManagementTable";
 import { useUserAdminActions } from "@/components/admin/useUserAdminActions";
 import { TabPanel } from "@/components/ui/TabPanel";
+import { useTeamManagementStore } from "@/stores/teamManagementStore";
 
 const ADMIN_TAB_PANEL_PROPS = {
   baseId: "admin",
@@ -240,6 +242,7 @@ export default function AdminPage() {
             duration: result.data?.duration || null,
           },
         }));
+        void useTeamManagementStore.getState().loadEquipesWithMatches();
       } else {
         setSyncStatus((prev) => ({
           ...prev,
@@ -294,6 +297,7 @@ export default function AdminPage() {
             duration: result.data?.duration || null,
           },
         }));
+        void useTeamManagementStore.getState().loadEquipesWithMatches();
       } else {
         const errorMessage =
           result.details ||
@@ -692,6 +696,8 @@ export default function AdminPage() {
                   headerIcon={<SportsIcon sx={{ mr: 1, color: "primary.main" }} />}
                   onSync={() => handleSyncTeamMatches()}
                 />
+
+                <ChampionshipRosterSyncCard />
 
                 <Card>
                   <CardContent>

--- a/src/app/api/club/championship/roster/[personKey]/route.ts
+++ b/src/app/api/club/championship/roster/[personKey]/route.ts
@@ -1,0 +1,168 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import { requireChampionshipRosterActor } from "@/lib/championship/api-auth";
+import { rosterParticipationPatchSchema } from "@/lib/championship/schema";
+import {
+  getChampionshipPlayer,
+  upsertChampionshipPlayer,
+  upsertPlayerClubProfile,
+  getPlayerClubProfile,
+  deleteChampionshipPlayer,
+} from "@/lib/championship/store";
+import { digitsLicense, resolveChampionshipPersonKey } from "@/lib/championship/person-key";
+
+type RouteContext = { params: Promise<{ personKey: string }> };
+
+export async function PATCH(req: Request, context: RouteContext) {
+  try {
+    if (!validateOrigin(req)) {
+      return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+    }
+    const auth = await requireChampionshipRosterActor();
+    if (!auth.ok) {
+      return jsonNoStore({ error: auth.error }, { status: auth.status });
+    }
+    const { personKey: rawKey } = await context.params;
+    const personKey = decodeURIComponent(rawKey);
+    if (!personKey) {
+      return jsonNoStore({ error: "Clé personne manquante" }, { status: 400 });
+    }
+
+    const parsed = rosterParticipationPatchSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return jsonNoStore({ error: "Données invalides" }, { status: 400 });
+    }
+
+    const config = await getActiveRegistrationConfig();
+    const seasonLabel = config.meta.seasonLabel;
+    const db = getFirestoreAdmin();
+    const existing = await getChampionshipPlayer(db, seasonLabel, personKey);
+    const patch = parsed.data;
+
+    const nextLicense =
+      patch.ffttLicense !== undefined
+        ? patch.ffttLicense
+        : existing?.ffttLicense ?? (digitsLicense(personKey) || null);
+    const resolvedKey =
+      resolveChampionshipPersonKey({
+        ffttLicense: nextLicense,
+        registrationId: existing?.registrationId ?? null,
+      }) ?? personKey;
+
+    const coachExcluded = patch.coachExcluded ?? existing?.coachExcluded ?? false;
+    const championnat = coachExcluded
+      ? false
+      : (patch.championnat ?? existing?.championnat ?? false);
+    const championnatParis = coachExcluded
+      ? false
+      : (patch.championnatParis ?? existing?.championnatParis ?? false);
+    const coachIncluded =
+      !coachExcluded &&
+      (championnat || championnatParis) &&
+      !(existing?.includedFromDossier ?? false);
+
+    await upsertChampionshipPlayer(db, {
+      personKey: resolvedKey,
+      seasonLabel,
+      registrationId: existing?.registrationId ?? null,
+      ffttLicense: nextLicense,
+      firstName: patch.firstName ?? existing?.firstName ?? "",
+      lastName: patch.lastName ?? existing?.lastName ?? "",
+      sex: patch.sex ?? existing?.sex ?? "",
+      includedFromDossier: existing?.includedFromDossier ?? false,
+      coachIncluded: existing?.coachIncluded || coachIncluded,
+      coachExcluded,
+      championnat,
+      championnatParis,
+      paymentStatus: existing?.paymentStatus ?? null,
+      registrationStatus: existing?.registrationStatus ?? null,
+      licensePresence: existing?.licensePresence ?? "unknown",
+      licenseValidationStatus: existing?.licenseValidationStatus ?? null,
+      preferredTeams: patch.preferredTeams ??
+        existing?.preferredTeams ?? { masculine: [], feminine: [] },
+      isTemporary: patch.isTemporary ?? existing?.isTemporary ?? false,
+      hasPlayedAtLeastOneMatch: existing?.hasPlayedAtLeastOneMatch,
+      hasPlayedAtLeastOneMatchParis: existing?.hasPlayedAtLeastOneMatchParis,
+      highestMasculineTeamNumberByPhase: existing?.highestMasculineTeamNumberByPhase,
+      highestFeminineTeamNumberByPhase: existing?.highestFeminineTeamNumberByPhase,
+      highestTeamNumberByPhaseParis: existing?.highestTeamNumberByPhaseParis,
+      masculineMatchesByTeamByPhase: existing?.masculineMatchesByTeamByPhase,
+      feminineMatchesByTeamByPhase: existing?.feminineMatchesByTeamByPhase,
+      matchesByTeamByPhaseParis: existing?.matchesByTeamByPhaseParis,
+    });
+
+    if (patch.discordMentions !== undefined || patch.isWheelchair !== undefined) {
+      const currentProfile = await getPlayerClubProfile(db, resolvedKey);
+      await upsertPlayerClubProfile(db, {
+        personKey: resolvedKey,
+        discordMentions:
+          patch.discordMentions ?? currentProfile?.discordMentions ?? [],
+        isWheelchair: patch.isWheelchair ?? currentProfile?.isWheelchair ?? false,
+      });
+    }
+
+    logAuditAction(AUDIT_ACTIONS.CHAMPIONSHIP_ROSTER_UPDATED, auth.uid, {
+      resource: "championshipRoster",
+      resourceId: resolvedKey,
+      details: { fields: Object.keys(patch), seasonLabel },
+      success: true,
+    });
+
+    return jsonNoStore({ success: true, personKey: resolvedKey, seasonLabel });
+  } catch (error) {
+    console.error("[api/club/championship/roster PATCH]", error);
+    return jsonNoStore(
+      { error: "Impossible de mettre à jour l'effectif championnat" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: Request, context: RouteContext) {
+  try {
+    if (!validateOrigin(req)) {
+      return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+    }
+    const auth = await requireChampionshipRosterActor();
+    if (!auth.ok) {
+      return jsonNoStore({ error: auth.error }, { status: auth.status });
+    }
+    const { personKey: rawKey } = await context.params;
+    const personKey = decodeURIComponent(rawKey);
+    if (!personKey) {
+      return jsonNoStore({ error: "Clé personne manquante" }, { status: 400 });
+    }
+    const config = await getActiveRegistrationConfig();
+    const seasonLabel = config.meta.seasonLabel;
+    const db = getFirestoreAdmin();
+    const existing = await getChampionshipPlayer(db, seasonLabel, personKey);
+    if (!existing) {
+      return jsonNoStore({ error: "Joueur introuvable dans l'effectif" }, { status: 404 });
+    }
+    if (!existing.isTemporary) {
+      return jsonNoStore(
+        { error: "Seuls les joueurs temporaires peuvent être supprimés" },
+        { status: 403 }
+      );
+    }
+    await deleteChampionshipPlayer(db, seasonLabel, personKey);
+    logAuditAction(AUDIT_ACTIONS.CHAMPIONSHIP_ROSTER_DELETED, auth.uid, {
+      resource: "championshipRoster",
+      resourceId: personKey,
+      details: { seasonLabel, isTemporary: true },
+      success: true,
+    });
+    return jsonNoStore({ success: true, personKey, seasonLabel });
+  } catch (error) {
+    console.error("[api/club/championship/roster DELETE]", error);
+    return jsonNoStore(
+      { error: "Impossible de supprimer le joueur temporaire" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/club/championship/roster/route.ts
+++ b/src/app/api/club/championship/roster/route.ts
@@ -1,0 +1,65 @@
+export const runtime = "nodejs";
+
+import { jsonNoStore } from "@/lib/http/cache-headers";
+import { getFirestoreAdmin } from "@/lib/firebase-admin";
+import { validateOrigin } from "@/lib/auth/csrf-utils";
+import { AUDIT_ACTIONS, logAuditAction } from "@/lib/auth/audit-logger";
+import { getActiveRegistrationConfig } from "@/lib/club-registration-config/store";
+import {
+  requireChampionshipRecalculateActor,
+  requireChampionshipRosterActor,
+} from "@/lib/championship/api-auth";
+import { backfillPlayerClubProfilesFromPlayers } from "@/lib/championship/backfill-profiles";
+import { listChampionshipRosterViews } from "@/lib/championship/list-roster-views";
+import { seedChampionshipRosterForSeason } from "@/lib/championship/seed-season";
+
+export async function GET() {
+  try {
+    const auth = await requireChampionshipRosterActor();
+    if (!auth.ok) {
+      return jsonNoStore({ error: auth.error }, { status: auth.status });
+    }
+    const config = await getActiveRegistrationConfig();
+    const seasonLabel = config.meta.seasonLabel;
+    const db = getFirestoreAdmin();
+    const roster = await listChampionshipRosterViews(db, seasonLabel);
+    return jsonNoStore({ seasonLabel, roster });
+  } catch (error) {
+    console.error("[api/club/championship/roster GET]", error);
+    return jsonNoStore(
+      { error: "Impossible de charger l'effectif championnat" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    if (!validateOrigin(req)) {
+      return jsonNoStore({ error: "Invalid origin" }, { status: 403 });
+    }
+    const auth = await requireChampionshipRecalculateActor();
+    if (!auth.ok) {
+      return jsonNoStore({ error: auth.error }, { status: auth.status });
+    }
+    const config = await getActiveRegistrationConfig();
+    const seasonLabel = config.meta.seasonLabel;
+    const db = getFirestoreAdmin();
+    const [seed, profiles] = await Promise.all([
+      seedChampionshipRosterForSeason(db, seasonLabel),
+      backfillPlayerClubProfilesFromPlayers(db),
+    ]);
+    logAuditAction(AUDIT_ACTIONS.CHAMPIONSHIP_ROSTER_RECALCULATED, auth.uid, {
+      resource: "championshipRoster",
+      details: { seasonLabel, ...seed, profilesCopied: profiles.copied },
+      success: true,
+    });
+    return jsonNoStore({ seasonLabel, ...seed, profilesCopied: profiles.copied });
+  } catch (error) {
+    console.error("[api/club/championship/roster POST]", error);
+    return jsonNoStore(
+      { error: "Impossible de recalculer l'effectif championnat" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/club/registration/route.ts
+++ b/src/app/api/club/registration/route.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/club-registration-config/store";
 import { canBypassSlotEnrollmentClose } from "@/lib/club-registration-config/slot-enrollments";
 import { createRegistrationWithIdempotency } from "@/lib/club-registration/create-registration-with-idempotency";
+import { syncRosterAfterRegistrationChange } from "@/lib/championship/sync-after-registration";
 import {
   findRegistrationLicenseConflicts,
   formatBlockingLicenseConflictMessage,
@@ -211,6 +212,10 @@ export async function POST(req: Request) {
         })
       ),
     });
+
+    if (!duplicated) {
+      await syncRosterAfterRegistrationChange(db, registrationId);
+    }
 
     logAuditAction(AUDIT_ACTIONS.CLUB_REGISTRATION_SUBMITTED, decoded.uid, {
       resource: "clubRegistration",

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -9,6 +9,7 @@ import { verifyStripeWebhookSignature } from "@/lib/club-registration/stripe";
 import { normalizeRegistrationPayment } from "@/lib/club-registration/payment/normalize-payment";
 import { applyStripeCheckoutPaid } from "@/lib/club-registration/payment/apply-stripe-checkout-paid";
 import { paymentWriteWithSettlement } from "@/lib/club-registration/payment/settlement-firestore";
+import { syncRosterAfterRegistrationChange } from "@/lib/championship/sync-after-registration";
 
 type StripeWebhookEvent = {
   id: string;
@@ -128,6 +129,8 @@ export async function POST(req: Request) {
       },
       success: true,
     });
+
+    await syncRosterAfterRegistrationChange(getFirestoreAdmin(), registrationId);
 
     if (applied.amountCents > 0 && applied.markRegistrationPaid) {
       try {

--- a/src/app/compositions/_containers/CompositionsPageContainer.tsx
+++ b/src/app/compositions/_containers/CompositionsPageContainer.tsx
@@ -155,8 +155,7 @@ export function CompositionsPageContainer() {
     setDefaultCompositions,
     defaultCompositionsLoaded,
   } = useDefaultCompositions({
-    selectedPhase,
-    compositionDefaultsService,
+    selectedPhase, selectedEpreuve, equipes, compositionDefaultsService,
   });
 
   const availablePlayersSubtitle = useMemo(() => {

--- a/src/app/compositions/_containers/DefaultCompositionsContainer.tsx
+++ b/src/app/compositions/_containers/DefaultCompositionsContainer.tsx
@@ -91,8 +91,7 @@ export function DefaultCompositionsContainer() {
     setDefaultCompositions,
     defaultCompositionsLoaded,
   } = useDefaultCompositions({
-    selectedPhase,
-    compositionDefaultsService,
+    selectedPhase, selectedEpreuve, equipes, compositionDefaultsService,
   });
 
   const {
@@ -162,12 +161,7 @@ export function DefaultCompositionsContainer() {
   );
 
   const championshipPlayers = useMemo(
-    () =>
-      players.filter(
-        (player) => 
-          player.participation?.championnat === true && 
-          (player.isActive || player.isTemporary)
-      ),
+    () => players.filter((player) => player.participation?.championnat === true),
     [players]
   );
 

--- a/src/app/equipes/page.tsx
+++ b/src/app/equipes/page.tsx
@@ -32,7 +32,7 @@ import { EquipeAccordion } from "@/components/equipes/EquipeAccordion";
 
 export default function EquipesPage() {
   const { user } = useAuth();
-  const { equipes: initialEquipes, loading, error, currentPhase } = useTeamData();
+  const { equipes: initialEquipes, loading, error, currentPhase } = useTeamData({ refreshOnMount: true });
   const updateTeamInStore = useTeamManagementStore((state) => state.updateTeam);
   const [equipes, setEquipes] = React.useState(initialEquipes);
   const [tabValue, setTabValue] = React.useState(0);

--- a/src/app/joueurs/page.tsx
+++ b/src/app/joueurs/page.tsx
@@ -41,6 +41,11 @@ import {
   type JoueursFilters,
 } from "@/lib/players/player-filters";
 import { useJoueursCrud } from "@/hooks/useJoueursCrud";
+import { useJoueursRosterToggles } from "@/hooks/useJoueursRosterToggles";
+import {
+  mergeLoadedPlayersWithRoster,
+  splitMergedPlayersByTab,
+} from "@/lib/championship/load-merged-players";
 import { PlayersBasicTable } from "@/components/players/PlayersBasicTable";
 import { PlayersActiveTable } from "@/components/players/PlayersActiveTable";
 import { DiscordMentionsAutocomplete } from "@/components/players/DiscordMentionsAutocomplete";
@@ -113,10 +118,15 @@ export default function JoueursPage() {
         playerService.getPlayersWithoutLicense(),
         playerService.getTemporaryPlayers(),
       ]);
-
-      setPlayers(activePlayers);
-      setPlayersWithoutLicense(withoutLicense);
-      setTemporaryPlayers(temporary);
+      const merged = await mergeLoadedPlayersWithRoster([
+        ...activePlayers,
+        ...withoutLicense,
+        ...temporary,
+      ]);
+      const split = splitMergedPlayersByTab(merged);
+      setPlayers(split.active);
+      setPlayersWithoutLicense(split.withoutLicense);
+      setTemporaryPlayers(split.temporary);
     } catch (error) {
       console.error("Erreur lors du chargement des joueurs:", error);
     } finally {
@@ -312,143 +322,21 @@ export default function JoueursPage() {
     recomputeFilteredPlayersFromLists,
   });
 
-  const handleToggleParticipationParis = async (
-    player: Player,
-    inChampionshipParis: boolean
-  ) => {
-    try {
-      // Mettre à jour seulement la participation au championnat de Paris
-      await playerService.updatePlayer(player.id, {
-        participation: {
-          ...player.participation,
-          championnatParis: inChampionshipParis,
-        },
-      });
-
-      // Mettre à jour l'état local
-      setPlayers((prevPlayers) =>
-        prevPlayers.map((p) =>
-          p.id === player.id
-            ? {
-                ...p,
-                participation: {
-                  ...p.participation,
-                  championnatParis: inChampionshipParis,
-                },
-              }
-            : p
-        )
-      );
-
-      // Mettre à jour le store Zustand pour synchroniser avec les autres pages
-      updatePlayerInStore(player.id, {
-        participation: {
-          ...player.participation,
-          championnatParis: inChampionshipParis,
-        },
-      });
-    } catch (error) {
-      console.error(
-        "Erreur lors de la mise à jour de la participation au championnat de Paris:",
-        error
-      );
-      alert("Erreur lors de la mise à jour de la participation");
-    }
-  };
-
-  const handleToggleParticipation = async (
-    player: Player,
-    isParticipating: boolean
-  ) => {
-    try {
-      // Mettre à jour seulement la participation au championnat
-      await playerService.updatePlayer(player.id, {
-        participation: {
-          ...player.participation,
-          championnat: isParticipating,
-        },
-      });
-      // Mettre à jour l&apos;état local immédiatement pour un feedback visuel rapide
-      const updatePlayerInList = (p: Player) =>
-        p.id === player.id
-          ? {
-              ...p,
-              participation: {
-                ...p.participation,
-                championnat: isParticipating,
-              },
-            }
-          : p;
-
-      const updatedPlayers = players.map(updatePlayerInList);
-      const updatedTemporaryPlayers = temporaryPlayers.map(updatePlayerInList);
-      const updatedPlayersWithoutLicense =
-        playersWithoutLicense.map(updatePlayerInList);
-
-      setPlayers(updatedPlayers);
-      setTemporaryPlayers(updatedTemporaryPlayers);
-      setPlayersWithoutLicense(updatedPlayersWithoutLicense);
-
-      // Mettre à jour le store Zustand pour synchroniser avec les autres pages
-      updatePlayerInStore(player.id, {
-        participation: {
-          ...player.participation,
-          championnat: isParticipating,
-        },
-      });
-
-      recomputeFilteredPlayersFromLists(
-        updatedPlayers,
-        updatedPlayersWithoutLicense,
-        updatedTemporaryPlayers
-      );
-    } catch (error) {
-      console.error(
-        "Erreur lors de la mise à jour de la participation:",
-        error
-      );
-    }
-  };
-
-  const handleToggleWheelchair = useCallback(
-    async (player: Player) => {
-      const newValue = !player.isWheelchair;
-      const oldValue = player.isWheelchair;
-
-      const applyWheelchairState = (value: boolean) => {
-        setPlayers((prev) =>
-          prev.map((p) =>
-            p.id === player.id ? { ...p, isWheelchair: value } : p
-          )
-        );
-        setPlayersWithoutLicense((prev) =>
-          prev.map((p) =>
-            p.id === player.id ? { ...p, isWheelchair: value } : p
-          )
-        );
-        setTemporaryPlayers((prev) =>
-          prev.map((p) =>
-            p.id === player.id ? { ...p, isWheelchair: value } : p
-          )
-        );
-        setFilteredPlayers((prev) =>
-          prev.map((p) =>
-            p.id === player.id ? { ...p, isWheelchair: value } : p
-          )
-        );
-      };
-
-      applyWheelchairState(newValue ?? false);
-      try {
-        await playerService.updatePlayer(player.id, { isWheelchair: newValue });
-        updatePlayerInStore(player.id, { isWheelchair: newValue });
-      } catch (error) {
-        console.error("Erreur lors de la mise à jour du flag fauteuil:", error);
-        applyWheelchairState(oldValue ?? false);
-      }
-    },
-    [playerService, updatePlayerInStore]
-  );
+  const {
+    handleToggleParticipation,
+    handleToggleParticipationParis,
+    handleToggleWheelchair,
+  } = useJoueursRosterToggles({
+    players,
+    playersWithoutLicense,
+    temporaryPlayers,
+    setPlayers,
+    setPlayersWithoutLicense,
+    setTemporaryPlayers,
+    setFilteredPlayers,
+    updatePlayerInStore,
+    recomputeFilteredPlayersFromLists,
+  });
 
   return (
     <AuthGuard

--- a/src/components/admin/ChampionshipRosterSyncCard.tsx
+++ b/src/components/admin/ChampionshipRosterSyncCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import GroupsIcon from "@mui/icons-material/Groups";
+import { useState } from "react";
+import { recalculateChampionshipRoster } from "@/lib/championship/client";
+
+export function ChampionshipRosterSyncCard() {
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <Card>
+      <CardContent>
+        <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+          <GroupsIcon sx={{ mr: 1, color: "primary.main" }} />
+          <Typography variant="h6">Effectif championnat</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Reconstruit l&apos;effectif de la saison depuis les dossiers
+          d&apos;adhésion (ouverture de saison, rattrapage). Ce n&apos;est pas
+          une synchronisation FFTT : les dossiers se recalent déjà tout seuls à
+          la soumission, au paiement et à une modification secrétariat.
+        </Typography>
+        <Button
+          variant="contained"
+          fullWidth
+          startIcon={
+            busy ? <CircularProgress size={20} color="inherit" /> : <RefreshIcon />
+          }
+          disabled={busy}
+          onClick={() => {
+            setBusy(true);
+            void recalculateChampionshipRoster()
+              .catch((error: unknown) => {
+                console.error(error);
+                alert("Impossible de recalculer l'effectif championnat");
+              })
+              .finally(() => setBusy(false));
+          }}
+        >
+          {busy ? "Recalcul en cours..." : "Recalculer l'effectif"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/championship/ChampionshipStatusChips.tsx
+++ b/src/components/championship/ChampionshipStatusChips.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Chip, Stack, Tooltip } from "@mui/material";
+import type { ChampionshipAlertCode } from "@/lib/championship/merge-players";
+import type { Player } from "@/types/team-management";
+
+const ALERT_LABELS: Record<ChampionshipAlertCode, { label: string; title: string }> = {
+  unpaid: { label: "Non payé", title: "Dossier d'adhésion pas encore soldé" },
+  payment_requested: {
+    label: "Paiement demandé",
+    title: "Paiement demandé, en attente d'encaissement",
+  },
+  not_in_club_list: {
+    label: "Hors liste FFTT",
+    title: "Licence absente de la liste club FFTT de la saison",
+  },
+  fftt_sqy_unlicensed: {
+    label: "Licence saison",
+    title: "Toujours affilié SQY à la FFTT, sans licence de saison",
+  },
+  other_club: { label: "Autre club", title: "Licence rattachée à un autre club FFTT" },
+  other_federation: {
+    label: "Autre fédé",
+    title: "Licence d'une autre fédération",
+  },
+  no_license: { label: "Sans n°", title: "Pas de numéro de licence sur le dossier" },
+};
+
+type Props = {
+  player: Player;
+};
+
+export function ChampionshipStatusChips({ player }: Props) {
+  const alerts = player.championshipAlerts ?? [];
+  if (alerts.length === 0) {
+    return null;
+  }
+  return (
+    <Stack direction="row" gap={0.5} flexWrap="wrap" component="span">
+      {alerts.map((code) => {
+        const meta = ALERT_LABELS[code];
+        const label =
+          code === "other_club" && player.nomClub?.trim()
+            ? player.nomClub.trim()
+            : meta.label;
+        return (
+          <Tooltip key={code} title={meta.title}>
+            <Chip
+              label={label}
+              size="small"
+              color="warning"
+              variant="outlined"
+              sx={{ height: 20, fontSize: "0.65rem" }}
+            />
+          </Tooltip>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/src/components/compositions/AvailablePlayerListItem.tsx
+++ b/src/components/compositions/AvailablePlayerListItem.tsx
@@ -17,6 +17,7 @@ import {
   DragIndicator,
   Warning,
 } from "@mui/icons-material";
+import { ChampionshipStatusChips } from "@/components/championship/ChampionshipStatusChips";
 import { Player } from "@/types/team-management";
 
 interface AvailablePlayerListItemProps {
@@ -85,6 +86,7 @@ export function AvailablePlayerListItem({
               <Typography variant="body2" component="span">
                 {player.firstName} {player.name}
               </Typography>
+              <ChampionshipStatusChips player={player} />
               {player.isWheelchair && (
                 <Tooltip title="Joueur en fauteuil">
                   <AccessibleIcon fontSize="small" sx={{ color: "primary.main", ml: 0.5 }} />

--- a/src/components/players/PlayersActiveTable.tsx
+++ b/src/components/players/PlayersActiveTable.tsx
@@ -23,6 +23,7 @@ import {
   AlternateEmail as AlternateEmailIcon,
   SportsTennis as SportsTennisIcon,
 } from "@mui/icons-material";
+import { ChampionshipStatusChips } from "@/components/championship/ChampionshipStatusChips";
 import { Player } from "@/types/team-management";
 
 interface PlayersActiveTableProps {
@@ -151,6 +152,7 @@ export function PlayersActiveTable({
                   <Typography variant="body2" fontWeight="medium">
                     {player.firstName} {player.name}
                   </Typography>
+                  <ChampionshipStatusChips player={player} />
                   {player.hasPlayedAtLeastOneMatch && (
                     <Chip
                       icon={<SportsTennisIcon />}

--- a/src/components/players/PlayersBasicTable.tsx
+++ b/src/components/players/PlayersBasicTable.tsx
@@ -25,6 +25,7 @@ import {
   Edit as EditIcon,
   SportsTennis as SportsTennisIcon,
 } from "@mui/icons-material";
+import { ChampionshipStatusChips } from "@/components/championship/ChampionshipStatusChips";
 import { Player } from "@/types/team-management";
 
 interface PlayersBasicTableProps {
@@ -56,11 +57,18 @@ export function PlayersBasicTable({
   onToggleWheelchair,
 }: PlayersBasicTableProps) {
   const renderLicenseCell = (player: Player) => {
-    if (licenseMode === "withoutLicense") {
-      return <Chip label="Sans licence" color="warning" size="small" />;
-    }
     if (licenseMode === "temporary") {
       return <Chip label="Temporaire" color="error" size="small" />;
+    }
+    if (player.championshipAlerts?.includes("other_club")) {
+      return player.license || (
+        <Chip label="Autre club" color="warning" size="small" />
+      );
+    }
+    if (licenseMode === "withoutLicense") {
+      return player.license || (
+        <Chip label="Sans licence" color="warning" size="small" />
+      );
     }
     return player.license;
   };
@@ -91,6 +99,7 @@ export function PlayersBasicTable({
                   <Typography variant="body2" fontWeight="medium">
                     {player.firstName} {player.name}
                   </Typography>
+                  <ChampionshipStatusChips player={player} />
                   {player.hasPlayedAtLeastOneMatch && (
                     <Chip
                       icon={<SportsTennisIcon />}

--- a/src/hooks/useChampionshipRoster.ts
+++ b/src/hooks/useChampionshipRoster.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchChampionshipRoster } from "@/lib/championship/client";
+import { mergePlayersWithChampionshipRoster } from "@/lib/championship/merge-players";
+import type { ChampionshipRosterView } from "@/lib/championship/merge-players";
+import type { Player } from "@/types/team-management";
+
+export function useChampionshipRoster(players: Player[]) {
+  const [roster, setRoster] = useState<ChampionshipRosterView[]>([]);
+  const [seasonLabel, setSeasonLabel] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [loaded, setLoaded] = useState(false);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchChampionshipRoster();
+      setRoster(result.roster);
+      setSeasonLabel(result.seasonLabel);
+      setLoaded(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur effectif");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const mergedPlayers = loaded
+    ? mergePlayersWithChampionshipRoster(players, roster)
+    : players;
+
+  return { mergedPlayers, roster, seasonLabel, loading, error, reload };
+}

--- a/src/hooks/useCompositionAssignments.ts
+++ b/src/hooks/useCompositionAssignments.ts
@@ -10,6 +10,7 @@ import {
 import { ChampionshipType } from "@/types";
 import { Player } from "@/types/team-management";
 import { CompositionService } from "@/lib/services/composition-service";
+import { resolveIdEpreuveFromEquipes } from "@/lib/shared/epreuve-utils";
 
 interface UseCompositionAssignmentsParams {
   players: Player[];
@@ -178,6 +179,15 @@ export function useCompositionAssignments({
                 phase: selectedPhase,
                 championshipType,
                 teams: newCompositions,
+                ...(resolveIdEpreuveFromEquipes(filteredEquipes, championshipType) !==
+                undefined
+                  ? {
+                      idEpreuve: resolveIdEpreuveFromEquipes(
+                        filteredEquipes,
+                        championshipType
+                      ),
+                    }
+                  : {}),
               });
             } catch (error) {
               console.error("Erreur lors de la sauvegarde:", error);
@@ -228,6 +238,15 @@ export function useCompositionAssignments({
                 phase: selectedPhase,
                 championshipType,
                 teams: newCompositions,
+                ...(resolveIdEpreuveFromEquipes(filteredEquipes, championshipType) !==
+                undefined
+                  ? {
+                      idEpreuve: resolveIdEpreuveFromEquipes(
+                        filteredEquipes,
+                        championshipType
+                      ),
+                    }
+                  : {}),
               });
             } catch (error) {
               console.error("Erreur lors de la sauvegarde:", error);

--- a/src/hooks/useCompositions.ts
+++ b/src/hooks/useCompositions.ts
@@ -11,12 +11,14 @@ interface CompositionParams {
   journee: number | null;
   phase: "aller" | "retour" | null;
   championshipType: ChampionshipType;
+  idEpreuve?: number;
 }
 
 export const useCompositions = ({
   journee,
   phase,
   championshipType,
+  idEpreuve,
 }: CompositionParams) => {
   const {
     subscribeToComposition,
@@ -30,16 +32,16 @@ export const useCompositions = ({
 
   const composition = useTeamManagementStore((state) =>
     journee && phase
-      ? getCompositionByDay(state, { journee, phase, championshipType })
+      ? getCompositionByDay(state, { journee, phase, championshipType, ...(idEpreuve !== undefined ? { idEpreuve } : {}) })
       : null
   );
 
   const key = useMemo(
     () =>
       journee && phase
-        ? getDayKey({ journee, phase, championshipType })
+        ? getDayKey({ journee, phase, championshipType, ...(idEpreuve !== undefined ? { idEpreuve } : {}) })
         : null,
-    [championshipType, journee, phase]
+    [championshipType, idEpreuve, journee, phase]
   );
 
   useEffect(() => {
@@ -47,8 +49,13 @@ export const useCompositions = ({
       return undefined;
     }
 
-    return subscribeToComposition({ journee, phase, championshipType });
-  }, [championshipType, journee, phase, subscribeToComposition]);
+    return subscribeToComposition({
+      journee,
+      phase,
+      championshipType,
+      ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+    });
+  }, [championshipType, idEpreuve, journee, phase, subscribeToComposition]);
 
   return {
     composition: composition as DayComposition | null,

--- a/src/hooks/useCompositionsRealtimeSync.ts
+++ b/src/hooks/useCompositionsRealtimeSync.ts
@@ -3,7 +3,7 @@ import { useAvailabilities } from "@/hooks/useAvailabilities";
 import { useCompositions } from "@/hooks/useCompositions";
 import { EquipeWithMatches } from "@/hooks/useTeamData";
 import { getPlayersByType } from "@/lib/compositions/championship-utils";
-import { getIdEpreuve, isParisEpreuve, EpreuveType } from "@/lib/shared/epreuve-utils";
+import { getIdEpreuve, isParisEpreuve, EpreuveType, resolveIdEpreuveFromEquipes } from "@/lib/shared/epreuve-utils";
 import { Player } from "@/types/team-management";
 import { ChampionshipType } from "@/types";
 
@@ -41,13 +41,25 @@ export function useCompositionsRealtimeSync({
   const [availabilitiesLoaded, setAvailabilitiesLoaded] = useState(false);
 
   const idEpreuve = useMemo(() => getIdEpreuve(selectedEpreuve), [selectedEpreuve]);
+  const masculinIdEpreuve = useMemo(
+    () =>
+      resolveIdEpreuveFromEquipes(equipes, "masculin", selectedEpreuve) ??
+      idEpreuve,
+    [equipes, idEpreuve, selectedEpreuve]
+  );
+  const femininIdEpreuve = useMemo(
+    () =>
+      resolveIdEpreuveFromEquipes(equipes, "feminin", selectedEpreuve) ??
+      idEpreuve,
+    [equipes, idEpreuve, selectedEpreuve]
+  );
 
   const { availability: masculineAvailability, error: errorMasculineAvailability } =
     useAvailabilities({
       journee: selectedJournee,
       phase: selectedPhase,
       championshipType: "masculin",
-      ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+      ...(masculinIdEpreuve !== undefined ? { idEpreuve: masculinIdEpreuve } : {}),
     });
 
   const { availability: feminineAvailability, error: errorFeminineAvailability } =
@@ -55,7 +67,7 @@ export function useCompositionsRealtimeSync({
       journee: selectedJournee,
       phase: selectedPhase,
       championshipType: "feminin",
-      ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+      ...(femininIdEpreuve !== undefined ? { idEpreuve: femininIdEpreuve } : {}),
     });
 
   useEffect(() => {
@@ -86,11 +98,14 @@ export function useCompositionsRealtimeSync({
     : tabValue === 0
     ? "masculin"
     : "feminin";
+  const compositionIdEpreuve =
+    championshipType === "feminin" ? femininIdEpreuve : masculinIdEpreuve;
 
   const { composition: realtimeComposition, error: compositionError } = useCompositions({
     journee: selectedJournee,
     phase: selectedPhase,
     championshipType,
+    ...(compositionIdEpreuve !== undefined ? { idEpreuve: compositionIdEpreuve } : {}),
   });
 
   useEffect(() => {

--- a/src/hooks/useDefaultCompositionAssignments.ts
+++ b/src/hooks/useDefaultCompositionAssignments.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { usePlayerDrag } from "@/hooks/usePlayerDrag";
-import { EpreuveType, isParisEpreuve } from "@/lib/shared/epreuve-utils";
 import { CompositionDefaultsService } from "@/lib/services/composition-defaults-service";
+import { EpreuveType, isParisEpreuve, resolveIdEpreuveFromEquipes } from "@/lib/shared/epreuve-utils";
 import { EquipeWithMatches } from "@/hooks/useTeamData";
 import { ChampionshipType } from "@/types";
 import { Player } from "@/types/team-management";
@@ -12,6 +12,20 @@ import {
 } from "@/lib/compositions/validators";
 
 const MAX_PLAYERS_PER_DEFAULT_TEAM = 5;
+
+function defaultsPayload(
+  phase: "aller" | "retour",
+  championshipType: ChampionshipType,
+  teams: Record<string, string[]>,
+  idEpreuve: number | undefined
+) {
+  return {
+    phase,
+    championshipType,
+    teams,
+    ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+  };
+}
 
 interface DefaultCompositionsState {
   masculin: Record<string, string[]>;
@@ -47,6 +61,11 @@ export function useDefaultCompositionAssignments({
   compositionDefaultsService,
   setDefaultCompositionMessage,
 }: UseDefaultCompositionAssignmentsParams) {
+  const idEpreuveFor = useCallback(
+    (championshipType: ChampionshipType) =>
+      resolveIdEpreuveFromEquipes(equipes, championshipType, selectedEpreuve),
+    [equipes, selectedEpreuve]
+  );
   const canDropPlayer = useCallback(
     (playerId: string, teamId: string): AssignmentValidationResult => {
       const equipe = equipes.find((e) => e.team.id === teamId);
@@ -139,11 +158,14 @@ export function useDefaultCompositionAssignments({
         };
         setDefaultCompositions(nextState);
         try {
-          await compositionDefaultsService.saveDefaults({
-            phase: selectedPhase,
-            championshipType,
-            teams: updatedForType,
-          });
+          await compositionDefaultsService.saveDefaults(
+            defaultsPayload(
+              selectedPhase,
+              championshipType,
+              updatedForType,
+              idEpreuveFor(championshipType)
+            )
+          );
           setDefaultCompositionMessage(null);
           return true;
         } catch {
@@ -171,11 +193,14 @@ export function useDefaultCompositionAssignments({
       });
 
       try {
-        await compositionDefaultsService.saveDefaults({
-          phase: selectedPhase,
-          championshipType,
-          teams: updatedForType,
-        });
+        await compositionDefaultsService.saveDefaults(
+          defaultsPayload(
+            selectedPhase,
+            championshipType,
+            updatedForType,
+            idEpreuveFor(championshipType)
+          )
+        );
         setDefaultCompositionMessage(null);
         return true;
       } catch {
@@ -192,6 +217,7 @@ export function useDefaultCompositionAssignments({
       canDropPlayer,
       selectedEpreuve,
       equipesByType,
+      idEpreuveFor,
       defaultCompositions,
       setDefaultCompositions,
       compositionDefaultsService,
@@ -229,11 +255,14 @@ export function useDefaultCompositionAssignments({
       if (!nextTeamsForType) return;
 
       try {
-        await compositionDefaultsService.saveDefaults({
-          phase: selectedPhase,
-          championshipType,
-          teams: nextTeamsForType,
-        });
+        await compositionDefaultsService.saveDefaults(
+          defaultsPayload(
+            selectedPhase,
+            championshipType,
+            nextTeamsForType,
+            idEpreuveFor(championshipType)
+          )
+        );
       } catch {
         setDefaultCompositionMessage(
           "Erreur lors de la sauvegarde de la composition par défaut."
@@ -246,6 +275,7 @@ export function useDefaultCompositionAssignments({
       selectedEpreuve,
       setDefaultCompositions,
       compositionDefaultsService,
+      idEpreuveFor,
       setDefaultCompositionMessage,
     ]
   );

--- a/src/hooks/useDefaultCompositions.ts
+++ b/src/hooks/useDefaultCompositions.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { CompositionDefaultsService } from "@/lib/services/composition-defaults-service";
+import { EquipeWithMatches } from "@/hooks/useTeamData";
+import { EpreuveType, resolveIdEpreuveFromEquipes } from "@/lib/shared/epreuve-utils";
 
 interface DefaultCompositionsState {
   masculin: Record<string, string[]>;
@@ -8,11 +10,15 @@ interface DefaultCompositionsState {
 
 interface UseDefaultCompositionsParams {
   selectedPhase: "aller" | "retour" | null;
+  selectedEpreuve?: EpreuveType | null;
+  equipes?: EquipeWithMatches[];
   compositionDefaultsService: CompositionDefaultsService;
 }
 
 export function useDefaultCompositions({
   selectedPhase,
+  selectedEpreuve = null,
+  equipes = [],
   compositionDefaultsService,
 }: UseDefaultCompositionsParams) {
   const [defaultCompositions, setDefaultCompositions] =
@@ -35,8 +41,16 @@ export function useDefaultCompositions({
     const loadDefaults = async () => {
       try {
         const [masculineDefaults, feminineDefaults] = await Promise.all([
-          compositionDefaultsService.getDefaults(selectedPhase, "masculin"),
-          compositionDefaultsService.getDefaults(selectedPhase, "feminin"),
+          compositionDefaultsService.getDefaults(
+            selectedPhase,
+            "masculin",
+            resolveIdEpreuveFromEquipes(equipes, "masculin", selectedEpreuve)
+          ),
+          compositionDefaultsService.getDefaults(
+            selectedPhase,
+            "feminin",
+            resolveIdEpreuveFromEquipes(equipes, "feminin", selectedEpreuve)
+          ),
         ]);
 
         setDefaultCompositions({
@@ -55,7 +69,7 @@ export function useDefaultCompositions({
     };
 
     void loadDefaults();
-  }, [selectedPhase, compositionDefaultsService]);
+  }, [equipes, selectedEpreuve, selectedPhase, compositionDefaultsService]);
 
   return {
     defaultCompositions,

--- a/src/hooks/useJoueursCrud.ts
+++ b/src/hooks/useJoueursCrud.ts
@@ -3,6 +3,11 @@ import { doc, getDoc } from "firebase/firestore";
 import { getDbInstanceDirect } from "@/lib/firebase";
 import { Player } from "@/types/team-management";
 import { FirestorePlayerService } from "@/lib/services/firestore-player-service";
+import {
+  createTemporaryChampionshipPlayer,
+  deleteChampionshipRosterPerson,
+  patchChampionshipRosterPerson,
+} from "@/lib/championship/client";
 
 interface JoueurFormState {
   firstName: string;
@@ -114,25 +119,14 @@ export function useJoueursCrud({
         newPlayer.firstName.trim().charAt(0).toUpperCase() +
         newPlayer.firstName.trim().slice(1).toLowerCase();
 
-      await playerService.createTemporaryPlayer({
+      await createTemporaryChampionshipPlayer({
         firstName: normalizedFirstName,
-        name: normalizedName,
-        license: newPlayer.license.trim() || "",
+        lastName: normalizedName,
+        license: newPlayer.license.trim() || undefined,
         gender: newPlayer.gender,
-        nationality: newPlayer.nationality,
-        isActive: false,
-        isTemporary: true,
+        inChampionship: newPlayer.inChampionship,
         isWheelchair: newPlayer.isWheelchair,
-        typeLicence: "",
-        points: newPlayer.points || 500,
-        preferredTeams: { masculine: [], feminine: [] },
-        participation: {
-          championnat: newPlayer.inChampionship,
-          championnatParis: false,
-        },
-        hasPlayedAtLeastOneMatch: false,
-        hasPlayedAtLeastOneMatchParis: false,
-        ...(discordMentions.length > 0 ? { discordMentions } : {}),
+        discordMentions,
       });
 
       await loadPlayers();
@@ -148,7 +142,7 @@ export function useJoueursCrud({
     } finally {
       setCreating(false);
     }
-  }, [discordMentions, licenseExists, loadPlayers, newPlayer, playerService]);
+  }, [discordMentions, licenseExists, loadPlayers, newPlayer]);
 
   const handleEditPlayer = useCallback((player: Player) => {
     setEditingPlayer(player);
@@ -193,30 +187,20 @@ export function useJoueursCrud({
         newPlayer.firstName.trim().charAt(0).toUpperCase() +
         newPlayer.firstName.trim().slice(1).toLowerCase();
 
+      const personKey = editingPlayer.championshipPersonKey || editingPlayer.id;
       if (editingPlayer.isTemporary) {
-        await playerService.updateTemporaryPlayer(editingPlayer.id, {
+        await patchChampionshipRosterPerson(personKey, {
           firstName: normalizedFirstName,
-          name: normalizedName,
-          license: newPlayer.license.trim() || "",
-          gender: newPlayer.gender,
-          nationality: newPlayer.nationality,
-          isActive: false,
+          lastName: normalizedName,
+          ffttLicense: newPlayer.license.trim() || null,
+          sex: newPlayer.gender === "F" ? "female" : "male",
           isTemporary: true,
+          championnat: newPlayer.inChampionship,
           isWheelchair: newPlayer.isWheelchair,
-          typeLicence: editingPlayer.typeLicence || "",
-          points: newPlayer.points || 500,
-          preferredTeams: editingPlayer.preferredTeams || { masculine: [], feminine: [] },
-          participation: {
-            championnat: newPlayer.inChampionship,
-            championnatParis: false,
-          },
-          hasPlayedAtLeastOneMatch: editingPlayer.hasPlayedAtLeastOneMatch || false,
-          hasPlayedAtLeastOneMatchParis:
-            editingPlayer.hasPlayedAtLeastOneMatchParis || false,
-          ...(discordMentions.length > 0 ? { discordMentions } : {}),
+          discordMentions,
         });
       } else {
-        await playerService.updatePlayer(editingPlayer.id, {
+        await patchChampionshipRosterPerson(personKey, {
           discordMentions,
           isWheelchair: newPlayer.isWheelchair,
         });
@@ -285,7 +269,6 @@ export function useJoueursCrud({
     editingPlayer,
     licenseExistsForOther,
     newPlayer,
-    playerService,
     players,
     playersWithoutLicense,
     recomputeFilteredPlayersFromLists,
@@ -304,7 +287,9 @@ export function useJoueursCrud({
       if (!confirmDelete) return;
       try {
         setDeleting(player.id);
-        await playerService.deletePlayer(player.id);
+        await deleteChampionshipRosterPerson(
+          player.championshipPersonKey || player.id
+        );
         removePlayerFromStore(player.id);
         await loadPlayers();
       } catch (error) {
@@ -314,7 +299,7 @@ export function useJoueursCrud({
         setDeleting(null);
       }
     },
-    [loadPlayers, playerService, removePlayerFromStore]
+    [loadPlayers, removePlayerFromStore]
   );
 
   return {

--- a/src/hooks/useJoueursRosterToggles.ts
+++ b/src/hooks/useJoueursRosterToggles.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback } from "react";
+import { patchChampionshipRosterPerson } from "@/lib/championship/client";
+import type { Player } from "@/types/team-management";
+
+function rosterKey(player: Player): string {
+  return player.championshipPersonKey || player.id;
+}
+
+type Params = {
+  players: Player[];
+  playersWithoutLicense: Player[];
+  temporaryPlayers: Player[];
+  setPlayers: React.Dispatch<React.SetStateAction<Player[]>>;
+  setPlayersWithoutLicense: React.Dispatch<React.SetStateAction<Player[]>>;
+  setTemporaryPlayers: React.Dispatch<React.SetStateAction<Player[]>>;
+  setFilteredPlayers?: React.Dispatch<React.SetStateAction<Player[]>>;
+  updatePlayerInStore: (playerId: string, updates: Partial<Player>) => void;
+  recomputeFilteredPlayersFromLists: (
+    nextPlayers: Player[],
+    nextPlayersWithoutLicense: Player[],
+    nextTemporaryPlayers: Player[]
+  ) => void;
+};
+
+function mapPlayer(
+  list: Player[],
+  playerId: string,
+  updates: Partial<Player>
+): Player[] {
+  return list.map((item) =>
+    item.id === playerId ? { ...item, ...updates } : item
+  );
+}
+
+export function useJoueursRosterToggles({
+  players,
+  playersWithoutLicense,
+  temporaryPlayers,
+  setPlayers,
+  setPlayersWithoutLicense,
+  setTemporaryPlayers,
+  setFilteredPlayers,
+  updatePlayerInStore,
+  recomputeFilteredPlayersFromLists,
+}: Params) {
+  const applyLocal = useCallback(
+    (playerId: string, updates: Partial<Player>) => {
+      const nextPlayers = mapPlayer(players, playerId, updates);
+      const nextWithout = mapPlayer(playersWithoutLicense, playerId, updates);
+      const nextTemporary = mapPlayer(temporaryPlayers, playerId, updates);
+      setPlayers(nextPlayers);
+      setPlayersWithoutLicense(nextWithout);
+      setTemporaryPlayers(nextTemporary);
+      setFilteredPlayers?.((prev) => mapPlayer(prev, playerId, updates));
+      updatePlayerInStore(playerId, updates);
+      recomputeFilteredPlayersFromLists(nextPlayers, nextWithout, nextTemporary);
+    },
+    [
+      players,
+      playersWithoutLicense,
+      temporaryPlayers,
+      recomputeFilteredPlayersFromLists,
+      setFilteredPlayers,
+      setPlayers,
+      setPlayersWithoutLicense,
+      setTemporaryPlayers,
+      updatePlayerInStore,
+    ]
+  );
+
+  const handleToggleParticipation = useCallback(
+    async (player: Player, isParticipating: boolean) => {
+      try {
+        await patchChampionshipRosterPerson(rosterKey(player), {
+          championnat: isParticipating,
+        });
+        applyLocal(player.id, {
+          participation: { ...player.participation, championnat: isParticipating },
+        });
+      } catch (error) {
+        console.error("Erreur lors de la mise à jour de la participation:", error);
+      }
+    },
+    [applyLocal]
+  );
+
+  const handleToggleParticipationParis = useCallback(
+    async (player: Player, inChampionshipParis: boolean) => {
+      try {
+        await patchChampionshipRosterPerson(rosterKey(player), {
+          championnatParis: inChampionshipParis,
+        });
+        applyLocal(player.id, {
+          participation: {
+            ...player.participation,
+            championnatParis: inChampionshipParis,
+          },
+        });
+      } catch (error) {
+        console.error(
+          "Erreur lors de la mise à jour de la participation au championnat de Paris:",
+          error
+        );
+        alert("Erreur lors de la mise à jour de la participation");
+      }
+    },
+    [applyLocal]
+  );
+
+  const handleToggleWheelchair = useCallback(
+    async (player: Player) => {
+      const next = !player.isWheelchair;
+      applyLocal(player.id, { isWheelchair: next });
+      try {
+        await patchChampionshipRosterPerson(rosterKey(player), {
+          isWheelchair: next,
+        });
+      } catch (error) {
+        console.error("Erreur lors de la mise à jour du flag fauteuil:", error);
+        applyLocal(player.id, { isWheelchair: player.isWheelchair === true });
+      }
+    },
+    [applyLocal]
+  );
+
+  return {
+    handleToggleParticipation,
+    handleToggleParticipationParis,
+    handleToggleWheelchair,
+  };
+}

--- a/src/hooks/useTeamData.ts
+++ b/src/hooks/useTeamData.ts
@@ -15,7 +15,10 @@ interface TeamDataState {
   currentPhase: "aller" | "retour";
 }
 
-export function useTeamData(): TeamDataState {
+export function useTeamData(options?: {
+  refreshOnMount?: boolean;
+}): TeamDataState {
+  const refreshOnMount = options?.refreshOnMount === true;
   const {
     equipesWithMatches,
     equipesLoading,
@@ -29,10 +32,22 @@ export function useTeamData(): TeamDataState {
   }));
 
   useEffect(() => {
+    if (!refreshOnMount) return;
+    void loadEquipesWithMatches();
+  }, [loadEquipesWithMatches, refreshOnMount]);
+
+  useEffect(() => {
+    if (refreshOnMount) return;
     if (!equipesWithMatches.length && !equipesLoading && !equipesError) {
       void loadEquipesWithMatches();
     }
-  }, [equipesError, equipesLoading, equipesWithMatches.length, loadEquipesWithMatches]);
+  }, [
+    equipesError,
+    equipesLoading,
+    equipesWithMatches.length,
+    loadEquipesWithMatches,
+    refreshOnMount,
+  ]);
 
   const currentPhase = useMemo(() => {
     if (equipesWithMatches.length === 0) {

--- a/src/lib/auth/audit-logger.ts
+++ b/src/lib/auth/audit-logger.ts
@@ -109,4 +109,7 @@ export const AUDIT_ACTIONS = {
   ATTENDANCE_LEAD_CREATED: "attendance.lead.created",
   ATTENDANCE_LEAD_UPDATED: "attendance.lead.updated",
   ATTENDANCE_SLOT_ADDED: "attendance.slot.added",
+  CHAMPIONSHIP_ROSTER_RECALCULATED: "championship.roster.recalculated",
+  CHAMPIONSHIP_ROSTER_UPDATED: "championship.roster.updated",
+  CHAMPIONSHIP_ROSTER_DELETED: "championship.roster.deleted",
 } as const;

--- a/src/lib/championship/access.ts
+++ b/src/lib/championship/access.ts
@@ -1,0 +1,18 @@
+import { hasAnyRole, USER_ROLES, type UserRole } from "@/lib/auth/roles";
+
+/** Lecture / toggles championnat — aligné sur compositions, dispos, joueurs. */
+export const CHAMPIONSHIP_ROSTER_ROLES = [
+  USER_ROLES.ADMIN,
+  USER_ROLES.COACH,
+] as const;
+
+/** Recalcul d’effectif — page admin synchronisation, ADMIN uniquement. */
+export const CHAMPIONSHIP_RECALCULATE_ROLES = [USER_ROLES.ADMIN] as const;
+
+export function canAccessChampionshipRoster(role: UserRole): boolean {
+  return hasAnyRole(role, CHAMPIONSHIP_ROSTER_ROLES);
+}
+
+export function canRecalculateChampionshipRoster(role: UserRole): boolean {
+  return hasAnyRole(role, CHAMPIONSHIP_RECALCULATE_ROLES);
+}

--- a/src/lib/championship/api-auth.ts
+++ b/src/lib/championship/api-auth.ts
@@ -1,0 +1,35 @@
+import { cookies } from "next/headers";
+import { adminAuth } from "@/lib/firebase-admin";
+import { resolveRole, type UserRole } from "@/lib/auth/roles";
+import {
+  canAccessChampionshipRoster,
+  canRecalculateChampionshipRoster,
+} from "./access";
+
+export type ChampionshipActor =
+  | { ok: true; uid: string; role: UserRole }
+  | { ok: false; status: 401 | 403; error: string };
+
+async function requireActor(
+  allowed: (role: UserRole) => boolean
+): Promise<ChampionshipActor> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get("__session")?.value;
+  if (!sessionCookie) {
+    return { ok: false, status: 401, error: "Authentification requise" };
+  }
+  const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+  const role = resolveRole(decoded.role as string | undefined);
+  if (!allowed(role)) {
+    return { ok: false, status: 403, error: "Accès refusé" };
+  }
+  return { ok: true, uid: decoded.uid, role };
+}
+
+export function requireChampionshipRosterActor(): Promise<ChampionshipActor> {
+  return requireActor(canAccessChampionshipRoster);
+}
+
+export function requireChampionshipRecalculateActor(): Promise<ChampionshipActor> {
+  return requireActor(canRecalculateChampionshipRoster);
+}

--- a/src/lib/championship/apply-match-sync-to-roster.ts
+++ b/src/lib/championship/apply-match-sync-to-roster.ts
@@ -1,0 +1,97 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { championshipPlayersCollection } from "./store";
+
+export type MatchSyncBurnoutUpdate = Record<string, unknown>;
+
+function remapMatchSyncUpdates(
+  playerId: string,
+  seasonLabel: string,
+  updates: MatchSyncBurnoutUpdate
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {
+    personKey: playerId,
+    seasonLabel,
+    ffttLicense: playerId,
+    coachExcluded: false,
+    includedFromDossier: false,
+    ...updates,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+  if (next["participation.championnat"] === true) {
+    next.championnat = true;
+    delete next["participation.championnat"];
+  }
+  if (next["participation.championnatParis"] === true) {
+    next.championnatParis = true;
+    delete next["participation.championnatParis"];
+  }
+  return next;
+}
+
+export async function applyMatchSyncUpdatesToRoster(
+  db: Firestore,
+  seasonLabel: string,
+  playerId: string,
+  updates: MatchSyncBurnoutUpdate
+): Promise<void> {
+  if (Object.keys(updates).length === 0) {
+    return;
+  }
+  await championshipPlayersCollection(db, seasonLabel)
+    .doc(playerId)
+    .set(remapMatchSyncUpdates(playerId, seasonLabel, updates), { merge: true });
+}
+
+export async function loadChampionshipPlayersByIds(
+  db: Firestore,
+  seasonLabel: string,
+  playerIds: string[]
+): Promise<Map<string, Record<string, unknown>>> {
+  const map = new Map<string, Record<string, unknown>>();
+  const col = championshipPlayersCollection(db, seasonLabel);
+  const chunkSize = 10;
+  for (let i = 0; i < playerIds.length; i += chunkSize) {
+    const refs = playerIds.slice(i, i + chunkSize).map((id) => col.doc(id));
+    if (refs.length === 0) {
+      continue;
+    }
+    const docs = await db.getAll(...refs);
+    for (const doc of docs) {
+      if (doc.exists) {
+        map.set(doc.id, doc.data() as Record<string, unknown>);
+      }
+    }
+  }
+  return map;
+}
+
+export async function commitMatchSyncUpdatesToRoster(
+  db: Firestore,
+  seasonLabel: string,
+  playersToUpdate: Array<{ playerId: string; updates: MatchSyncBurnoutUpdate }>
+): Promise<{ updated: number; errors: number }> {
+  let updated = 0;
+  let errors = 0;
+  const batchSize = 400;
+  for (let i = 0; i < playersToUpdate.length; i += batchSize) {
+    const batch = db.batch();
+    const slice = playersToUpdate.slice(i, i + batchSize);
+    for (const { playerId, updates } of slice) {
+      batch.set(
+        championshipPlayersCollection(db, seasonLabel).doc(playerId),
+        remapMatchSyncUpdates(playerId, seasonLabel, updates),
+        { merge: true }
+      );
+      updated += 1;
+    }
+    try {
+      await batch.commit();
+    } catch (error) {
+      console.error("❌ Erreur lors du commit du brûlage roster:", error);
+      errors += slice.length;
+      updated -= slice.length;
+    }
+  }
+  return { updated, errors };
+}

--- a/src/lib/championship/backfill-profiles.ts
+++ b/src/lib/championship/backfill-profiles.ts
@@ -1,0 +1,40 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { PLAYER_CLUB_PROFILES_COLLECTION } from "./paths";
+
+export async function backfillPlayerClubProfilesFromPlayers(
+  db: Firestore
+): Promise<{ copied: number }> {
+  const snap = await db.collection("players").get();
+  let copied = 0;
+  const chunkSize = 400;
+  const docs = snap.docs.filter((doc) => {
+    const data = doc.data();
+    return (
+      Array.isArray(data.discordMentions) && data.discordMentions.length > 0
+    ) || data.isWheelchair === true;
+  });
+
+  for (let i = 0; i < docs.length; i += chunkSize) {
+    const batch = db.batch();
+    for (const doc of docs.slice(i, i + chunkSize)) {
+      const data = doc.data();
+      const personKey = String(data.licence ?? doc.id).replace(/\D/g, "") || doc.id;
+      batch.set(
+        db.collection(PLAYER_CLUB_PROFILES_COLLECTION).doc(personKey),
+        {
+          personKey,
+          discordMentions: Array.isArray(data.discordMentions)
+            ? data.discordMentions.filter((item: unknown) => typeof item === "string")
+            : [],
+          isWheelchair: data.isWheelchair === true,
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+      copied += 1;
+    }
+    await batch.commit();
+  }
+  return { copied };
+}

--- a/src/lib/championship/client.ts
+++ b/src/lib/championship/client.ts
@@ -1,0 +1,80 @@
+import type { ChampionshipRosterView } from "./merge-players";
+import type { RosterParticipationPatch } from "./schema";
+import { temporaryPersonKey } from "./person-key";
+
+export async function fetchChampionshipRoster(): Promise<{
+  seasonLabel: string;
+  roster: ChampionshipRosterView[];
+}> {
+  const response = await fetch("/api/club/championship/roster");
+  if (!response.ok) {
+    throw new Error("Impossible de charger l'effectif championnat");
+  }
+  return (await response.json()) as {
+    seasonLabel: string;
+    roster: ChampionshipRosterView[];
+  };
+}
+
+export async function patchChampionshipRosterPerson(
+  personKey: string,
+  patch: RosterParticipationPatch
+): Promise<{ personKey: string }> {
+  const response = await fetch(
+    `/api/club/championship/roster/${encodeURIComponent(personKey)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    }
+  );
+  if (!response.ok) {
+    throw new Error("Impossible de mettre à jour l'effectif championnat");
+  }
+  return (await response.json()) as { personKey: string };
+}
+
+export async function deleteChampionshipRosterPerson(
+  personKey: string
+): Promise<void> {
+  const response = await fetch(
+    `/api/club/championship/roster/${encodeURIComponent(personKey)}`,
+    { method: "DELETE" }
+  );
+  if (!response.ok) {
+    throw new Error("Impossible de supprimer le joueur temporaire");
+  }
+}
+
+export async function createTemporaryChampionshipPlayer(input: {
+  firstName: string;
+  lastName: string;
+  license?: string | undefined;
+  gender: "M" | "F";
+  inChampionship: boolean;
+  isWheelchair: boolean;
+  discordMentions: string[];
+}): Promise<string> {
+  const personKey = temporaryPersonKey(input.license);
+  const result = await patchChampionshipRosterPerson(personKey, {
+    firstName: input.firstName,
+    lastName: input.lastName,
+    ffttLicense: input.license?.trim() ? input.license.trim() : null,
+    sex: input.gender === "F" ? "female" : "male",
+    isTemporary: true,
+    championnat: input.inChampionship,
+    championnatParis: false,
+    isWheelchair: input.isWheelchair,
+    discordMentions: input.discordMentions,
+  });
+  return result.personKey;
+}
+
+export async function recalculateChampionshipRoster(): Promise<void> {
+  const response = await fetch("/api/club/championship/roster", {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error("Impossible de recalculer l'effectif championnat");
+  }
+}

--- a/src/lib/championship/competition-mapping.test.ts
+++ b/src/lib/championship/competition-mapping.test.ts
@@ -1,0 +1,22 @@
+import {
+  flagsFromCompetitionIds,
+  hasChampionshipCompetitionIntent,
+} from "./competition-mapping";
+
+describe("flagsFromCompetitionIds", () => {
+  it("maps equipe and paris independently", () => {
+    expect(
+      flagsFromCompetitionIds(["championnat_equipe", "criterium_federal_seniors"])
+    ).toEqual({ championnat: true, championnatParis: false });
+    expect(flagsFromCompetitionIds(["championnat_paris"])).toEqual({
+      championnat: false,
+      championnatParis: true,
+    });
+  });
+
+  it("ignores youth competitions for the equipes pool", () => {
+    expect(
+      hasChampionshipCompetitionIntent(["championnat_jeunes", "criterium_federal_jeunes"])
+    ).toBe(false);
+  });
+});

--- a/src/lib/championship/competition-mapping.ts
+++ b/src/lib/championship/competition-mapping.ts
@@ -1,0 +1,24 @@
+export const CHAMPIONNAT_EQUIPE_COMPETITION_ID = "championnat_equipe";
+export const CHAMPIONNAT_PARIS_COMPETITION_ID = "championnat_paris";
+
+export type ChampionshipCompetitionFlags = {
+  championnat: boolean;
+  championnatParis: boolean;
+};
+
+export function flagsFromCompetitionIds(
+  competitionIds: readonly string[] | null | undefined
+): ChampionshipCompetitionFlags {
+  const ids = new Set(competitionIds ?? []);
+  return {
+    championnat: ids.has(CHAMPIONNAT_EQUIPE_COMPETITION_ID),
+    championnatParis: ids.has(CHAMPIONNAT_PARIS_COMPETITION_ID),
+  };
+}
+
+export function hasChampionshipCompetitionIntent(
+  competitionIds: readonly string[] | null | undefined
+): boolean {
+  const flags = flagsFromCompetitionIds(competitionIds);
+  return flags.championnat || flags.championnatParis;
+}

--- a/src/lib/championship/license-presence.test.ts
+++ b/src/lib/championship/license-presence.test.ts
@@ -1,0 +1,71 @@
+import { resolveLicensePresence } from "./license-presence";
+
+describe("resolveLicensePresence", () => {
+  it("returns none without a license number", () => {
+    expect(resolveLicensePresence({})).toBe("none");
+  });
+
+  it("returns in_club_list when the club list has a current T/P/A type", () => {
+    expect(
+      resolveLicensePresence({
+        ffttLicense: "7886788",
+        listedInClub: true,
+        typeLicence: "T",
+      })
+    ).toBe("in_club_list");
+  });
+
+  it("treats a club-list affiliate without a season type as unlicensed", () => {
+    expect(
+      resolveLicensePresence({
+        ffttLicense: "5984668",
+        listedInClub: true,
+        typeLicence: null,
+        playerNomClub: "SQY PING",
+      })
+    ).toBe("fftt_sqy_unlicensed");
+  });
+
+  it("treats leftover last-season T/P/A on a SQY affiliation as unlicensed", () => {
+    expect(
+      resolveLicensePresence({
+        ffttLicense: "1234567",
+        listedInClub: false,
+        typeLicence: "T",
+        playerNomClub: "SQY PING",
+      })
+    ).toBe("fftt_sqy_unlicensed");
+  });
+
+  it("flags Deshayes-style SQY affiliation without a season licence", () => {
+    expect(
+      resolveLicensePresence({
+        ffttLicense: "7876509",
+        listedInClub: false,
+        typeLicence: null,
+        playerNomClub: "SQY PING",
+      })
+    ).toBe("fftt_sqy_unlicensed");
+  });
+
+  it("flags Marly-style other federation from license validation", () => {
+    expect(
+      resolveLicensePresence({
+        ffttLicense: "25260171435",
+        listedInClub: false,
+        licenseValidationStatus: "other_federation",
+      })
+    ).toBe("other_federation");
+  });
+
+  it("flags a mutation to another club", () => {
+    expect(
+      resolveLicensePresence({
+        ffttLicense: "7859322",
+        listedInClub: false,
+        typeLicence: "T",
+        playerNomClub: "CHESNAY 78 AS",
+      })
+    ).toBe("other_club");
+  });
+});

--- a/src/lib/championship/license-presence.ts
+++ b/src/lib/championship/license-presence.ts
@@ -1,0 +1,40 @@
+import { isPlayableLicenseType } from "@/lib/players/current-club-license";
+import type { LicensePresence } from "./schema";
+
+export type LicensePresenceInput = {
+  ffttLicense?: string | null;
+  listedInClub?: boolean | null;
+  typeLicence?: string | null;
+  licenseValidationStatus?: string | null;
+  playerNomClub?: string | null;
+};
+
+const SQY_CLUB_NAME_RE = /sqy\s*ping/i;
+
+export function resolveLicensePresence(input: LicensePresenceInput): LicensePresence {
+  const license = (input.ffttLicense ?? "").replace(/\D/g, "");
+  if (!license) {
+    return "none";
+  }
+  if (input.licenseValidationStatus === "other_federation") {
+    return "other_federation";
+  }
+  if (input.listedInClub === true) {
+    return isPlayableLicenseType(input.typeLicence)
+      ? "in_club_list"
+      : "fftt_sqy_unlicensed";
+  }
+  const nomClub = input.playerNomClub ?? "";
+  const stillSqy = SQY_CLUB_NAME_RE.test(nomClub);
+  if (nomClub.trim() && !stillSqy) {
+    return "other_club";
+  }
+  // Last-season T/P/A leftover on a SQY affiliation is not a current club licence.
+  if (input.listedInClub === false) {
+    return "fftt_sqy_unlicensed";
+  }
+  if (stillSqy && (input.typeLicence ?? "").trim() === "") {
+    return "fftt_sqy_unlicensed";
+  }
+  return "unknown";
+}

--- a/src/lib/championship/license-presence.ts
+++ b/src/lib/championship/license-presence.ts
@@ -1,5 +1,5 @@
 import { isPlayableLicenseType } from "@/lib/players/current-club-license";
-import type { LicensePresence } from "./schema";
+import type { LicensePresence } from "./records";
 
 export type LicensePresenceInput = {
   ffttLicense?: string | null;

--- a/src/lib/championship/list-roster-views.ts
+++ b/src/lib/championship/list-roster-views.ts
@@ -1,0 +1,35 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { PLAYER_CLUB_PROFILES_COLLECTION } from "./paths";
+import { listChampionshipPlayers } from "./store";
+import type { ChampionshipRosterView } from "./merge-players";
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+export async function listChampionshipRosterViews(
+  db: Firestore,
+  seasonLabel: string
+): Promise<ChampionshipRosterView[]> {
+  const [roster, profilesSnap] = await Promise.all([
+    listChampionshipPlayers(db, seasonLabel),
+    db.collection(PLAYER_CLUB_PROFILES_COLLECTION).get(),
+  ]);
+  const profiles = new Map(
+    profilesSnap.docs.map((doc) => [doc.id, doc.data() as Record<string, unknown>])
+  );
+
+  return roster.map((entry) => {
+    const profile =
+      profiles.get(entry.personKey) ??
+      (entry.ffttLicense ? profiles.get(entry.ffttLicense) : undefined);
+    return {
+      ...entry,
+      id: entry.personKey,
+      discordMentions: asStringArray(profile?.discordMentions),
+      isWheelchair: profile?.isWheelchair === true,
+    };
+  });
+}

--- a/src/lib/championship/load-merged-players.ts
+++ b/src/lib/championship/load-merged-players.ts
@@ -1,0 +1,34 @@
+import { fetchChampionshipRoster } from "./client";
+import { mergePlayersWithChampionshipRoster } from "./merge-players";
+import type { Player } from "@/types/team-management";
+
+export async function mergeLoadedPlayersWithRoster(
+  players: Player[]
+): Promise<Player[]> {
+  try {
+    const { roster } = await fetchChampionshipRoster();
+    return mergePlayersWithChampionshipRoster(players, roster);
+  } catch {
+    return players;
+  }
+}
+
+export function splitMergedPlayersByTab(merged: Player[]): {
+  active: Player[];
+  withoutLicense: Player[];
+  temporary: Player[];
+} {
+  const active: Player[] = [];
+  const withoutLicense: Player[] = [];
+  const temporary: Player[] = [];
+  for (const player of merged) {
+    if (player.isTemporary) {
+      temporary.push(player);
+    } else if (player.isActive) {
+      active.push(player);
+    } else {
+      withoutLicense.push(player);
+    }
+  }
+  return { active, withoutLicense, temporary };
+}

--- a/src/lib/championship/mark-listed-in-club.ts
+++ b/src/lib/championship/mark-listed-in-club.ts
@@ -1,0 +1,46 @@
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+
+const PLAYERS = "players";
+
+export async function markPlayersListedInClub(
+  db: Firestore,
+  listedLicences: Iterable<string>
+): Promise<{ listed: number; unlisted: number }> {
+  const listed = new Set(
+    [...listedLicences].map((licence) => licence.replace(/\D/g, "")).filter(Boolean)
+  );
+  const snap = await db.collection(PLAYERS).get();
+  let listedCount = 0;
+  let unlistedCount = 0;
+  const now = FieldValue.serverTimestamp();
+
+  const pending: Array<{ ref: DocumentReference; listedInClub: boolean }> = [];
+  for (const doc of snap.docs) {
+    const licence = String(doc.data().licence ?? doc.id).replace(/\D/g, "");
+    const listedInClub = listed.has(licence) || listed.has(doc.id);
+    pending.push({ ref: doc.ref, listedInClub });
+    if (listedInClub) {
+      listedCount += 1;
+    } else {
+      unlistedCount += 1;
+    }
+  }
+
+  const chunkSize = 400;
+  for (let i = 0; i < pending.length; i += chunkSize) {
+    const batch = db.batch();
+    for (const item of pending.slice(i, i + chunkSize)) {
+      batch.set(
+        item.ref,
+        item.listedInClub
+          ? { listedInClub: true, lastSeenInClubListAt: now }
+          : { listedInClub: false, typeLicence: FieldValue.delete() },
+        { merge: true }
+      );
+    }
+    await batch.commit();
+  }
+
+  return { listed: listedCount, unlisted: unlistedCount };
+}

--- a/src/lib/championship/merge-players.test.ts
+++ b/src/lib/championship/merge-players.test.ts
@@ -1,0 +1,170 @@
+import { mergePlayersWithChampionshipRoster } from "./merge-players";
+import type { ChampionshipRosterView } from "./merge-players";
+import type { Player } from "@/types/team-management";
+
+function player(partial: Partial<Player> & Pick<Player, "id" | "name" | "firstName">): Player {
+  return {
+    license: partial.id,
+    typeLicence: "T",
+    gender: "M",
+    nationality: "FR",
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    preferredTeams: { masculine: [], feminine: [] },
+    participation: { championnat: true, championnatParis: false },
+    ...partial,
+  };
+}
+
+function roster(
+  partial: Partial<ChampionshipRosterView> & Pick<ChampionshipRosterView, "id" | "personKey">
+): ChampionshipRosterView {
+  return {
+    seasonLabel: "2026-2027",
+    registrationId: null,
+    ffttLicense: partial.id,
+    firstName: "A",
+    lastName: "B",
+    includedFromDossier: true,
+    coachIncluded: false,
+    coachExcluded: false,
+    championnat: true,
+    championnatParis: false,
+    paymentStatus: "paid",
+    registrationStatus: "paid",
+    licensePresence: "in_club_list",
+    licenseValidationStatus: null,
+    preferredTeams: { masculine: [], feminine: [] },
+    isTemporary: false,
+    discordMentions: [],
+    isWheelchair: false,
+    ...partial,
+  };
+}
+
+describe("mergePlayersWithChampionshipRoster", () => {
+  it("flags a leftover player who moved to another club", () => {
+    const merged = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "7859322",
+          name: "LECHEMINANT",
+          firstName: "Claude",
+          listedInClub: false,
+          nomClub: "CHESNAY 78 AS",
+          typeLicence: "T",
+        }),
+      ],
+      []
+    );
+    expect(merged[0].isActive).toBe(false);
+    expect(merged[0].championshipAlerts).toEqual(["other_club"]);
+  });
+
+  it("clears last-season participation when the player is absent from the roster", () => {
+    const merged = mergePlayersWithChampionshipRoster(
+      [player({ id: "111", name: "OLD", firstName: "Ghost" })],
+      []
+    );
+    expect(merged[0].participation.championnat).toBe(false);
+  });
+
+  it("adds a dossier-only competitor missing from players", () => {
+    const merged = mergePlayersWithChampionshipRoster(
+      [],
+      [
+        roster({
+          id: "reg_abc",
+          personKey: "reg_abc",
+          ffttLicense: null,
+          firstName: "Laurent",
+          lastName: "DESHAYES",
+          licensePresence: "none",
+          paymentStatus: "pending",
+        }),
+      ]
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe("reg_abc");
+    expect(merged[0].championshipAlerts).toEqual(["unpaid", "no_license"]);
+  });
+
+  it("does not treat a roster in_club_list flag as a current FFTT licence", () => {
+    const merged = mergePlayersWithChampionshipRoster(
+      [player({ id: "111", name: "A", firstName: "B", listedInClub: false })],
+      [roster({ id: "111", personKey: "111", licensePresence: "in_club_list" })]
+    );
+    expect(merged[0].listedInClub).toBe(false);
+    expect(merged[0].participation.championnat).toBe(true);
+    expect(merged[0].typeLicence).toBe("");
+    expect(merged[0].isActive).toBe(false);
+  });
+
+  it("hides last-season licence types when the player is off the club list", () => {
+    const leftover = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "111",
+          name: "OLD",
+          firstName: "Ghost",
+          listedInClub: false,
+          typeLicence: "T",
+          isActive: true,
+        }),
+      ],
+      []
+    );
+    expect(leftover[0].isActive).toBe(false);
+    expect(leftover[0].typeLicence).toBe("");
+
+    const onRoster = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "111",
+          name: "OLD",
+          firstName: "Ghost",
+          listedInClub: false,
+          typeLicence: "T",
+          isActive: true,
+        }),
+      ],
+      [roster({ id: "111", personKey: "111", licensePresence: "unknown" })]
+    );
+    expect(onRoster[0].isActive).toBe(false);
+    expect(onRoster[0].typeLicence).toBe("");
+  });
+
+  it("does not keep last-season burnout from the FFTT player mirror", () => {
+    const lastSeasonBurnout = { aller: 4, retour: 6 };
+    const withoutRoster = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "111",
+          name: "OLD",
+          firstName: "Ghost",
+          highestMasculineTeamNumberByPhase: lastSeasonBurnout,
+          hasPlayedAtLeastOneMatch: true,
+        }),
+      ],
+      []
+    );
+    expect(withoutRoster[0].highestMasculineTeamNumberByPhase).toBeUndefined();
+    expect(withoutRoster[0].hasPlayedAtLeastOneMatch).toBe(false);
+
+    const onRoster = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "111",
+          name: "A",
+          firstName: "B",
+          highestMasculineTeamNumberByPhase: lastSeasonBurnout,
+          hasPlayedAtLeastOneMatch: true,
+        }),
+      ],
+      [roster({ id: "111", personKey: "111" })]
+    );
+    expect(onRoster[0].highestMasculineTeamNumberByPhase).toBeUndefined();
+    expect(onRoster[0].hasPlayedAtLeastOneMatch).toBe(false);
+  });
+});

--- a/src/lib/championship/merge-players.ts
+++ b/src/lib/championship/merge-players.ts
@@ -1,0 +1,216 @@
+import { currentClubLicenseFields } from "@/lib/players/current-club-license";
+import { resolveLicensePresence } from "./license-presence";
+import type { ChampionshipPlayerRecord, LicensePresence } from "./schema";
+import type { Player } from "@/types/team-management";
+
+export type ChampionshipAlertCode =
+  | "unpaid"
+  | "payment_requested"
+  | "not_in_club_list"
+  | "fftt_sqy_unlicensed"
+  | "other_club"
+  | "other_federation"
+  | "no_license";
+
+export type ChampionshipRosterView = ChampionshipPlayerRecord & {
+  id: string;
+  discordMentions: string[];
+  isWheelchair: boolean;
+};
+
+const EMPTY_TEAMS = { masculine: [] as string[], feminine: [] as string[] };
+
+const SEASONAL_MATCH_STAT_KEYS = [
+  "hasPlayedAtLeastOneMatch",
+  "hasPlayedAtLeastOneMatchParis",
+  "highestMasculineTeamNumberByPhase",
+  "highestFeminineTeamNumberByPhase",
+  "highestTeamNumberByPhaseParis",
+  "masculineMatchesByTeamByPhase",
+  "feminineMatchesByTeamByPhase",
+  "matchesByTeamByPhaseParis",
+] as const;
+
+function withoutSeasonalMatchStats(player: Player): Player {
+  const rest: Record<string, unknown> = { ...player };
+  for (const key of SEASONAL_MATCH_STAT_KEYS) {
+    delete rest[key];
+  }
+  return rest as unknown as Player;
+}
+
+function withCurrentClubLicense(player: Player): Player {
+  return { ...player, ...currentClubLicenseFields(player) };
+}
+
+function alertsFromPlayerMirror(player: Player): ChampionshipAlertCode[] {
+  return alertsFromRoster({
+    licensePresence: resolveLicensePresence({
+      ffttLicense: player.license,
+      listedInClub: player.listedInClub === true,
+      typeLicence: player.typeLicence,
+      playerNomClub: player.nomClub ?? player.club ?? null,
+    }),
+  });
+}
+
+export function alertsFromRoster(record: {
+  paymentStatus?: string | null;
+  licensePresence: LicensePresence;
+}): ChampionshipAlertCode[] {
+  const alerts: ChampionshipAlertCode[] = [];
+  if (record.paymentStatus === "payment_requested") {
+    alerts.push("payment_requested");
+  } else if (record.paymentStatus && record.paymentStatus !== "paid") {
+    alerts.push("unpaid");
+  }
+  switch (record.licensePresence) {
+    case "none":
+      alerts.push("no_license");
+      break;
+    case "in_club_list":
+      break;
+    case "fftt_sqy_unlicensed":
+      alerts.push("fftt_sqy_unlicensed");
+      break;
+    case "other_club":
+      alerts.push("other_club");
+      break;
+    case "other_federation":
+      alerts.push("other_federation");
+      break;
+    case "unknown":
+      alerts.push("not_in_club_list");
+      break;
+    default:
+      break;
+  }
+  return alerts;
+}
+
+function emptyPlayer(id: string): Player {
+  return {
+    id,
+    name: "",
+    firstName: "",
+    license: "",
+    typeLicence: "",
+    gender: "M",
+    nationality: "FR",
+    isActive: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    preferredTeams: { ...EMPTY_TEAMS },
+    participation: {},
+  };
+}
+
+export function mergePlayersWithChampionshipRoster(
+  players: Player[],
+  roster: ChampionshipRosterView[]
+): Player[] {
+  const byId = new Map(players.map((player) => [player.id, { ...player }]));
+  const rosterByLicense = new Map<string, ChampionshipRosterView>();
+
+  for (const entry of roster) {
+    rosterByLicense.set(entry.id, entry);
+    const license = entry.ffttLicense;
+    if (license) {
+      rosterByLicense.set(license, entry);
+    }
+  }
+
+  const mergedIds = new Set<string>();
+  const result: Player[] = [];
+
+  for (const player of byId.values()) {
+    const entry =
+      rosterByLicense.get(player.id) ??
+      (player.license ? rosterByLicense.get(player.license) : undefined);
+    if (!entry) {
+      result.push(
+        withCurrentClubLicense({
+          ...withoutSeasonalMatchStats(player),
+          participation: {
+            ...player.participation,
+            championnat: false,
+            championnatParis: false,
+          },
+          championshipAlerts: alertsFromPlayerMirror(player),
+          championshipPersonKey: player.id,
+          hasPlayedAtLeastOneMatch: false,
+          hasPlayedAtLeastOneMatchParis: false,
+        })
+      );
+      continue;
+    }
+    mergedIds.add(entry.id);
+    if (entry.ffttLicense) {
+      mergedIds.add(entry.ffttLicense);
+    }
+    result.push(withCurrentClubLicense(applyRosterToPlayer(player, entry)));
+  }
+
+  for (const entry of roster) {
+    if (mergedIds.has(entry.id)) {
+      continue;
+    }
+    if (entry.ffttLicense && mergedIds.has(entry.ffttLicense)) {
+      continue;
+    }
+    result.push(
+      withCurrentClubLicense(applyRosterToPlayer(emptyPlayer(entry.id), entry))
+    );
+    mergedIds.add(entry.id);
+  }
+
+  return result;
+}
+
+function applyRosterToPlayer(
+  player: Player,
+  entry: ChampionshipRosterView
+): Player {
+  const gender =
+    entry.sex === "female" ? "F" : entry.sex === "male" ? "M" : player.gender;
+  return {
+    ...withoutSeasonalMatchStats(player),
+    id: player.id || entry.id,
+    name: entry.lastName || player.name,
+    firstName: entry.firstName || player.firstName,
+    license: entry.ffttLicense || player.license,
+    gender,
+    isTemporary: entry.isTemporary === true || player.isTemporary === true,
+    isWheelchair: entry.isWheelchair === true,
+    discordMentions: entry.discordMentions,
+    preferredTeams: entry.preferredTeams ?? player.preferredTeams,
+    participation: {
+      ...player.participation,
+      championnat: entry.championnat,
+      championnatParis: entry.championnatParis,
+    },
+    championshipAlerts: alertsFromRoster(entry),
+    championshipPersonKey: entry.personKey || entry.id,
+    listedInClub: player.listedInClub === true,
+    hasPlayedAtLeastOneMatch: entry.hasPlayedAtLeastOneMatch === true,
+    hasPlayedAtLeastOneMatchParis: entry.hasPlayedAtLeastOneMatchParis === true,
+    ...(entry.highestMasculineTeamNumberByPhase
+      ? { highestMasculineTeamNumberByPhase: entry.highestMasculineTeamNumberByPhase }
+      : {}),
+    ...(entry.highestFeminineTeamNumberByPhase
+      ? { highestFeminineTeamNumberByPhase: entry.highestFeminineTeamNumberByPhase }
+      : {}),
+    ...(entry.highestTeamNumberByPhaseParis
+      ? { highestTeamNumberByPhaseParis: entry.highestTeamNumberByPhaseParis }
+      : {}),
+    ...(entry.masculineMatchesByTeamByPhase
+      ? { masculineMatchesByTeamByPhase: entry.masculineMatchesByTeamByPhase }
+      : {}),
+    ...(entry.feminineMatchesByTeamByPhase
+      ? { feminineMatchesByTeamByPhase: entry.feminineMatchesByTeamByPhase }
+      : {}),
+    ...(entry.matchesByTeamByPhaseParis
+      ? { matchesByTeamByPhaseParis: entry.matchesByTeamByPhaseParis }
+      : {}),
+  } as Player;
+}

--- a/src/lib/championship/merge-players.ts
+++ b/src/lib/championship/merge-players.ts
@@ -1,16 +1,13 @@
 import { currentClubLicenseFields } from "@/lib/players/current-club-license";
 import { resolveLicensePresence } from "./license-presence";
-import type { ChampionshipPlayerRecord, LicensePresence } from "./schema";
+import type {
+  ChampionshipAlertCode,
+  ChampionshipPlayerRecord,
+  LicensePresence,
+} from "./records";
 import type { Player } from "@/types/team-management";
 
-export type ChampionshipAlertCode =
-  | "unpaid"
-  | "payment_requested"
-  | "not_in_club_list"
-  | "fftt_sqy_unlicensed"
-  | "other_club"
-  | "other_federation"
-  | "no_license";
+export type { ChampionshipAlertCode };
 
 export type ChampionshipRosterView = ChampionshipPlayerRecord & {
   id: string;

--- a/src/lib/championship/paths.ts
+++ b/src/lib/championship/paths.ts
@@ -1,0 +1,16 @@
+import { sanitizeSeasonLabel } from "./person-key";
+
+export const SEASONS_COLLECTION = "seasons";
+export const CHAMPIONSHIP_PLAYERS_COLLECTION = "championshipPlayers";
+export const PLAYER_CLUB_PROFILES_COLLECTION = "playerClubProfiles";
+
+export function championshipPlayersCollectionPath(seasonLabel: string): string {
+  return `${SEASONS_COLLECTION}/${sanitizeSeasonLabel(seasonLabel)}/${CHAMPIONSHIP_PLAYERS_COLLECTION}`;
+}
+
+export function championshipPlayerDocPath(
+  seasonLabel: string,
+  personKey: string
+): string {
+  return `${championshipPlayersCollectionPath(seasonLabel)}/${personKey}`;
+}

--- a/src/lib/championship/person-key.test.ts
+++ b/src/lib/championship/person-key.test.ts
@@ -1,0 +1,62 @@
+import {
+  parseRegistrationPersonKey,
+  resolveChampionshipPersonKey,
+  sanitizeSeasonLabel,
+  temporaryPersonKey,
+} from "./person-key";
+
+describe("resolveChampionshipPersonKey", () => {
+  it("prefers a valid FFTT license", () => {
+    expect(
+      resolveChampionshipPersonKey({
+        ffttLicense: "7876509",
+        registrationId: "abc",
+      })
+    ).toBe("7876509");
+  });
+
+  it("falls back to the registration id", () => {
+    expect(
+      resolveChampionshipPersonKey({
+        ffttLicense: "",
+        registrationId: "MuRgYDhI8JUxwuc50yUQ",
+      })
+    ).toBe("reg_MuRgYDhI8JUxwuc50yUQ");
+  });
+
+  it("strips non-digits from the license", () => {
+    expect(
+      resolveChampionshipPersonKey({ ffttLicense: " 78 76509 " })
+    ).toBe("7876509");
+  });
+
+  it("returns null without license or registration", () => {
+    expect(resolveChampionshipPersonKey({})).toBeNull();
+  });
+});
+
+describe("parseRegistrationPersonKey", () => {
+  it("reads the registration id", () => {
+    expect(parseRegistrationPersonKey("reg_abc")).toBe("abc");
+  });
+
+  it("rejects a license key", () => {
+    expect(parseRegistrationPersonKey("7876509")).toBeNull();
+  });
+});
+
+describe("temporaryPersonKey", () => {
+  it("uses a valid license when provided", () => {
+    expect(temporaryPersonKey("7876509")).toBe("7876509");
+  });
+
+  it("falls back to a tmp_ key without a license", () => {
+    expect(temporaryPersonKey()).toMatch(/^tmp_[a-f0-9]{12}$/);
+  });
+});
+
+describe("sanitizeSeasonLabel", () => {
+  it("keeps a standard season label", () => {
+    expect(sanitizeSeasonLabel("2026-2027")).toBe("2026-2027");
+  });
+});

--- a/src/lib/championship/person-key.ts
+++ b/src/lib/championship/person-key.ts
@@ -1,0 +1,60 @@
+const FFTT_LICENSE_RE = /^[0-9]{5,12}$/;
+const REGISTRATION_KEY_PREFIX = "reg_";
+const TEMPORARY_KEY_PREFIX = "tmp_";
+
+export function digitsLicense(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value)).replace(/\D/g, "");
+  }
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.replace(/\D/g, "");
+}
+
+export function isFfttLicensePersonKey(value: string): boolean {
+  return FFTT_LICENSE_RE.test(value);
+}
+
+export function registrationPersonKey(registrationId: string): string {
+  return `${REGISTRATION_KEY_PREFIX}${registrationId}`;
+}
+
+export function parseRegistrationPersonKey(personKey: string): string | null {
+  if (!personKey.startsWith(REGISTRATION_KEY_PREFIX)) {
+    return null;
+  }
+  const id = personKey.slice(REGISTRATION_KEY_PREFIX.length);
+  return id.length > 0 ? id : null;
+}
+
+/** Licence FFTT si connue, sinon `reg_{registrationId}`. */
+export function resolveChampionshipPersonKey(params: {
+  ffttLicense?: string | null;
+  registrationId?: string | null;
+}): string | null {
+  const license = digitsLicense(params.ffttLicense);
+  if (FFTT_LICENSE_RE.test(license)) {
+    return license;
+  }
+  if (params.registrationId && params.registrationId.trim().length > 0) {
+    return registrationPersonKey(params.registrationId.trim());
+  }
+  return null;
+}
+
+export function temporaryPersonKey(license?: string | null): string {
+  const licenseKey = digitsLicense(license);
+  if (FFTT_LICENSE_RE.test(licenseKey)) {
+    return licenseKey;
+  }
+  return `${TEMPORARY_KEY_PREFIX}${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+export function sanitizeSeasonLabel(seasonLabel: string): string {
+  const trimmed = seasonLabel.trim();
+  if (!trimmed) {
+    throw new Error("Libellé de saison manquant");
+  }
+  return trimmed.replace(/[/#]/g, "-");
+}

--- a/src/lib/championship/records.ts
+++ b/src/lib/championship/records.ts
@@ -1,0 +1,88 @@
+/**
+ * Types métier du roster saisonnier, sans Zod.
+ * Cloud Functions (TS 4.9) compile le graphe de sync et ne peut pas parser Zod v4.
+ */
+
+export const LICENSE_PRESENCE_VALUES = [
+  "in_club_list",
+  "fftt_sqy_unlicensed",
+  "other_club",
+  "other_federation",
+  "none",
+  "unknown",
+] as const;
+
+export type LicensePresence = (typeof LICENSE_PRESENCE_VALUES)[number];
+
+export type ChampionshipAlertCode =
+  | "unpaid"
+  | "payment_requested"
+  | "not_in_club_list"
+  | "fftt_sqy_unlicensed"
+  | "other_club"
+  | "other_federation"
+  | "no_license";
+
+export type PreferredTeams = {
+  masculine: string[];
+  feminine: string[];
+};
+
+export type BurnoutByPhase = {
+  aller?: number | undefined;
+  retour?: number | undefined;
+};
+
+export type MatchesByTeamByPhase = {
+  aller?: Record<string, number> | undefined;
+  retour?: Record<string, number> | undefined;
+};
+
+export type ChampionshipPlayerRecord = {
+  personKey: string;
+  seasonLabel: string;
+  registrationId: string | null;
+  ffttLicense: string | null;
+  firstName: string;
+  lastName: string;
+  sex?: "female" | "male" | "other" | "" | undefined;
+  includedFromDossier: boolean;
+  coachIncluded: boolean;
+  coachExcluded: boolean;
+  championnat: boolean;
+  championnatParis: boolean;
+  paymentStatus: string | null;
+  registrationStatus: string | null;
+  licensePresence: LicensePresence;
+  licenseValidationStatus: string | null;
+  preferredTeams: PreferredTeams;
+  isTemporary: boolean;
+  hasPlayedAtLeastOneMatch?: boolean | undefined;
+  hasPlayedAtLeastOneMatchParis?: boolean | undefined;
+  highestMasculineTeamNumberByPhase?: BurnoutByPhase | undefined;
+  highestFeminineTeamNumberByPhase?: BurnoutByPhase | undefined;
+  highestTeamNumberByPhaseParis?: BurnoutByPhase | undefined;
+  masculineMatchesByTeamByPhase?: MatchesByTeamByPhase | undefined;
+  feminineMatchesByTeamByPhase?: MatchesByTeamByPhase | undefined;
+  matchesByTeamByPhaseParis?: MatchesByTeamByPhase | undefined;
+};
+
+export type PlayerClubProfileRecord = {
+  personKey: string;
+  discordMentions: string[];
+  isWheelchair: boolean;
+};
+
+export type RosterParticipationPatch = {
+  championnat?: boolean | undefined;
+  championnatParis?: boolean | undefined;
+  coachExcluded?: boolean | undefined;
+  isTemporary?: boolean | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  sex?: "female" | "male" | "other" | "" | undefined;
+  ffttLicense?: string | null | undefined;
+  isWheelchair?: boolean | undefined;
+  discordMentions?: string[] | undefined;
+  preferredTeams?: PreferredTeams | undefined;
+};

--- a/src/lib/championship/resolve-roster-entry.test.ts
+++ b/src/lib/championship/resolve-roster-entry.test.ts
@@ -1,0 +1,97 @@
+import { resolveRosterEntryFromRegistration } from "./resolve-roster-entry";
+
+const SEASON = "2026-2027";
+
+describe("resolveRosterEntryFromRegistration", () => {
+  it("upserts a paid competitor (Deshayes) even without club-list licence", () => {
+    const result = resolveRosterEntryFromRegistration(SEASON, {
+      registrationId: "MuRgYDhI8JUxwuc50yUQ",
+      status: "paid",
+      paymentStatus: "paid",
+      firstName: "Laurent",
+      lastName: "DESHAYES",
+      competitionIds: ["championnat_equipe"],
+      ffttLicense: "7876509",
+      listedInClub: false,
+      typeLicence: null,
+      playerNomClub: "SQY PING",
+    });
+    expect(result.action).toBe("upsert");
+    if (result.action !== "upsert") return;
+    expect(result.record.personKey).toBe("7876509");
+    expect(result.record.championnat).toBe(true);
+    expect(result.record.licensePresence).toBe("fftt_sqy_unlicensed");
+    expect(result.record.paymentStatus).toBe("paid");
+  });
+
+  it("keeps Marly with other-federation presence", () => {
+    const result = resolveRosterEntryFromRegistration(SEASON, {
+      registrationId: "GOaGSC1oWXFSMhalDx2S",
+      status: "paid",
+      firstName: "Nicolas",
+      lastName: "MARLY",
+      competitionIds: ["championnat_equipe"],
+      ffttLicense: "25260171435",
+      licenseValidationStatus: "other_federation",
+      listedInClub: false,
+    });
+    expect(result.action).toBe("upsert");
+    if (result.action !== "upsert") return;
+    expect(result.record.licensePresence).toBe("other_federation");
+  });
+
+  it("skips leisure dossiers without championship intent", () => {
+    const result = resolveRosterEntryFromRegistration(SEASON, {
+      registrationId: "leis1",
+      status: "paid",
+      competitionIds: [],
+      ffttLicense: "11111",
+    });
+    expect(result).toEqual({ action: "skip", reason: "no_intent" });
+  });
+
+  it("does not reinclude a coach-excluded player after a new seed", () => {
+    const result = resolveRosterEntryFromRegistration(
+      SEASON,
+      {
+        registrationId: "abc",
+        status: "paid",
+        competitionIds: ["championnat_equipe"],
+        ffttLicense: "1234567",
+      },
+      { coachExcluded: true, coachIncluded: false }
+    );
+    expect(result).toEqual({ action: "exclude", personKey: "1234567" });
+  });
+
+  it("keeps a coach-included player without dossier intent", () => {
+    const result = resolveRosterEntryFromRegistration(
+      SEASON,
+      {
+        registrationId: "coach1",
+        status: "paid",
+        competitionIds: [],
+        ffttLicense: "1234567",
+      },
+      {
+        coachExcluded: false,
+        coachIncluded: true,
+        championnat: true,
+        championnatParis: false,
+      }
+    );
+    expect(result.action).toBe("upsert");
+    if (result.action !== "upsert") return;
+    expect(result.record.championnat).toBe(true);
+    expect(result.record.includedFromDossier).toBe(false);
+  });
+
+  it("skips rejected registrations", () => {
+    const result = resolveRosterEntryFromRegistration(SEASON, {
+      registrationId: "rej",
+      status: "rejected",
+      competitionIds: ["championnat_equipe"],
+    });
+    expect(result).toEqual({ action: "skip", reason: "rejected" });
+  });
+});

--- a/src/lib/championship/resolve-roster-entry.ts
+++ b/src/lib/championship/resolve-roster-entry.ts
@@ -1,0 +1,112 @@
+import {
+  flagsFromCompetitionIds,
+  hasChampionshipCompetitionIntent,
+} from "./competition-mapping";
+import { resolveLicensePresence } from "./license-presence";
+import { resolveChampionshipPersonKey } from "./person-key";
+import type { ChampionshipPlayerRecord } from "./schema";
+
+export type ExistingRosterState = {
+  coachExcluded: boolean;
+  coachIncluded: boolean;
+  championnat?: boolean;
+  championnatParis?: boolean;
+  preferredTeams?: ChampionshipPlayerRecord["preferredTeams"];
+  isTemporary?: boolean;
+  hasPlayedAtLeastOneMatch?: boolean;
+  hasPlayedAtLeastOneMatchParis?: boolean;
+};
+
+export type RegistrationRosterInput = {
+  registrationId: string;
+  status?: string | null;
+  paymentStatus?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  sex?: string | null;
+  competitionIds?: readonly string[] | null;
+  ffttLicense?: string | null;
+  licenseValidationStatus?: string | null;
+  listedInClub?: boolean | null;
+  typeLicence?: string | null;
+  playerNomClub?: string | null;
+};
+
+export type ResolveRosterDecision =
+  | { action: "skip"; reason: "rejected" | "no_intent" | "no_person_key" }
+  | { action: "exclude"; personKey: string }
+  | { action: "upsert"; record: ChampionshipPlayerRecord };
+
+const EMPTY_TEAMS = { masculine: [] as string[], feminine: [] as string[] };
+
+export function resolveRosterEntryFromRegistration(
+  seasonLabel: string,
+  registration: RegistrationRosterInput,
+  existing?: ExistingRosterState | null
+): ResolveRosterDecision {
+  if (registration.status === "rejected") {
+    return { action: "skip", reason: "rejected" };
+  }
+
+  const flags = flagsFromCompetitionIds(registration.competitionIds);
+  const intent = hasChampionshipCompetitionIntent(registration.competitionIds);
+  const personKey = resolveChampionshipPersonKey({
+    ffttLicense: registration.ffttLicense ?? null,
+    registrationId: registration.registrationId,
+  });
+  if (!personKey) {
+    return { action: "skip", reason: "no_person_key" };
+  }
+
+  if (existing?.coachExcluded) {
+    return { action: "exclude", personKey };
+  }
+
+  if (!intent && !existing?.coachIncluded) {
+    return { action: "skip", reason: "no_intent" };
+  }
+
+  const championnat = intent
+    ? flags.championnat
+    : Boolean(existing?.championnat);
+  const championnatParis = intent
+    ? flags.championnatParis
+    : Boolean(existing?.championnatParis);
+
+  return {
+    action: "upsert",
+    record: {
+      personKey,
+      seasonLabel,
+      registrationId: registration.registrationId,
+      ffttLicense: registration.ffttLicense?.replace(/\D/g, "") || null,
+      firstName: registration.firstName ?? "",
+      lastName: registration.lastName ?? "",
+      sex:
+        registration.sex === "female" ||
+        registration.sex === "male" ||
+        registration.sex === "other"
+          ? registration.sex
+          : "",
+      includedFromDossier: intent,
+      coachIncluded: existing?.coachIncluded ?? false,
+      coachExcluded: false,
+      championnat,
+      championnatParis,
+      paymentStatus: registration.paymentStatus ?? null,
+      registrationStatus: registration.status ?? null,
+      licensePresence: resolveLicensePresence({
+        ffttLicense: registration.ffttLicense ?? null,
+        listedInClub: registration.listedInClub ?? null,
+        typeLicence: registration.typeLicence ?? null,
+        licenseValidationStatus: registration.licenseValidationStatus ?? null,
+        playerNomClub: registration.playerNomClub ?? null,
+      }),
+      licenseValidationStatus: registration.licenseValidationStatus ?? null,
+      preferredTeams: existing?.preferredTeams ?? EMPTY_TEAMS,
+      isTemporary: existing?.isTemporary ?? false,
+      hasPlayedAtLeastOneMatch: existing?.hasPlayedAtLeastOneMatch,
+      hasPlayedAtLeastOneMatchParis: existing?.hasPlayedAtLeastOneMatchParis,
+    },
+  };
+}

--- a/src/lib/championship/resolve-roster-entry.ts
+++ b/src/lib/championship/resolve-roster-entry.ts
@@ -4,7 +4,7 @@ import {
 } from "./competition-mapping";
 import { resolveLicensePresence } from "./license-presence";
 import { resolveChampionshipPersonKey } from "./person-key";
-import type { ChampionshipPlayerRecord } from "./schema";
+import type { ChampionshipPlayerRecord } from "./records";
 
 export type ExistingRosterState = {
   coachExcluded: boolean;

--- a/src/lib/championship/roster-match-stats.test.ts
+++ b/src/lib/championship/roster-match-stats.test.ts
@@ -1,0 +1,17 @@
+import { rosterDocIdsWithSeasonalMatchStats } from "./roster-match-stats";
+
+describe("rosterDocIdsWithSeasonalMatchStats", () => {
+  it("collects roster docs that still carry last-season burnout", () => {
+    expect(
+      rosterDocIdsWithSeasonalMatchStats([
+        { id: "clean", ffttLicense: "1" },
+        {
+          id: "burned",
+          ffttLicense: "2222",
+          highestMasculineTeamNumberByPhase: { aller: 3 },
+        },
+        { id: "played", hasPlayedAtLeastOneMatch: true },
+      ])
+    ).toEqual(["burned", "2222", "played"]);
+  });
+});

--- a/src/lib/championship/roster-match-stats.ts
+++ b/src/lib/championship/roster-match-stats.ts
@@ -1,4 +1,4 @@
-import type { ChampionshipPlayerRecord } from "./schema";
+import type { ChampionshipPlayerRecord } from "./records";
 
 const SEASONAL_MATCH_STAT_KEYS = [
   "hasPlayedAtLeastOneMatch",

--- a/src/lib/championship/roster-match-stats.ts
+++ b/src/lib/championship/roster-match-stats.ts
@@ -1,0 +1,44 @@
+import type { ChampionshipPlayerRecord } from "./schema";
+
+const SEASONAL_MATCH_STAT_KEYS = [
+  "hasPlayedAtLeastOneMatch",
+  "hasPlayedAtLeastOneMatchParis",
+  "highestMasculineTeamNumberByPhase",
+  "highestFeminineTeamNumberByPhase",
+  "highestTeamNumberByPhaseParis",
+  "masculineMatchesByTeamByPhase",
+  "feminineMatchesByTeamByPhase",
+  "matchesByTeamByPhaseParis",
+] as const;
+
+export type RosterMatchStatsSource = {
+  id: string;
+  ffttLicense?: string | null | undefined;
+} & Partial<
+  Pick<ChampionshipPlayerRecord, (typeof SEASONAL_MATCH_STAT_KEYS)[number]>
+>;
+
+export function rosterDocHasSeasonalMatchStats(
+  record: RosterMatchStatsSource
+): boolean {
+  return SEASONAL_MATCH_STAT_KEYS.some((key) => record[key] != null);
+}
+
+export function rosterDocIdsWithSeasonalMatchStats(
+  records: ReadonlyArray<RosterMatchStatsSource>
+): string[] {
+  const ids = new Set<string>();
+  for (const record of records) {
+    if (!rosterDocHasSeasonalMatchStats(record)) {
+      continue;
+    }
+    if (record.id) {
+      ids.add(record.id);
+    }
+    const license = record.ffttLicense;
+    if (typeof license === "string" && license.trim()) {
+      ids.add(license.trim());
+    }
+  }
+  return [...ids];
+}

--- a/src/lib/championship/schema.ts
+++ b/src/lib/championship/schema.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const LICENSE_PRESENCE_VALUES = [
+  "in_club_list",
+  "fftt_sqy_unlicensed",
+  "other_club",
+  "other_federation",
+  "none",
+  "unknown",
+] as const;
+
+export type LicensePresence = (typeof LICENSE_PRESENCE_VALUES)[number];
+
+export const licensePresenceSchema = z.enum(LICENSE_PRESENCE_VALUES);
+
+export const preferredTeamsSchema = z.object({
+  masculine: z.array(z.string()).default([]),
+  feminine: z.array(z.string()).default([]),
+});
+
+export const burnoutByPhaseSchema = z
+  .object({
+    aller: z.number().int().optional(),
+    retour: z.number().int().optional(),
+  })
+  .optional();
+
+export const matchesByTeamByPhaseSchema = z
+  .object({
+    aller: z.record(z.string(), z.number()).optional(),
+    retour: z.record(z.string(), z.number()).optional(),
+  })
+  .optional();
+
+export const championshipPlayerSchema = z.object({
+  personKey: z.string().min(1),
+  seasonLabel: z.string().min(1),
+  registrationId: z.string().nullable(),
+  ffttLicense: z.string().nullable(),
+  firstName: z.string(),
+  lastName: z.string(),
+  sex: z.enum(["female", "male", "other", ""]).optional(),
+  includedFromDossier: z.boolean(),
+  coachIncluded: z.boolean(),
+  coachExcluded: z.boolean(),
+  championnat: z.boolean(),
+  championnatParis: z.boolean(),
+  paymentStatus: z.string().nullable(),
+  registrationStatus: z.string().nullable(),
+  licensePresence: licensePresenceSchema,
+  licenseValidationStatus: z.string().nullable(),
+  preferredTeams: preferredTeamsSchema,
+  isTemporary: z.boolean().default(false),
+  hasPlayedAtLeastOneMatch: z.boolean().optional(),
+  hasPlayedAtLeastOneMatchParis: z.boolean().optional(),
+  highestMasculineTeamNumberByPhase: burnoutByPhaseSchema,
+  highestFeminineTeamNumberByPhase: burnoutByPhaseSchema,
+  highestTeamNumberByPhaseParis: burnoutByPhaseSchema,
+  masculineMatchesByTeamByPhase: matchesByTeamByPhaseSchema,
+  feminineMatchesByTeamByPhase: matchesByTeamByPhaseSchema,
+  matchesByTeamByPhaseParis: matchesByTeamByPhaseSchema,
+});
+
+export type ChampionshipPlayerRecord = z.infer<typeof championshipPlayerSchema>;
+
+export const playerClubProfileSchema = z.object({
+  personKey: z.string().min(1),
+  discordMentions: z.array(z.string()).default([]),
+  isWheelchair: z.boolean().default(false),
+});
+
+export type PlayerClubProfileRecord = z.infer<typeof playerClubProfileSchema>;
+
+export const rosterParticipationPatchSchema = z
+  .object({
+    championnat: z.boolean().optional(),
+    championnatParis: z.boolean().optional(),
+    coachExcluded: z.boolean().optional(),
+    isTemporary: z.boolean().optional(),
+    firstName: z.string().trim().max(120).optional(),
+    lastName: z.string().trim().max(120).optional(),
+    sex: z.enum(["female", "male", "other", ""]).optional(),
+    ffttLicense: z.string().regex(/^[0-9]{5,12}$/).nullable().optional(),
+    isWheelchair: z.boolean().optional(),
+    discordMentions: z.array(z.string()).optional(),
+    preferredTeams: preferredTeamsSchema.optional(),
+  })
+  .refine(
+    (value) => Object.values(value).some((entry) => entry !== undefined),
+    { message: "Aucun champ modifiable fourni" }
+  );
+
+export type RosterParticipationPatch = z.infer<typeof rosterParticipationPatchSchema>;

--- a/src/lib/championship/schema.ts
+++ b/src/lib/championship/schema.ts
@@ -1,15 +1,13 @@
 import { z } from "zod";
+import { LICENSE_PRESENCE_VALUES } from "./records";
 
-export const LICENSE_PRESENCE_VALUES = [
-  "in_club_list",
-  "fftt_sqy_unlicensed",
-  "other_club",
-  "other_federation",
-  "none",
-  "unknown",
-] as const;
-
-export type LicensePresence = (typeof LICENSE_PRESENCE_VALUES)[number];
+export { LICENSE_PRESENCE_VALUES } from "./records";
+export type {
+  ChampionshipPlayerRecord,
+  LicensePresence,
+  PlayerClubProfileRecord,
+  RosterParticipationPatch,
+} from "./records";
 
 export const licensePresenceSchema = z.enum(LICENSE_PRESENCE_VALUES);
 
@@ -61,15 +59,11 @@ export const championshipPlayerSchema = z.object({
   matchesByTeamByPhaseParis: matchesByTeamByPhaseSchema,
 });
 
-export type ChampionshipPlayerRecord = z.infer<typeof championshipPlayerSchema>;
-
 export const playerClubProfileSchema = z.object({
   personKey: z.string().min(1),
   discordMentions: z.array(z.string()).default([]),
   isWheelchair: z.boolean().default(false),
 });
-
-export type PlayerClubProfileRecord = z.infer<typeof playerClubProfileSchema>;
 
 export const rosterParticipationPatchSchema = z
   .object({
@@ -89,5 +83,3 @@ export const rosterParticipationPatchSchema = z
     (value) => Object.values(value).some((entry) => entry !== undefined),
     { message: "Aucun champ modifiable fourni" }
   );
-
-export type RosterParticipationPatch = z.infer<typeof rosterParticipationPatchSchema>;

--- a/src/lib/championship/season-label.ts
+++ b/src/lib/championship/season-label.ts
@@ -1,0 +1,19 @@
+import type { Firestore } from "firebase-admin/firestore";
+
+const CONFIG_COLLECTION = "clubRegistrationConfig";
+const ACTIVE_CONFIG_ID = "active";
+
+/**
+ * Lit `meta.seasonLabel` publié. Utilisable depuis Cloud Functions (passe le `db` déjà ouvert).
+ */
+export async function readPublishedSeasonLabel(db: Firestore): Promise<string> {
+  const snap = await db.collection(CONFIG_COLLECTION).doc(ACTIVE_CONFIG_ID).get();
+  const config = snap.data()?.config as
+    | { meta?: { seasonLabel?: unknown } }
+    | undefined;
+  const label = config?.meta?.seasonLabel;
+  if (typeof label === "string" && label.trim()) {
+    return label.trim();
+  }
+  throw new Error("Libellé de saison introuvable sur la config d'adhésion active");
+}

--- a/src/lib/championship/seed-from-registration.ts
+++ b/src/lib/championship/seed-from-registration.ts
@@ -1,0 +1,201 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { COLLECTION as REGISTRATIONS_COLLECTION } from "@/lib/club-registration/list-registrations";
+import { readKnownFfttLicenseFromRegistrationData } from "@/lib/license-validation/known-fftt-license";
+import {
+  deleteChampionshipPlayer,
+  findChampionshipPlayerByRegistrationId,
+  getChampionshipPlayer,
+  upsertChampionshipPlayer,
+} from "./store";
+import {
+  resolveRosterEntryFromRegistration,
+  type ExistingRosterState,
+  type RegistrationRosterInput,
+} from "./resolve-roster-entry";
+import { parseRegistrationPersonKey } from "./person-key";
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+export function registrationToRosterInput(
+  registrationId: string,
+  data: Record<string, unknown>,
+  player?: {
+    listedInClub?: boolean | null;
+    typeLicence?: string | null;
+    nomClub?: string | null;
+  } | null
+): RegistrationRosterInput {
+  return {
+    registrationId,
+    status: asString(data.status),
+    paymentStatus: asString(data.paymentStatus),
+    firstName: asString(data.firstName),
+    lastName: asString(data.lastName),
+    sex: asString(data.sex),
+    competitionIds: asStringArray(data.competitionIds),
+    ffttLicense: readKnownFfttLicenseFromRegistrationData(data),
+    licenseValidationStatus: asString(data.licenseValidationStatus),
+    listedInClub: player?.listedInClub ?? null,
+    typeLicence: player?.typeLicence ?? null,
+    playerNomClub:
+      player?.nomClub ??
+      (data.ffttLicenseLookup && typeof data.ffttLicenseLookup === "object"
+        ? asString((data.ffttLicenseLookup as Record<string, unknown>).nomClub)
+        : null),
+  };
+}
+
+async function loadPlayerMirror(
+  db: Firestore,
+  license: string | null
+): Promise<{
+  listedInClub?: boolean | null;
+  typeLicence?: string | null;
+  nomClub?: string | null;
+} | null> {
+  if (!license) {
+    return null;
+  }
+  const snap = await db.collection("players").doc(license).get();
+  if (!snap.exists) {
+    return { listedInClub: false, typeLicence: null, nomClub: null };
+  }
+  const data = snap.data() ?? {};
+  return {
+    listedInClub: data.listedInClub === true,
+    typeLicence: asString(data.typeLicence),
+    nomClub: asString(data.nomClub) ?? asString(data.club),
+  };
+}
+
+type RosterStateSource = {
+  coachExcluded?: boolean | undefined;
+  coachIncluded?: boolean | undefined;
+  championnat?: boolean | undefined;
+  championnatParis?: boolean | undefined;
+  preferredTeams?: ExistingRosterState["preferredTeams"] | undefined;
+  isTemporary?: boolean | undefined;
+  hasPlayedAtLeastOneMatch?: boolean | undefined;
+  hasPlayedAtLeastOneMatchParis?: boolean | undefined;
+};
+
+function toExistingState(
+  record: RosterStateSource | null | undefined
+): ExistingRosterState | null {
+  if (!record) {
+    return null;
+  }
+  const state: ExistingRosterState = {
+    coachExcluded: record.coachExcluded === true,
+    coachIncluded: record.coachIncluded === true,
+  };
+  if (typeof record.championnat === "boolean") {
+    state.championnat = record.championnat;
+  }
+  if (typeof record.championnatParis === "boolean") {
+    state.championnatParis = record.championnatParis;
+  }
+  if (record.preferredTeams) {
+    state.preferredTeams = record.preferredTeams;
+  }
+  if (typeof record.isTemporary === "boolean") {
+    state.isTemporary = record.isTemporary;
+  }
+  if (typeof record.hasPlayedAtLeastOneMatch === "boolean") {
+    state.hasPlayedAtLeastOneMatch = record.hasPlayedAtLeastOneMatch;
+  }
+  if (typeof record.hasPlayedAtLeastOneMatchParis === "boolean") {
+    state.hasPlayedAtLeastOneMatchParis = record.hasPlayedAtLeastOneMatchParis;
+  }
+  return state;
+}
+
+export async function syncChampionshipRosterFromRegistration(
+  db: Firestore,
+  seasonLabel: string,
+  registrationId: string
+): Promise<{ action: "upsert" | "exclude" | "skip" }> {
+  const snap = await db
+    .collection(REGISTRATIONS_COLLECTION)
+    .doc(registrationId)
+    .get();
+  if (!snap.exists) {
+    return { action: "skip" };
+  }
+  const data = (snap.data() ?? {}) as Record<string, unknown>;
+  const license = readKnownFfttLicenseFromRegistrationData(data);
+  const player = await loadPlayerMirror(db, license);
+
+  const existingByReg = await findChampionshipPlayerByRegistrationId(
+    db,
+    seasonLabel,
+    registrationId
+  );
+  const targetKeyPreview = license || existingByReg?.id || null;
+  const existingByKey =
+    targetKeyPreview && targetKeyPreview !== existingByReg?.id
+      ? await getChampionshipPlayer(db, seasonLabel, targetKeyPreview)
+      : null;
+  const existing = toExistingState(existingByKey ?? existingByReg);
+
+  const decision = resolveRosterEntryFromRegistration(
+    seasonLabel,
+    registrationToRosterInput(registrationId, data, player),
+    existing
+  );
+
+  if (decision.action === "skip") {
+    if (decision.reason === "no_intent") {
+      const current = existingByReg ?? existingByKey;
+      if (current?.includedFromDossier && !current.coachIncluded) {
+        const { id: personKey, ...currentRecord } = current;
+        await upsertChampionshipPlayer(db, {
+          ...currentRecord,
+          personKey,
+          seasonLabel,
+          includedFromDossier: false,
+          championnat: false,
+          championnatParis: false,
+        });
+        return { action: "exclude" };
+      }
+    }
+    return { action: "skip" };
+  }
+  if (decision.action === "exclude") {
+    const current = existingByReg ?? existingByKey;
+    if (current) {
+      const { id: personKey, ...currentRecord } = current;
+      await upsertChampionshipPlayer(db, {
+        ...currentRecord,
+        personKey,
+        seasonLabel,
+        coachExcluded: true,
+        championnat: false,
+        championnatParis: false,
+        includedFromDossier: false,
+      });
+    }
+    return { action: "exclude" };
+  }
+
+  await upsertChampionshipPlayer(db, decision.record);
+
+  const oldKey = existingByReg?.id;
+  if (oldKey && oldKey !== decision.record.personKey) {
+    const leftoverRegId = parseRegistrationPersonKey(oldKey);
+    if (leftoverRegId === registrationId) {
+      await deleteChampionshipPlayer(db, seasonLabel, oldKey);
+    }
+  }
+
+  return { action: "upsert" };
+}

--- a/src/lib/championship/seed-season.ts
+++ b/src/lib/championship/seed-season.ts
@@ -1,0 +1,47 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { COLLECTION as REGISTRATIONS_COLLECTION } from "@/lib/club-registration/list-registrations";
+import { syncChampionshipRosterFromRegistration } from "./seed-from-registration";
+
+export type SeedSeasonResult = {
+  scanned: number;
+  upserted: number;
+  excluded: number;
+  skipped: number;
+};
+
+export async function seedChampionshipRosterForSeason(
+  db: Firestore,
+  seasonLabel: string
+): Promise<SeedSeasonResult> {
+  const snap = await db.collection(REGISTRATIONS_COLLECTION).get();
+  const result: SeedSeasonResult = {
+    scanned: snap.size,
+    upserted: 0,
+    excluded: 0,
+    skipped: 0,
+  };
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    const docSeason =
+      typeof data.seasonLabel === "string" ? data.seasonLabel.trim() : "";
+    if (docSeason && docSeason !== seasonLabel) {
+      result.skipped += 1;
+      continue;
+    }
+    const action = await syncChampionshipRosterFromRegistration(
+      db,
+      seasonLabel,
+      doc.id
+    );
+    if (action.action === "upsert") {
+      result.upserted += 1;
+    } else if (action.action === "exclude") {
+      result.excluded += 1;
+    } else {
+      result.skipped += 1;
+    }
+  }
+
+  return result;
+}

--- a/src/lib/championship/store.ts
+++ b/src/lib/championship/store.ts
@@ -1,9 +1,11 @@
 import type { Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { championshipPlayersCollectionPath } from "./paths";
-import type { ChampionshipPlayerRecord } from "./schema";
+import type {
+  ChampionshipPlayerRecord,
+  PlayerClubProfileRecord,
+} from "./records";
 import { PLAYER_CLUB_PROFILES_COLLECTION } from "./paths";
-import type { PlayerClubProfileRecord } from "./schema";
 
 export function championshipPlayersCollection(
   db: Firestore,

--- a/src/lib/championship/store.ts
+++ b/src/lib/championship/store.ts
@@ -1,0 +1,110 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { championshipPlayersCollectionPath } from "./paths";
+import type { ChampionshipPlayerRecord } from "./schema";
+import { PLAYER_CLUB_PROFILES_COLLECTION } from "./paths";
+import type { PlayerClubProfileRecord } from "./schema";
+
+export function championshipPlayersCollection(
+  db: Firestore,
+  seasonLabel: string
+) {
+  return db.collection(championshipPlayersCollectionPath(seasonLabel));
+}
+
+export async function getChampionshipPlayer(
+  db: Firestore,
+  seasonLabel: string,
+  personKey: string
+): Promise<(ChampionshipPlayerRecord & { id: string }) | null> {
+  const snap = await championshipPlayersCollection(db, seasonLabel)
+    .doc(personKey)
+    .get();
+  if (!snap.exists) {
+    return null;
+  }
+  return { id: snap.id, ...(snap.data() as ChampionshipPlayerRecord) };
+}
+
+export async function listChampionshipPlayers(
+  db: Firestore,
+  seasonLabel: string
+): Promise<Array<ChampionshipPlayerRecord & { id: string }>> {
+  const snap = await championshipPlayersCollection(db, seasonLabel).get();
+  return snap.docs.map((doc) => ({
+    id: doc.id,
+    ...(doc.data() as ChampionshipPlayerRecord),
+  }));
+}
+
+export async function upsertChampionshipPlayer(
+  db: Firestore,
+  record: ChampionshipPlayerRecord
+): Promise<void> {
+  const { personKey, seasonLabel, ...rest } = record;
+  await championshipPlayersCollection(db, seasonLabel)
+    .doc(personKey)
+    .set(
+      {
+        ...rest,
+        personKey,
+        seasonLabel,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+}
+
+export async function findChampionshipPlayerByRegistrationId(
+  db: Firestore,
+  seasonLabel: string,
+  registrationId: string
+): Promise<(ChampionshipPlayerRecord & { id: string }) | null> {
+  const snap = await championshipPlayersCollection(db, seasonLabel)
+    .where("registrationId", "==", registrationId)
+    .limit(2)
+    .get();
+  if (snap.empty) {
+    return null;
+  }
+  const doc = snap.docs[0];
+  return { id: doc.id, ...(doc.data() as ChampionshipPlayerRecord) };
+}
+
+export async function deleteChampionshipPlayer(
+  db: Firestore,
+  seasonLabel: string,
+  personKey: string
+): Promise<void> {
+  await championshipPlayersCollection(db, seasonLabel).doc(personKey).delete();
+}
+
+export async function getPlayerClubProfile(
+  db: Firestore,
+  personKey: string
+): Promise<PlayerClubProfileRecord | null> {
+  const snap = await db
+    .collection(PLAYER_CLUB_PROFILES_COLLECTION)
+    .doc(personKey)
+    .get();
+  if (!snap.exists) {
+    return null;
+  }
+  return snap.data() as PlayerClubProfileRecord;
+}
+
+export async function upsertPlayerClubProfile(
+  db: Firestore,
+  profile: PlayerClubProfileRecord
+): Promise<void> {
+  await db
+    .collection(PLAYER_CLUB_PROFILES_COLLECTION)
+    .doc(profile.personKey)
+    .set(
+      {
+        ...profile,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+}

--- a/src/lib/championship/sync-after-registration.ts
+++ b/src/lib/championship/sync-after-registration.ts
@@ -1,0 +1,20 @@
+import type { Firestore } from "firebase-admin/firestore";
+import { readPublishedSeasonLabel } from "./season-label";
+import { syncChampionshipRosterFromRegistration } from "./seed-from-registration";
+
+/** Recalcule l'entrée roster du dossier. Les erreurs sont loguées, jamais remontées. */
+export async function syncRosterAfterRegistrationChange(
+  db: Firestore,
+  registrationId: string
+): Promise<void> {
+  try {
+    const seasonLabel = await readPublishedSeasonLabel(db);
+    await syncChampionshipRosterFromRegistration(db, seasonLabel, registrationId);
+  } catch (error) {
+    console.error(
+      "[championship] sync roster after registration failed",
+      registrationId,
+      error
+    );
+  }
+}

--- a/src/lib/championship/unlisted-player-mirror.test.ts
+++ b/src/lib/championship/unlisted-player-mirror.test.ts
@@ -1,0 +1,32 @@
+import { unlistedMirrorFieldsFromFfttDetails } from "./unlisted-player-mirror";
+
+describe("unlistedMirrorFieldsFromFfttDetails", () => {
+  it("keeps a mutation club and its current licence type", () => {
+    expect(
+      unlistedMirrorFieldsFromFfttDetails({
+        nomClub: "CHESNAY 78 AS",
+        numClub: "08780080",
+        typeLicence: "T",
+      })
+    ).toEqual({
+      nomClub: "CHESNAY 78 AS",
+      numClub: "08780080",
+      club: "CHESNAY 78 AS",
+      typeLicence: "T",
+    });
+  });
+
+  it("clears a leftover SQY type when FFTT has no season licence", () => {
+    expect(
+      unlistedMirrorFieldsFromFfttDetails({
+        nomClub: "SQY PING",
+        typeLicence: null,
+      })
+    ).toEqual({
+      nomClub: "SQY PING",
+      numClub: "",
+      club: "SQY PING",
+      typeLicence: "",
+    });
+  });
+});

--- a/src/lib/championship/unlisted-player-mirror.ts
+++ b/src/lib/championship/unlisted-player-mirror.ts
@@ -1,0 +1,87 @@
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import { typeLicenceFromFfttDetails } from "@/lib/players/current-club-license";
+
+const PLAYERS = "players";
+const FETCH_CONCURRENCY = 25;
+const WRITE_CHUNK = 400;
+
+export type UnlistedMirrorFields = {
+  nomClub: string;
+  numClub: string;
+  club: string;
+  typeLicence: string;
+};
+
+export function unlistedMirrorFieldsFromFfttDetails(
+  details: Record<string, unknown>
+): UnlistedMirrorFields {
+  const nomClub =
+    typeof details.nomClub === "string" ? details.nomClub.trim() : "";
+  const numClub =
+    typeof details.numClub === "string" ? details.numClub.trim() : "";
+  return {
+    nomClub,
+    numClub,
+    club: nomClub,
+    typeLicence: typeLicenceFromFfttDetails(details.typeLicence),
+  };
+}
+
+export async function refreshUnlistedPlayerMirrors(
+  db: Firestore,
+  fetchDetails: (licence: string) => Promise<Record<string, unknown> | null>
+): Promise<{ updated: number; errors: number }> {
+  const snap = await db.collection(PLAYERS).get();
+  const unlisted = snap.docs.filter(
+    (doc) => doc.data().listedInClub !== true && doc.data().isTemporary !== true
+  );
+
+  const pending: Array<{ ref: DocumentReference; fields: UnlistedMirrorFields }> =
+    [];
+  let errors = 0;
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < unlisted.length) {
+      const index = cursor;
+      cursor += 1;
+      const doc = unlisted[index];
+      if (!doc) {
+        continue;
+      }
+      const licence = String(doc.data().licence ?? doc.id).replace(/\D/g, "");
+      if (!licence) {
+        continue;
+      }
+      try {
+        const details = await fetchDetails(licence);
+        if (!details) {
+          continue;
+        }
+        pending.push({
+          ref: doc.ref,
+          fields: unlistedMirrorFieldsFromFfttDetails(details),
+        });
+      } catch {
+        errors += 1;
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(FETCH_CONCURRENCY, unlisted.length) },
+      () => worker()
+    )
+  );
+
+  for (let i = 0; i < pending.length; i += WRITE_CHUNK) {
+    const batch = db.batch();
+    for (const item of pending.slice(i, i + WRITE_CHUNK)) {
+      batch.set(item.ref, { listedInClub: false, ...item.fields }, { merge: true });
+    }
+    await batch.commit();
+  }
+
+  return { updated: pending.length, errors };
+}

--- a/src/lib/club-registration/patch-manager-registration.ts
+++ b/src/lib/club-registration/patch-manager-registration.ts
@@ -40,6 +40,7 @@ import {
 import { MANAGER_EDITABLE_FIELDS } from "@/lib/club-registration/registration-api-fields";
 import { ffttLicenseLookupSchema } from "@/lib/club-registration/schema-base";
 import { normalizeRegistrationLastNamePatch } from "@/lib/shared/person-name-format";
+import { syncRosterAfterRegistrationChange } from "@/lib/championship/sync-after-registration";
 
 const COLLECTION = "clubRegistrations";
 const MANAGER_ROLES = [USER_ROLES.ADMIN, USER_ROLES.SECRETARY] as const;
@@ -322,6 +323,8 @@ export async function patchManagerRegistration(
     details: { fields: Object.keys(updates) },
     success: true,
   });
+
+  await syncRosterAfterRegistrationChange(db, registrationId);
 
   return jsonNoStore({ success: true }, { status: 200 });
 }

--- a/src/lib/club-registration/persist-registration-on-submit.ts
+++ b/src/lib/club-registration/persist-registration-on-submit.ts
@@ -111,6 +111,7 @@ export function buildRegistrationSubmitDocument(params: {
     submitterAccountEmail,
     submitterRole,
     schemaVersion: 1,
+    seasonLabel: config.meta.seasonLabel,
     status: "submitted",
     submittedAt: now,
     updatedAt: now,

--- a/src/lib/compositions/composition-batch-operations.ts
+++ b/src/lib/compositions/composition-batch-operations.ts
@@ -7,6 +7,31 @@ import { isParisChampionship } from "@/lib/compositions/validators/team-utils";
 
 type CompositionMap = Record<string, string[]>;
 
+function idEpreuveFromTeams(teams: TeamListItem[]): number | undefined {
+  for (const equipe of teams) {
+    if (equipe.team.idEpreuve != null) {
+      return equipe.team.idEpreuve;
+    }
+  }
+  return undefined;
+}
+
+function compositionPayload(
+  journee: number,
+  phase: "aller" | "retour",
+  championshipType: ChampionshipType,
+  teams: CompositionMap,
+  idEpreuve: number | undefined
+) {
+  return {
+    journee,
+    phase,
+    championshipType,
+    teams,
+    ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+  };
+}
+
 interface TeamAvailabilitiesMap {
   [playerId: string]: {
     available?: boolean;
@@ -22,7 +47,7 @@ interface ApplyAvailabilities {
 }
 
 interface TeamListItem {
-  team: { id: string; name?: string };
+  team: { id: string; name?: string; idEpreuve?: number };
 }
 
 interface ResetParams {
@@ -62,24 +87,30 @@ export async function resetCompositionsBatch({
   try {
     await Promise.all([
       masculineTeamIds.length > 0
-        ? compositionService.saveComposition({
-            journee: selectedJournee,
-            phase: selectedPhase,
-            championshipType: "masculin",
-            teams: Object.fromEntries(
-              masculineTeamIds.map<[string, string[]]>((teamId) => [teamId, []])
-            ),
-          })
+        ? compositionService.saveComposition(
+            compositionPayload(
+              selectedJournee,
+              selectedPhase,
+              "masculin",
+              Object.fromEntries(
+                masculineTeamIds.map<[string, string[]]>((teamId) => [teamId, []])
+              ),
+              idEpreuveFromTeams(equipesByType.masculin)
+            )
+          )
         : Promise.resolve(),
       feminineTeamIds.length > 0
-        ? compositionService.saveComposition({
-            journee: selectedJournee,
-            phase: selectedPhase,
-            championshipType: "feminin",
-            teams: Object.fromEntries(
-              feminineTeamIds.map<[string, string[]]>((teamId) => [teamId, []])
-            ),
-          })
+        ? compositionService.saveComposition(
+            compositionPayload(
+              selectedJournee,
+              selectedPhase,
+              "feminin",
+              Object.fromEntries(
+                feminineTeamIds.map<[string, string[]]>((teamId) => [teamId, []])
+              ),
+              idEpreuveFromTeams(equipesByType.feminin)
+            )
+          )
         : Promise.resolve(),
     ]);
   } catch (error) {
@@ -199,30 +230,36 @@ export async function applyDefaultCompositionsBatch({
 
     await Promise.all([
       masculineTeamIds.length > 0
-        ? compositionService.saveComposition({
-            journee: selectedJournee,
-            phase: selectedPhase,
-            championshipType: "masculin",
-            teams: Object.fromEntries(
-              masculineTeamIds.map<[string, string[]]>((teamId) => [
-                teamId,
-                nextCompositions[teamId] || [],
-              ])
-            ),
-          })
+        ? compositionService.saveComposition(
+            compositionPayload(
+              selectedJournee,
+              selectedPhase,
+              "masculin",
+              Object.fromEntries(
+                masculineTeamIds.map<[string, string[]]>((teamId) => [
+                  teamId,
+                  nextCompositions[teamId] || [],
+                ])
+              ),
+              idEpreuveFromTeams(equipesByType.masculin)
+            )
+          )
         : Promise.resolve(),
       feminineTeamIds.length > 0
-        ? compositionService.saveComposition({
-            journee: selectedJournee,
-            phase: selectedPhase,
-            championshipType: "feminin",
-            teams: Object.fromEntries(
-              feminineTeamIds.map<[string, string[]]>((teamId) => [
-                teamId,
-                nextCompositions[teamId] || [],
-              ])
-            ),
-          })
+        ? compositionService.saveComposition(
+            compositionPayload(
+              selectedJournee,
+              selectedPhase,
+              "feminin",
+              Object.fromEntries(
+                feminineTeamIds.map<[string, string[]]>((teamId) => [
+                  teamId,
+                  nextCompositions[teamId] || [],
+                ])
+              ),
+              idEpreuveFromTeams(equipesByType.feminin)
+            )
+          )
         : Promise.resolve(),
     ]);
   } catch (error) {

--- a/src/lib/compositions/document-id.test.ts
+++ b/src/lib/compositions/document-id.test.ts
@@ -1,0 +1,24 @@
+import {
+  getCompositionDefaultsDocumentId,
+  getCompositionDocumentId,
+} from "./document-id";
+
+describe("composition document ids", () => {
+  it("namespaces day compositions by FFTT epreuve id", () => {
+    expect(getCompositionDocumentId(1, "aller", "masculin")).toBe(
+      "aller_1_masculin"
+    );
+    expect(getCompositionDocumentId(1, "aller", "masculin", 18368)).toBe(
+      "aller_1_masculin_18368"
+    );
+  });
+
+  it("namespaces default compositions by FFTT epreuve id", () => {
+    expect(getCompositionDefaultsDocumentId("aller", "feminin")).toBe(
+      "aller_feminin"
+    );
+    expect(getCompositionDefaultsDocumentId("aller", "feminin", 18369)).toBe(
+      "aller_feminin_18369"
+    );
+  });
+});

--- a/src/lib/compositions/document-id.ts
+++ b/src/lib/compositions/document-id.ts
@@ -1,0 +1,24 @@
+import { ChampionshipType } from "@/types";
+
+export function getCompositionDocumentId(
+  journee: number,
+  phase: "aller" | "retour",
+  championshipType: ChampionshipType,
+  idEpreuve?: number
+): string {
+  if (idEpreuve !== undefined) {
+    return `${phase}_${journee}_${championshipType}_${idEpreuve}`;
+  }
+  return `${phase}_${journee}_${championshipType}`;
+}
+
+export function getCompositionDefaultsDocumentId(
+  phase: "aller" | "retour",
+  championshipType: ChampionshipType,
+  idEpreuve?: number
+): string {
+  if (idEpreuve !== undefined) {
+    return `${phase}_${championshipType}_${idEpreuve}`;
+  }
+  return `${phase}_${championshipType}`;
+}

--- a/src/lib/license-validation/patch-license-validation.ts
+++ b/src/lib/license-validation/patch-license-validation.ts
@@ -10,6 +10,7 @@ import { COLLECTION } from "@/lib/club-registration/list-registrations";
 import { normalizeLicenseValidationStatus } from "@/lib/license-validation/license-validation-status";
 import { mapRegistrationToLicenseValidationDetail } from "@/lib/license-validation/map-registration";
 import { resolveLicenseValidationPatchFields } from "@/lib/license-validation/resolve-license-validation-patch";
+import { syncRosterAfterRegistrationChange } from "@/lib/championship/sync-after-registration";
 
 export type LicenseValidationPatchInput = {
   ffttLicense?: unknown;
@@ -103,6 +104,8 @@ export async function patchLicenseValidation(
     },
     success: true,
   });
+
+  await syncRosterAfterRegistrationChange(db, registrationId);
 
   return { ok: true, data: detail };
 }

--- a/src/lib/license-validation/receive-payment.ts
+++ b/src/lib/license-validation/receive-payment.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/club-registration/payment-constants";
 import { normalizePaymentReference } from "@/lib/club-registration/payment/payment-reference";
 import { wouldCreateOverpayment } from "@/lib/club-registration/payment/overpayment";
+import { syncRosterAfterRegistrationChange } from "@/lib/championship/sync-after-registration";
 
 const ALLOWED_METHODS = new Set<ReceivedPaymentMethodId>(RECEIVED_PAYMENT_METHOD_IDS);
 
@@ -159,6 +160,8 @@ export async function receiveLicenseValidationPayment(
     },
     success: true,
   });
+
+  await syncRosterAfterRegistrationChange(db, registrationId);
 
   return { ok: true };
 }

--- a/src/lib/players/current-club-license.test.ts
+++ b/src/lib/players/current-club-license.test.ts
@@ -1,0 +1,53 @@
+import {
+  currentClubLicenseFields,
+  isPlayableLicenseType,
+  typeLicenceFromFfttDetails,
+} from "./current-club-license";
+
+describe("currentClubLicenseFields", () => {
+  it("treats leftover last-season T/P/A as inactive when not on the club list", () => {
+    expect(
+      currentClubLicenseFields({
+        listedInClub: false,
+        license: "1234567",
+        typeLicence: "T",
+      })
+    ).toEqual({ isActive: false, typeLicence: "" });
+  });
+
+  it("keeps the FFTT type for people currently on the club list", () => {
+    expect(
+      currentClubLicenseFields({
+        listedInClub: true,
+        license: "1234567",
+        typeLicence: "P",
+      })
+    ).toEqual({ isActive: true, typeLicence: "P" });
+  });
+
+  it("does not mark listed members without a playable type as active", () => {
+    expect(
+      currentClubLicenseFields({
+        listedInClub: true,
+        license: "5984668",
+        typeLicence: "",
+      })
+    ).toEqual({ isActive: false, typeLicence: "" });
+  });
+});
+
+describe("typeLicenceFromFfttDetails", () => {
+  it("turns a null FFTT type into an empty string so last season T/P/A can be overwritten", () => {
+    expect(typeLicenceFromFfttDetails(null)).toBe("");
+    expect(typeLicenceFromFfttDetails(undefined)).toBe("");
+    expect(typeLicenceFromFfttDetails("T")).toBe("T");
+  });
+});
+
+describe("isPlayableLicenseType", () => {
+  it("accepts T, P and A only", () => {
+    expect(isPlayableLicenseType("T")).toBe(true);
+    expect(isPlayableLicenseType("p")).toBe(true);
+    expect(isPlayableLicenseType("X")).toBe(false);
+  });
+});

--- a/src/lib/players/current-club-license.ts
+++ b/src/lib/players/current-club-license.ts
@@ -1,0 +1,38 @@
+/**
+ * Current-season club licence = FFTT details type T/P/A.
+ * `getJoueursByClub` can still list SQY affiliates with a null type (no season licence).
+ */
+
+export type ClubLicenseInput = {
+  listedInClub?: boolean | null;
+  license?: string | null;
+  typeLicence?: string | null;
+};
+
+export function typeLicenceFromFfttDetails(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function isPlayableLicenseType(
+  typeLicence: string | null | undefined
+): boolean {
+  const type = (typeLicence ?? "").trim().toUpperCase();
+  return type === "T" || type === "P" || type === "A";
+}
+
+export function currentClubLicenseFields(input: ClubLicenseInput): {
+  isActive: boolean;
+  typeLicence: string;
+} {
+  const listedInClub = input.listedInClub === true;
+  const rawType = typeLicenceFromFfttDetails(input.typeLicence);
+  const typeLicence =
+    listedInClub && isPlayableLicenseType(rawType) ? rawType : "";
+  return {
+    typeLicence,
+    isActive:
+      listedInClub &&
+      Boolean((input.license ?? "").trim()) &&
+      isPlayableLicenseType(rawType),
+  };
+}

--- a/src/lib/server/team-matches.ts
+++ b/src/lib/server/team-matches.ts
@@ -1,5 +1,13 @@
 import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
+import { parseSeasonAgeReferenceDate } from "@/lib/club-registration/season-age";
+import { getDefaultRegistrationConfig } from "@/lib/club-registration-config/default-config";
+import { readPublishedSeasonLabel } from "@/lib/championship/season-label";
+import {
+  selectCurrentSeasonTeams,
+  selectLatestEpreuveGenerations,
+} from "@/lib/shared/team-listing";
+import { classifyClubChampionshipEpreuve } from "@/lib/shared/epreuve-utils";
 
 // Fonction helper pour convertir les Timestamps Firestore en Date
 function convertFirestoreTimestamp(value: unknown): Date | null {
@@ -54,7 +62,8 @@ export interface TeamMatch {
   isFemale?: boolean;
   division?: string;
   teamId?: string;
-  epreuve?: string;
+  epreuve?: string | undefined;
+  idEpreuve?: number | undefined;
   score?: unknown;
   result?: string;
   rencontreId?: string;
@@ -63,6 +72,7 @@ export interface TeamMatch {
   resultatsIndividuels?: unknown;
   joueursSQY: unknown[];
   joueursAdversaires: unknown[];
+  listedInFftt?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -77,17 +87,18 @@ export interface TeamSummary {
   discordChannelId?: string; // ID du canal Discord associé à l'équipe
   epreuve?: string; // Libellé de l'épreuve FFTT
   idEpreuve?: number; // ID de l'épreuve FFTT (15954, 15955, 15980, etc.)
+  listedInFftt?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export async function getTeams(firestore: Firestore): Promise<TeamSummary[]> {
   const teamsSnapshot = await firestore.collection("teams").get();
+  const seasonStart = await readSeasonStart(firestore);
 
-  const teams: TeamSummary[] = [];
-  teamsSnapshot.forEach((doc) => {
+  const mapped: TeamSummary[] = teamsSnapshot.docs.map((doc) => {
     const data = doc.data();
-    teams.push({
+    return {
       id: doc.id,
       name: data.name,
       division: data.division,
@@ -97,12 +108,34 @@ export async function getTeams(firestore: Firestore): Promise<TeamSummary[]> {
       discordChannelId: data.discordChannelId,
       epreuve: data.epreuve,
       idEpreuve: data.idEpreuve,
-      createdAt: data.createdAt?.toDate?.() || data.createdAt || new Date(),
-      updatedAt: data.updatedAt?.toDate?.() || data.updatedAt || new Date(),
-    });
+      listedInFftt: data.listedInFftt === true,
+      createdAt: convertFirestoreTimestamp(data.createdAt) || new Date(),
+      updatedAt: convertFirestoreTimestamp(data.updatedAt) || new Date(),
+    };
   });
 
+  const seasonal = selectCurrentSeasonTeams(
+    mapped,
+    (team) => ({
+      listedInFftt: team.listedInFftt === true,
+      updatedAt: team.updatedAt,
+    }),
+    seasonStart
+  );
+  const teams = selectLatestEpreuveGenerations(seasonal, (team) => ({
+    epreuveType: classifyClubChampionshipEpreuve({
+      idEpreuve: team.idEpreuve,
+      epreuve: team.epreuve,
+    }),
+    idEpreuve: team.idEpreuve,
+    updatedAt: team.updatedAt,
+  }));
+
   teams.sort((a, b) => (a.teamNumber || 0) - (b.teamNumber || 0));
+
+  console.log(
+    `📊 [getTeams] ${teams.length} équipes saison courante (${mapped.length} docs, listedInFftt=${mapped.filter((team) => team.listedInFftt).length})`
+  );
 
   return teams;
 }
@@ -117,7 +150,7 @@ export async function getTeamMatches(
     .collection("matches")
     .get();
 
-  const matches: TeamMatch[] = [];
+  const mapped: TeamMatch[] = [];
 
   matchesSnapshot.forEach((doc) => {
     const data = doc.data();
@@ -128,7 +161,7 @@ export async function getTeamMatches(
       return new Date();
     })();
     
-    matches.push({
+    mapped.push({
       id: doc.id,
       ffttId: data.ffttId,
       teamNumber: data.teamNumber,
@@ -145,6 +178,7 @@ export async function getTeamMatches(
       division: data.division,
       teamId: data.teamId,
       epreuve: data.epreuve,
+      idEpreuve: data.idEpreuve,
       score: data.score,
       result: data.result,
       rencontreId: data.rencontreId,
@@ -153,10 +187,28 @@ export async function getTeamMatches(
       resultatsIndividuels: data.resultatsIndividuels,
       joueursSQY: data.joueursSQY || [],
       joueursAdversaires: data.joueursAdversaires || [],
+      listedInFftt: data.listedInFftt === true,
       createdAt: convertFirestoreTimestamp(data.createdAt) || new Date(),
       updatedAt: convertFirestoreTimestamp(data.updatedAt) || new Date(),
     });
   });
+
+  const seasonal = selectCurrentSeasonTeams(
+    mapped,
+    (match) => ({
+      listedInFftt: match.listedInFftt === true,
+      updatedAt: match.updatedAt,
+    }),
+    null
+  );
+  const matches = selectLatestEpreuveGenerations(seasonal, (match) => ({
+    epreuveType: classifyClubChampionshipEpreuve({
+      idEpreuve: match.idEpreuve,
+      epreuve: match.epreuve,
+    }),
+    idEpreuve: match.idEpreuve,
+    updatedAt: match.updatedAt,
+  }));
 
   matches.sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
@@ -164,4 +216,16 @@ export async function getTeamMatches(
 
   return matches;
 }
+
+async function readSeasonStart(firestore: Firestore): Promise<Date | null> {
+  try {
+    const label = await readPublishedSeasonLabel(firestore);
+    return parseSeasonAgeReferenceDate(label);
+  } catch {
+    return parseSeasonAgeReferenceDate(
+      getDefaultRegistrationConfig().meta.seasonLabel
+    );
+  }
+}
+
 

--- a/src/lib/services/composition-defaults-service.ts
+++ b/src/lib/services/composition-defaults-service.ts
@@ -6,6 +6,7 @@ import {
 } from "firebase/firestore";
 import { getDbInstanceDirect } from "@/lib/firebase";
 import { ChampionshipType } from "@/types";
+import { getCompositionDefaultsDocumentId } from "@/lib/compositions/document-id";
 
 export interface PhaseCompositionDefaults {
   phase: "aller" | "retour";
@@ -19,17 +20,19 @@ export class CompositionDefaultsService {
 
   private getDocumentId(
     phase: "aller" | "retour",
-    championshipType: ChampionshipType
+    championshipType: ChampionshipType,
+    idEpreuve?: number
   ): string {
-    return `${phase}_${championshipType}`;
+    return getCompositionDefaultsDocumentId(phase, championshipType, idEpreuve);
   }
 
   async getDefaults(
     phase: "aller" | "retour",
-    championshipType: ChampionshipType
+    championshipType: ChampionshipType,
+    idEpreuve?: number | undefined
   ): Promise<PhaseCompositionDefaults | null> {
     try {
-      const docId = this.getDocumentId(phase, championshipType);
+      const docId = this.getDocumentId(phase, championshipType, idEpreuve);
       const docRef = doc(getDbInstanceDirect(), this.collectionName, docId);
       const docSnap = await getDoc(docRef);
 
@@ -62,11 +65,12 @@ export class CompositionDefaultsService {
     phase: "aller" | "retour";
     championshipType: ChampionshipType;
     teams: Record<string, string[]>;
+    idEpreuve?: number | undefined;
   }): Promise<void> {
-    const { phase, championshipType, teams } = params;
+    const { phase, championshipType, teams, idEpreuve } = params;
 
     try {
-      const docId = this.getDocumentId(phase, championshipType);
+      const docId = this.getDocumentId(phase, championshipType, idEpreuve);
       const docRef = doc(getDbInstanceDirect(), this.collectionName, docId);
 
       await setDoc(
@@ -76,6 +80,7 @@ export class CompositionDefaultsService {
           championshipType,
           teams,
           updatedAt: Timestamp.fromDate(new Date()),
+          ...(idEpreuve !== undefined ? { idEpreuve } : {}),
         },
         { merge: true }
       );

--- a/src/lib/services/composition-service.ts
+++ b/src/lib/services/composition-service.ts
@@ -8,6 +8,7 @@ import {
 } from "firebase/firestore";
 import { getDbInstanceDirect } from "@/lib/firebase";
 import { ChampionshipType } from "@/types";
+import { getCompositionDocumentId } from "@/lib/compositions/document-id";
 
 export interface DayComposition {
   journee: number;
@@ -16,6 +17,7 @@ export interface DayComposition {
   teams: {
     [teamId: string]: string[]; // teamId -> playerIds[]
   };
+  idEpreuve?: number | undefined;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -26,18 +28,25 @@ export class CompositionService {
   private getDocumentId(
     journee: number,
     phase: "aller" | "retour",
-    championshipType: ChampionshipType
+    championshipType: ChampionshipType,
+    idEpreuve?: number
   ): string {
-    return `${phase}_${journee}_${championshipType}`;
+    return getCompositionDocumentId(journee, phase, championshipType, idEpreuve);
   }
 
   async getComposition(
     journee: number,
     phase: "aller" | "retour",
-    championshipType: ChampionshipType
+    championshipType: ChampionshipType,
+    idEpreuve?: number
   ): Promise<DayComposition | null> {
     try {
-      const docId = this.getDocumentId(journee, phase, championshipType);
+      const docId = this.getDocumentId(
+        journee,
+        phase,
+        championshipType,
+        idEpreuve
+      );
       const docRef = doc(getDbInstanceDirect(), this.collectionName, docId);
       const docSnap = await getDoc(docRef);
 
@@ -71,7 +80,8 @@ export class CompositionService {
       const docId = this.getDocumentId(
         composition.journee,
         composition.phase,
-        composition.championshipType
+        composition.championshipType,
+        composition.idEpreuve
       );
       const docRef = doc(getDbInstanceDirect(), this.collectionName, docId);
 
@@ -87,6 +97,9 @@ export class CompositionService {
             : Timestamp.fromDate(new Date(composition.createdAt))
           : Timestamp.fromDate(new Date()),
       };
+      if (composition.idEpreuve !== undefined) {
+        dataToSave.idEpreuve = composition.idEpreuve;
+      }
 
       await setDoc(docRef, dataToSave, { merge: true });
     } catch (error) {
@@ -107,10 +120,16 @@ export class CompositionService {
     journee: number,
     phase: "aller" | "retour",
     championshipType: ChampionshipType,
-    callback: (composition: DayComposition | null) => void
+    callback: (composition: DayComposition | null) => void,
+    idEpreuve?: number
   ): Unsubscribe {
     try {
-      const docId = this.getDocumentId(journee, phase, championshipType);
+      const docId = this.getDocumentId(
+        journee,
+        phase,
+        championshipType,
+        idEpreuve
+      );
       const docRef = doc(getDbInstanceDirect(), this.collectionName, docId);
 
       const unsubscribe = onSnapshot(

--- a/src/lib/services/firestore-player-service.ts
+++ b/src/lib/services/firestore-player-service.ts
@@ -14,6 +14,7 @@ import {
   deleteField,
 } from "firebase/firestore";
 import { getDbInstanceDirect } from "@/lib/firebase";
+import { currentClubLicenseFields } from "@/lib/players/current-club-license";
 import { Player } from "@/types/team-management";
 
 export class FirestorePlayerService {
@@ -22,12 +23,19 @@ export class FirestorePlayerService {
   // Convertir les données Firestore vers le format Player
   private convertFirestoreToPlayer(doc: QueryDocumentSnapshot<DocumentData>): Player {
     const data = doc.data();
+    const listedInClub = data.listedInClub === true;
+    const license = data.licence || "";
+    const { isActive, typeLicence } = currentClubLicenseFields({
+      listedInClub,
+      license,
+      typeLicence: data.typeLicence || "",
+    });
     return {
       id: doc.id,
       name: data.nom || "",
       firstName: data.prenom || "",
-      license: data.licence || "",
-      typeLicence: data.typeLicence || "",
+      license,
+      typeLicence,
       gender: data.sexe === "F" ? "F" : "M",
       nationality:
         data.nationalite === "F"
@@ -35,12 +43,12 @@ export class FirestorePlayerService {
           : data.nationalite === "C"
           ? "C"
           : "ETR",
-      isActive: this.calculateIsActive(data.licence, data.typeLicence),
+      isActive,
       isTemporary: data.isTemporary || false,
-      isWheelchair: data.isWheelchair || false,
+      isWheelchair: data.isWheelchair === true,
+      listedInClub,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: data.updatedAt?.toDate() || new Date(),
-      // Champs de gestion des équipes
       preferredTeams: {
         masculine: data.preferredTeams?.masculine || [],
         feminine: data.preferredTeams?.feminine || [],
@@ -79,21 +87,6 @@ export class FirestorePlayerService {
       isHomme: data.isHomme,
       ...(data.place ? { place: parseInt(data.place) } : {}),
     };
-  }
-
-  // Calculer si un joueur est actif basé sur sa licence et son type
-  private calculateIsActive(licence: string, typeLicence?: string): boolean {
-    if (!licence || licence.trim() === "") {
-      return false; // Pas de licence = pas actif
-    }
-
-    // Si typeLicence existe, seuls T, P et A sont actifs
-    if (typeLicence) {
-      return typeLicence === "T" || typeLicence === "P" || typeLicence === "A";
-    }
-
-    // Si pas de typeLicence mais licence existe, considérer comme inactif
-    return false;
   }
 
   async getAllPlayers(): Promise<Player[]> {

--- a/src/lib/shared/epreuve-utils.test.ts
+++ b/src/lib/shared/epreuve-utils.test.ts
@@ -1,0 +1,104 @@
+import {
+  classifyClubChampionshipEpreuve,
+  getMatchEpreuve,
+  isParisEpreuve,
+  isTrackedClubChampionshipEpreuve,
+  resolveIdEpreuveFromEquipes,
+} from "./epreuve-utils";
+
+describe("classifyClubChampionshipEpreuve", () => {
+  it("keeps previous-season numeric IDs", () => {
+    expect(classifyClubChampionshipEpreuve({ idEpreuve: 15954 })).toBe(
+      "championnat_equipes"
+    );
+    expect(classifyClubChampionshipEpreuve({ idEpreuve: 15955 })).toBe(
+      "championnat_equipes"
+    );
+    expect(classifyClubChampionshipEpreuve({ idEpreuve: 15980 })).toBe(
+      "championnat_paris"
+    );
+  });
+
+  it("recognizes 2026-2027 France IDs and FED_ labels", () => {
+    expect(classifyClubChampionshipEpreuve({ idEpreuve: 18368 })).toBe(
+      "championnat_equipes"
+    );
+    expect(classifyClubChampionshipEpreuve({ idEpreuve: 18369 })).toBe(
+      "championnat_equipes"
+    );
+    expect(
+      isTrackedClubChampionshipEpreuve({
+        idEpreuve: 19999,
+        libelleEpreuve: "FED_Championnat de France par Equipes Masculin",
+      })
+    ).toBe(true);
+    expect(
+      isTrackedClubChampionshipEpreuve({
+        idEpreuve: 19998,
+        libelleEpreuve: "FED_Championnat de France par Equipes Féminin",
+      })
+    ).toBe(true);
+  });
+
+  it("ignores other FFTT competitions", () => {
+    expect(
+      isTrackedClubChampionshipEpreuve({
+        idEpreuve: 17000,
+        libelleEpreuve: "FED_Critérium fédéral",
+      })
+    ).toBe(false);
+    expect(
+      isTrackedClubChampionshipEpreuve({
+        idEpreuve: 17001,
+        libelleEpreuve: "Championnat de France individuel",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("getMatchEpreuve", () => {
+  it("classifies a new-season match by id even without a label", () => {
+    expect(getMatchEpreuve({ idEpreuve: 18368 })).toBe("championnat_equipes");
+  });
+
+  it("classifies from the stored team label", () => {
+    expect(
+      getMatchEpreuve(
+        {},
+        { epreuve: "FED_Championnat de France par Equipes Masculin" }
+      )
+    ).toBe("championnat_equipes");
+  });
+});
+
+describe("isParisEpreuve", () => {
+  it("detects Paris from type or label", () => {
+    expect(isParisEpreuve("championnat_paris")).toBe(true);
+    expect(isParisEpreuve("Championnat de Paris IDF (Excellence)")).toBe(true);
+    expect(isParisEpreuve("FED_Championnat de France par Equipes Masculin")).toBe(
+      false
+    );
+  });
+});
+
+describe("resolveIdEpreuveFromEquipes", () => {
+  const equipes = [
+    {
+      team: { idEpreuve: 18368, epreuve: "FED_Championnat de France par Equipes Masculin" },
+      matches: [{ isFemale: false }],
+    },
+    {
+      team: { idEpreuve: 18369, epreuve: "FED_Championnat de France par Equipes Féminin" },
+      matches: [{ isFemale: true }],
+    },
+  ];
+
+  it("picks the current France epreuve id by gender", () => {
+    expect(resolveIdEpreuveFromEquipes(equipes, "masculin", "championnat_equipes")).toBe(
+      18368
+    );
+    expect(resolveIdEpreuveFromEquipes(equipes, "feminin", "championnat_equipes")).toBe(
+      18369
+    );
+  });
+});

--- a/src/lib/shared/epreuve-utils.ts
+++ b/src/lib/shared/epreuve-utils.ts
@@ -1,11 +1,127 @@
-// Type pour les épreuves : "championnat_equipes" regroupe les épreuves 15954 (masculin) et 15955 (féminin)
-// "championnat_paris" correspond à l'épreuve 15980
+// Type pour les épreuves : "championnat_equipes" regroupe France masculin/féminin.
+// "championnat_paris" correspond au championnat de Paris IDF (Excellence).
 export type EpreuveType = "championnat_equipes" | "championnat_paris";
 
-// ID des épreuves FFTT
+export type FfttEpreuveRef = {
+  idEpreuve?: number | null | undefined;
+  libelleEpreuve?: string | null | undefined;
+  epreuve?: string | null | undefined;
+};
+
+// IDs FFTT connus (saisons passées + courante). Ils changent chaque année :
+// le libellé reste la source de vérité pour la synchro.
 export const ID_EPREUVE_MASCULIN = 15954;
 export const ID_EPREUVE_FEMININ = 15955;
 export const ID_EPREUVE_PARIS = 15980;
+
+const KNOWN_FRANCE_TEAM_EPREUVE_IDS: ReadonlySet<number> = new Set([
+  ID_EPREUVE_MASCULIN,
+  ID_EPREUVE_FEMININ,
+  18368, // 2026-2027 masculin
+  18369, // 2026-2027 féminin
+]);
+
+const KNOWN_PARIS_EPREUVE_IDS: ReadonlySet<number> = new Set([ID_EPREUVE_PARIS]);
+
+function normalizeEpreuveLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[éèêë]/g, "e")
+    .replace(/[àâ]/g, "a")
+    .replace(/[îï]/g, "i")
+    .replace(/[ôö]/g, "o")
+    .replace(/[ùûü]/g, "u")
+    .replace(/ç/g, "c")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function epreuveLabelOf(params: FfttEpreuveRef): string {
+  return normalizeEpreuveLabel(params.libelleEpreuve ?? params.epreuve ?? "");
+}
+
+function classifyFromLabel(label: string): EpreuveType | null {
+  if (!label) return null;
+  if (label.includes("paris idf") || (label.includes("excellence") && label.includes("paris"))) {
+    return "championnat_paris";
+  }
+  if (label.includes("excellence") && !label.includes("championnat de france")) {
+    return "championnat_paris";
+  }
+  const isFranceTeams =
+    label.includes("championnat de france") &&
+    (label.includes("equipe") || label.includes("equipes") || label.includes("par equipe"));
+  if (isFranceTeams) {
+    return "championnat_equipes";
+  }
+  return null;
+}
+
+export function classifyClubChampionshipEpreuve(
+  params: FfttEpreuveRef
+): EpreuveType | null {
+  const idEpreuve = params.idEpreuve ?? null;
+  if (idEpreuve != null && KNOWN_FRANCE_TEAM_EPREUVE_IDS.has(idEpreuve)) {
+    return "championnat_equipes";
+  }
+  if (idEpreuve != null && KNOWN_PARIS_EPREUVE_IDS.has(idEpreuve)) {
+    return "championnat_paris";
+  }
+  return classifyFromLabel(epreuveLabelOf(params));
+}
+
+export function isTrackedClubChampionshipEpreuve(params: FfttEpreuveRef): boolean {
+  return classifyClubChampionshipEpreuve(params) != null;
+}
+
+export type ChampionshipGender = "masculin" | "feminin";
+
+export function resolveIdEpreuveFromEquipes(
+  equipes: ReadonlyArray<{
+    team: {
+      idEpreuve?: number | undefined;
+      epreuve?: string | undefined;
+      isFemale?: boolean | undefined;
+    };
+    matches?: ReadonlyArray<{ isFemale?: boolean | undefined }>;
+  }>,
+  championshipType: ChampionshipGender,
+  epreuveType?: EpreuveType | null
+): number | undefined {
+  const wantParis = epreuveType === "championnat_paris";
+  const wantFemale = championshipType === "feminin";
+
+  for (const equipe of equipes) {
+    const classified = classifyClubChampionshipEpreuve({
+      idEpreuve: equipe.team.idEpreuve,
+      epreuve: equipe.team.epreuve,
+    });
+    if (wantParis) {
+      if (classified === "championnat_paris" && equipe.team.idEpreuve != null) {
+        return equipe.team.idEpreuve;
+      }
+      continue;
+    }
+    if (classified === "championnat_paris") {
+      continue;
+    }
+    const isFemale =
+      equipe.team.isFemale === true ||
+      equipe.matches?.some((match) => match.isFemale === true) === true;
+    if (isFemale !== wantFemale) {
+      continue;
+    }
+    if (equipe.team.idEpreuve != null) {
+      return equipe.team.idEpreuve;
+    }
+  }
+
+  if (wantParis) {
+    return ID_EPREUVE_PARIS;
+  }
+  return undefined;
+}
 
 /**
  * Calcule l'idEpreuve à partir de selectedEpreuve
@@ -32,30 +148,13 @@ export function getIdEpreuve(epreuve: EpreuveType | null): number | undefined {
  */
 export function getMatchEpreuve(
   match: { idEpreuve?: number },
-  equipe?: { idEpreuve?: number; epreuve?: string }
+  equipe?: { idEpreuve?: number; epreuve?: string; libelleEpreuve?: string }
 ): EpreuveType | null {
-  // Essayer d'abord depuis le match
-  const idEpreuve = match.idEpreuve ?? equipe?.idEpreuve;
-  
-  if (idEpreuve === ID_EPREUVE_MASCULIN || idEpreuve === ID_EPREUVE_FEMININ) {
-    return "championnat_equipes";
-  }
-  if (idEpreuve === ID_EPREUVE_PARIS) {
-    return "championnat_paris";
-  }
-  
-  // Fallback : vérifier le libellé de l'épreuve
-  if (equipe?.epreuve) {
-    const epreuveLower = equipe.epreuve.toLowerCase();
-    if (epreuveLower.includes("paris idf") || epreuveLower.includes("excellence")) {
-      return "championnat_paris";
-    }
-    if (epreuveLower.includes("championnat de france") || epreuveLower.includes("par équipes")) {
-      return "championnat_equipes";
-    }
-  }
-  
-  return null;
+  return classifyClubChampionshipEpreuve({
+    idEpreuve: match.idEpreuve ?? equipe?.idEpreuve,
+    epreuve: equipe?.epreuve,
+    libelleEpreuve: equipe?.libelleEpreuve,
+  });
 }
 
 /**
@@ -66,9 +165,7 @@ export function isParisEpreuve(epreuve: EpreuveType | string | null | undefined)
   if (epreuve == null) return false;
   if (epreuve === "championnat_paris") return true;
   if (typeof epreuve === "string") {
-    const lower = epreuve.toLowerCase();
-    return lower.includes("excellence") || lower.includes("paris idf");
+    return classifyFromLabel(normalizeEpreuveLabel(epreuve)) === "championnat_paris";
   }
   return false;
 }
-

--- a/src/lib/shared/mark-matches-listed-in-fftt.ts
+++ b/src/lib/shared/mark-matches-listed-in-fftt.ts
@@ -1,0 +1,46 @@
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+
+export async function markMatchesListedInFftt(
+  db: Firestore,
+  teamId: string,
+  listedMatchIds: Iterable<string>
+): Promise<{ listed: number; unlisted: number }> {
+  const listed = new Set([...listedMatchIds].filter(Boolean));
+  if (!teamId || listed.size === 0) {
+    return { listed: 0, unlisted: 0 };
+  }
+
+  const snap = await db.collection("teams").doc(teamId).collection("matches").get();
+  const now = FieldValue.serverTimestamp();
+  const pending: Array<{ ref: DocumentReference; listedInFftt: boolean }> = [];
+  let listedCount = 0;
+  let unlistedCount = 0;
+
+  for (const doc of snap.docs) {
+    const listedInFftt = listed.has(doc.id);
+    pending.push({ ref: doc.ref, listedInFftt });
+    if (listedInFftt) {
+      listedCount += 1;
+    } else {
+      unlistedCount += 1;
+    }
+  }
+
+  const chunkSize = 400;
+  for (let i = 0; i < pending.length; i += chunkSize) {
+    const batch = db.batch();
+    for (const item of pending.slice(i, i + chunkSize)) {
+      batch.set(
+        item.ref,
+        item.listedInFftt
+          ? { listedInFftt: true, lastSeenInFfttAt: now }
+          : { listedInFftt: false },
+        { merge: true }
+      );
+    }
+    await batch.commit();
+  }
+
+  return { listed: listedCount, unlisted: unlistedCount };
+}

--- a/src/lib/shared/mark-teams-listed-in-fftt.ts
+++ b/src/lib/shared/mark-teams-listed-in-fftt.ts
@@ -1,0 +1,48 @@
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+
+const TEAMS = "teams";
+
+export async function markTeamsListedInFftt(
+  db: Firestore,
+  listedTeamIds: Iterable<string>
+): Promise<{ listed: number; unlisted: number }> {
+  const listed = new Set([...listedTeamIds].filter(Boolean));
+  // Une synchro vide (mauvais filtre d'épreuve, API partielle) ne doit pas
+  // dé-lister tout le club.
+  if (listed.size === 0) {
+    return { listed: 0, unlisted: 0 };
+  }
+  const snap = await db.collection(TEAMS).get();
+  const now = FieldValue.serverTimestamp();
+  const pending: Array<{ ref: DocumentReference; listedInFftt: boolean }> = [];
+  let listedCount = 0;
+  let unlistedCount = 0;
+
+  for (const doc of snap.docs) {
+    const listedInFftt = listed.has(doc.id);
+    pending.push({ ref: doc.ref, listedInFftt });
+    if (listedInFftt) {
+      listedCount += 1;
+    } else {
+      unlistedCount += 1;
+    }
+  }
+
+  const chunkSize = 400;
+  for (let i = 0; i < pending.length; i += chunkSize) {
+    const batch = db.batch();
+    for (const item of pending.slice(i, i + chunkSize)) {
+      batch.set(
+        item.ref,
+        item.listedInFftt
+          ? { listedInFftt: true, lastSeenInFfttAt: now }
+          : { listedInFftt: false },
+        { merge: true }
+      );
+    }
+    await batch.commit();
+  }
+
+  return { listed: listedCount, unlisted: unlistedCount };
+}

--- a/src/lib/shared/player-sync.ts
+++ b/src/lib/shared/player-sync.ts
@@ -1,8 +1,11 @@
 import { FFTTAPI } from "@omichalo/ffttapi-node";
 import { createFFTTAPI, getFFTTConfig } from "./fftt-utils";
 import { FFTTJoueurDetails } from "./fftt-types";
-import type { Firestore, DocumentReference } from "firebase-admin/firestore";
+import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
+import { markPlayersListedInClub } from "@/lib/championship/mark-listed-in-club";
+import { refreshUnlistedPlayerMirrors } from "@/lib/championship/unlisted-player-mirror";
+import { typeLicenceFromFfttDetails } from "@/lib/players/current-club-license";
 
 export interface PlayerSyncResult {
   success: boolean;
@@ -261,6 +264,8 @@ export class PlayerSyncService {
           enrichedPlayer[key] = details[key];
         }
       });
+      // Null typeLicence must overwrite last season's T/P/A (Firestore merge keeps stale values).
+      enrichedPlayer.typeLicence = typeLicenceFromFfttDetails(details.typeLicence);
     }
 
     return enrichedPlayer;
@@ -282,108 +287,28 @@ export class PlayerSyncService {
         `💾 Sauvegarde de ${players.length} joueurs enrichis dans Firestore...`
       );
 
-      // Traitement par batch pour éviter les limites Firestore
       const batchSize = 500;
       for (let i = 0; i < players.length; i += batchSize) {
-        const batchEnd = Math.min(i + batchSize, players.length);
-        const batchPlayers = players.slice(i, batchEnd);
-
-        // OPTIMISATION : Récupérer tous les documents existants en une seule requête
-        // au lieu de faire une requête par joueur
-        // Note: getAll() peut récupérer jusqu'à 10 documents à la fois
-        const docRefs = batchPlayers.map((player) =>
-          db.collection("players").doc(player.licence)
-        );
-        
-        console.log(
-          `📥 Récupération des données existantes pour le batch ${
-            Math.floor(i / batchSize) + 1
-          } (${docRefs.length} documents)...`
-        );
-        
-        // Créer une Map pour un accès rapide aux données existantes
-        const existingDataMap = new Map<string, Record<string, unknown>>();
-        
-        // getAll() peut récupérer jusqu'à 10 documents à la fois
-        // Diviser en sous-batches de 10 et les traiter en parallèle pour optimiser
-        const getAllBatchSize = 10;
-        const getAllBatches: Array<Array<DocumentReference>> = [];
-        
-        for (let k = 0; k < docRefs.length; k += getAllBatchSize) {
-          getAllBatches.push(docRefs.slice(k, k + getAllBatchSize));
-        }
-        
-        // Traiter les batches getAll() en parallèle (max 5 à la fois pour ne pas surcharger)
-        const maxConcurrentGetAll = 5;
-        for (let k = 0; k < getAllBatches.length; k += maxConcurrentGetAll) {
-          const concurrentBatches = getAllBatches.slice(k, k + maxConcurrentGetAll);
-          const getAllPromises = concurrentBatches.map((batch) => db.getAll(...batch));
-          
-          const results = await Promise.all(getAllPromises);
-          
-          results.forEach((docs) => {
-            docs.forEach((doc) => {
-              if (doc.exists) {
-                existingDataMap.set(doc.id, doc.data() as Record<string, unknown>);
-              }
-            });
-          });
-        }
-
-        // Préparer le batch d'écriture
+        const batchPlayers = players.slice(i, Math.min(i + batchSize, players.length));
         const batch = db.batch();
-
-        // Préserver UNIQUEMENT les champs de gestion qui ne viennent pas de l'API FFTT
-        // Ces champs sont gérés manuellement par l'utilisateur et ne doivent pas être écrasés
-        const userManagedFields = [
-          "discordMentions",
-          "participation",
-          "preferredTeams",
-          "isTemporary",
-          "isWheelchair", // Préservé car géré manuellement par l'utilisateur (non remonté par l'API FFTT)
-          "hasPlayedAtLeastOneMatch", // Préservé car géré par la synchro des matchs
-          "highestMasculineTeamNumberByPhase", // Préservé car géré par la synchro des matchs (règles de brûlage par phase)
-          "highestFeminineTeamNumberByPhase", // Préservé car géré par la synchro des matchs (règles de brûlage par phase)
-          "masculineMatchesByTeamByPhase", // Préservé car géré par la synchro des matchs (affichage du brûlage par phase)
-          "feminineMatchesByTeamByPhase", // Préservé car géré par la synchro des matchs (affichage du brûlage par phase)
-        ];
 
         for (const player of batchPlayers) {
           try {
-            const docRef = db.collection("players").doc(player.licence);
-            const existingData = existingDataMap.get(player.licence) || {};
-
-            // Filtrer les valeurs undefined et préparer les données pour Firestore
             const playerData = Object.fromEntries(
               Object.entries(player).filter(([, value]) => value !== undefined)
             );
-
-            // Si le joueur existant est temporaire, tout écraser (ne pas préserver les champs userManagedFields)
-            const isExistingTemporary = existingData.isTemporary === true;
-            
-            if (!isExistingTemporary) {
-              // Préserver les champs de gestion uniquement si le joueur n'est pas temporaire
-              userManagedFields.forEach((field) => {
-                // Préserver le champ s'il existe dans les données existantes (même s'il est vide/null)
-                // Ces champs ne viennent pas de l'API FFTT et doivent être préservés
-                if (existingData && existingData[field] !== undefined) {
-                  playerData[field] = existingData[field];
-                }
-              });
-            } else {
-              // Si le joueur est temporaire, tout écraser et marquer comme non temporaire
-              playerData.isTemporary = false;
-            }
-
-            // Convertir les dates en Timestamp Firestore
             if (playerData.createdAt instanceof Date) {
               playerData.createdAt = Timestamp.fromDate(playerData.createdAt);
             }
             if (playerData.updatedAt instanceof Date) {
               playerData.updatedAt = Timestamp.fromDate(playerData.updatedAt);
             }
-
-            batch.set(docRef, playerData, { merge: true });
+            playerData.listedInClub = true;
+            batch.set(
+              db.collection("players").doc(player.licence),
+              playerData,
+              { merge: true }
+            );
             saved++;
           } catch (playerError) {
             console.error(
@@ -394,16 +319,20 @@ export class PlayerSyncService {
           }
         }
 
-        // Commiter le batch
         await batch.commit();
         console.log(
-          `✅ Batch ${
-            Math.floor(i / batchSize) + 1
-          } sauvegardé (${saved} joueurs enrichis, ${errors} erreurs)`
+          `✅ Batch ${Math.floor(i / batchSize) + 1} sauvegardé (${saved} joueurs enrichis, ${errors} erreurs)`
         );
       }
 
-      // Mettre à jour les métadonnées
+      await markPlayersListedInClub(
+        db,
+        players.map((player) => player.licence)
+      );
+      await refreshUnlistedPlayerMirrors(db, (licence) =>
+        this.getPlayerDetails(licence)
+      );
+
       await db.collection("metadata").doc("lastSync").set(
         {
           players: new Date(),

--- a/src/lib/shared/team-listing.test.ts
+++ b/src/lib/shared/team-listing.test.ts
@@ -1,0 +1,113 @@
+import {
+  isCurrentSeasonTeam,
+  selectCurrentSeasonTeams,
+  selectLatestEpreuveGenerations,
+} from "./team-listing";
+
+describe("isCurrentSeasonTeam", () => {
+  const seasonStart = new Date(2025, 8, 1, 12, 0, 0);
+
+  it("keeps only FFTT-listed teams once the flag exists", () => {
+    expect(
+      isCurrentSeasonTeam({
+        listedInFftt: true,
+        anyTeamListedInFftt: true,
+      })
+    ).toBe(true);
+    expect(
+      isCurrentSeasonTeam({
+        listedInFftt: false,
+        anyTeamListedInFftt: true,
+        updatedAt: new Date(),
+        seasonStart,
+      })
+    ).toBe(false);
+    expect(
+      isCurrentSeasonTeam({
+        listedInFftt: undefined,
+        anyTeamListedInFftt: true,
+        seasonStart,
+      })
+    ).toBe(false);
+  });
+
+  it("hides stale teams before the first listedInFftt sync", () => {
+    expect(
+      isCurrentSeasonTeam({
+        listedInFftt: undefined,
+        anyTeamListedInFftt: false,
+        updatedAt: new Date(2025, 5, 15),
+        seasonStart,
+      })
+    ).toBe(false);
+    expect(
+      isCurrentSeasonTeam({
+        listedInFftt: undefined,
+        anyTeamListedInFftt: false,
+        updatedAt: new Date(2025, 9, 2),
+        seasonStart,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("selectCurrentSeasonTeams", () => {
+  const seasonStart = new Date(2026, 8, 1, 12, 0, 0);
+
+  it("does not empty the list when no team is listed and all look stale", () => {
+    const teams = [
+      { id: "old", listedInFftt: undefined, updatedAt: new Date(2025, 5, 1) },
+    ];
+    expect(
+      selectCurrentSeasonTeams(teams, (team) => team, seasonStart)
+    ).toEqual(teams);
+  });
+});
+
+describe("selectLatestEpreuveGenerations", () => {
+  it("drops last year's France epreuve IDs when the new season is present", () => {
+    const now = new Date("2026-08-22T16:26:00Z");
+    const lastYear = new Date("2026-05-01T10:00:00Z");
+    const teams = [
+      {
+        id: "old-m",
+        epreuveType: "championnat_equipes",
+        idEpreuve: 15954,
+        updatedAt: lastYear,
+      },
+      {
+        id: "new-m",
+        epreuveType: "championnat_equipes",
+        idEpreuve: 18368,
+        updatedAt: now,
+      },
+      {
+        id: "new-f",
+        epreuveType: "championnat_equipes",
+        idEpreuve: 18369,
+        updatedAt: now,
+      },
+      {
+        id: "paris",
+        epreuveType: "championnat_paris",
+        idEpreuve: 15980,
+        updatedAt: lastYear,
+      },
+    ];
+    expect(
+      selectLatestEpreuveGenerations(teams, (team) => team).map((team) => team.id)
+    ).toEqual(["new-m", "new-f", "paris"]);
+  });
+
+  it("keeps a single epreuve generation unchanged", () => {
+    const teams = [
+      {
+        id: "a",
+        epreuveType: "championnat_equipes",
+        idEpreuve: 15954,
+        updatedAt: new Date("2026-03-01"),
+      },
+    ];
+    expect(selectLatestEpreuveGenerations(teams, (team) => team)).toEqual(teams);
+  });
+});

--- a/src/lib/shared/team-listing.ts
+++ b/src/lib/shared/team-listing.ts
@@ -1,0 +1,92 @@
+/** IDs d'épreuve FFTT changent chaque saison : on garde la génération la plus récente. */
+const EPREUVE_GENERATION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function isCurrentSeasonTeam(params: {
+  listedInFftt?: boolean | null;
+  updatedAt?: Date | null;
+  anyTeamListedInFftt: boolean;
+  seasonStart?: Date | null;
+}): boolean {
+  if (params.anyTeamListedInFftt) {
+    return params.listedInFftt === true;
+  }
+  const seasonStart = params.seasonStart ?? null;
+  const updatedAt = params.updatedAt ?? null;
+  if (seasonStart && updatedAt) {
+    return updatedAt.getTime() >= seasonStart.getTime();
+  }
+  return true;
+}
+
+export function selectCurrentSeasonTeams<T>(
+  teams: T[],
+  getState: (team: T) => {
+    listedInFftt?: boolean | null | undefined;
+    updatedAt?: Date | null | undefined;
+  },
+  seasonStart?: Date | null
+): T[] {
+  const anyTeamListedInFftt = teams.some(
+    (team) => getState(team).listedInFftt === true
+  );
+  const filtered = teams.filter((team) => {
+    const state = getState(team);
+    return isCurrentSeasonTeam({
+      listedInFftt: state.listedInFftt ?? null,
+      updatedAt: state.updatedAt ?? null,
+      anyTeamListedInFftt,
+      seasonStart: seasonStart ?? null,
+    });
+  });
+  if (!anyTeamListedInFftt && filtered.length === 0 && teams.length > 0) {
+    return teams;
+  }
+  return filtered;
+}
+
+export function selectLatestEpreuveGenerations<T>(
+  teams: T[],
+  getState: (team: T) => {
+    epreuveType?: string | null | undefined;
+    idEpreuve?: number | null | undefined;
+    updatedAt?: Date | null | undefined;
+  }
+): T[] {
+  const tracked = teams.filter((team) => Boolean(getState(team).epreuveType));
+  if (tracked.length === 0) {
+    return teams;
+  }
+
+  const byType = new Map<string, T[]>();
+  for (const team of tracked) {
+    const type = getState(team).epreuveType;
+    if (!type) continue;
+    const list = byType.get(type) ?? [];
+    list.push(team);
+    byType.set(type, list);
+  }
+
+  const kept: T[] = [];
+  for (const group of byType.values()) {
+    const maxUpdatedById = new Map<number | "none", number>();
+    for (const team of group) {
+      const id = getState(team).idEpreuve ?? "none";
+      const ts = getState(team).updatedAt?.getTime() ?? 0;
+      maxUpdatedById.set(id, Math.max(maxUpdatedById.get(id) ?? 0, ts));
+    }
+    const overallMax = Math.max(0, ...maxUpdatedById.values());
+    const cutoff = overallMax - EPREUVE_GENERATION_WINDOW_MS;
+    const currentIds = new Set(
+      [...maxUpdatedById.entries()]
+        .filter(([, ts]) => ts >= cutoff)
+        .map(([id]) => id)
+    );
+    kept.push(
+      ...group.filter((team) =>
+        currentIds.has(getState(team).idEpreuve ?? "none")
+      )
+    );
+  }
+  return kept;
+}
+

--- a/src/lib/shared/team-matches-sync-save.ts
+++ b/src/lib/shared/team-matches-sync-save.ts
@@ -6,6 +6,7 @@ import {
   hasMatchCompositionData,
   playerNameKey,
 } from "./team-matches-roster-utils";
+import { markMatchesListedInFftt } from "./mark-matches-listed-in-fftt";
 
 type SyncPlayer = NonNullable<MatchData["joueursSQY"]>[number];
 type ResultPlayer = { nom: string; prenom: string; points?: number };
@@ -211,6 +212,7 @@ export async function saveMatchesToTeamSubcollections(
 
           const matchData = {
             ...match,
+            listedInFftt: true,
             joueursSQY: mergedComposition.joueursSQY,
             resultatsIndividuels: mergedComposition.resultatsIndividuels,
             date: Timestamp.fromDate(match.date),
@@ -436,6 +438,13 @@ export async function saveMatchesToTeamSubcollections(
     }
 
     await Promise.all(batchPromises);
+
+    for (const [teamId, teamMatches] of matchesByTeam) {
+      const listedIds = teamMatches
+        .map((match) => (typeof match.id === "string" ? match.id.trim() : ""))
+        .filter((id) => id.length > 0);
+      await markMatchesListedInFftt(db, teamId, listedIds);
+    }
 
     console.log(
       `✅ Synchronisation terminée: ${saved} matchs sauvegardés sur ${matches.length} matchs reçus`

--- a/src/lib/shared/team-matches-sync.ts
+++ b/src/lib/shared/team-matches-sync.ts
@@ -2,13 +2,8 @@ import { FFTTAPI } from "@omichalo/ffttapi-node";
 import { createFFTTAPI, getFFTTConfig } from "./fftt-utils";
 import { FFTTEquipe, FFTTRencontre } from "./fftt-types";
 import { createBaseMatch, isFemaleTeam, determinePhaseFromDivision } from "./fftt-utils";
-import type {
-  Firestore,
-  DocumentReference,
-  UpdateData,
-  DocumentData,
-} from "firebase-admin/firestore";
-import { Timestamp, FieldValue } from "firebase-admin/firestore";
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
 import type {
   MatchData,
   TeamMatchesSyncResult,
@@ -22,8 +17,16 @@ import {
   extractClubIdFromLien,
 } from "./team-matches-sync-enrichment";
 import { recalculateJourneesByDate } from "./team-matches-sync-journee";
+import { isTrackedClubChampionshipEpreuve } from "./epreuve-utils";
 import { saveMatchesToTeamSubcollections } from "./team-matches-sync-save";
 import { listLicensedSqyPlayersInMatch } from "./match-composition-utils";
+import { readPublishedSeasonLabel } from "@/lib/championship/season-label";
+import { listChampionshipPlayers } from "@/lib/championship/store";
+import { rosterDocIdsWithSeasonalMatchStats } from "@/lib/championship/roster-match-stats";
+import {
+  commitMatchSyncUpdatesToRoster,
+  loadChampionshipPlayersByIds,
+} from "@/lib/championship/apply-match-sync-to-roster";
 
 export type {
   TeamMatchesSyncResult,
@@ -240,17 +243,8 @@ export class TeamMatchesSyncService {
       // Récupérer les équipes du club
       const equipes = await this.ffttApi.getEquipesByClub(this.clubCode);
 
-      // Filtrer les équipes pour les épreuves spécifiques et ajouter le champ isFemale
-      // 15954 = Championnat de France par Équipes Masculin
-      // 15955 = Championnat de France par Équipes Féminin
-      // 15980 = Championnat de Paris IDF (Excellence)
       const filteredEquipes = equipes
-        .filter(
-          (equipe: FFTTEquipe) =>
-            equipe.idEpreuve === 15954 ||
-            equipe.idEpreuve === 15955 ||
-            equipe.idEpreuve === 15980
-        )
+        .filter((equipe: FFTTEquipe) => isTrackedClubChampionshipEpreuve(equipe))
         .map((equipe: FFTTEquipe) => {
           // S'assurer que isFemale est défini en utilisant toutes les informations disponibles
           return {
@@ -803,65 +797,25 @@ export class TeamMatchesSyncService {
         ...Array.from(feminineMatchesByTeamByPlayerByPhase.keys()),
         ...Array.from(matchesByTeamByPlayerByPhaseParis.keys()),
       ]);
-      const playerIds = Array.from(allPlayerIds);
-      const playersToUpdate = [];
+      const playersToUpdate: Array<{
+        playerId: string;
+        updates: Record<string, unknown>;
+      }> = [];
 
-      // OPTIMISATION : Utiliser le cache de joueurs si fourni, sinon récupérer avec getAll()
-      console.log(`📥 Récupération de ${playerIds.length} joueurs...`);
-
-      // Créer une Map pour un accès rapide aux données existantes
-      const playerDataMap = new Map<string, Record<string, unknown>>();
-
-      if (playersCache) {
-        // Utiliser le cache de joueurs déjà chargé (évite les reads supplémentaires)
-        console.log(
-          `✅ Utilisation du cache de joueurs (${playersCache.length} joueurs en cache)`
-        );
-        for (const player of playersCache) {
-          if (playerIds.includes(player.id)) {
-            playerDataMap.set(player.id, player);
-          }
-        }
-      } else {
-        // Fallback : récupérer avec getAll() si pas de cache
-        const docRefs = playerIds.map((playerId) =>
-          db.collection("players").doc(playerId)
-        );
-
-        // getAll() peut récupérer jusqu'à 10 documents à la fois
-        // Diviser en sous-batches de 10 et les traiter en parallèle
-        const getAllBatchSize = 10;
-        const getAllBatches: Array<Array<DocumentReference>> = [];
-
-        for (let k = 0; k < docRefs.length; k += getAllBatchSize) {
-          getAllBatches.push(docRefs.slice(k, k + getAllBatchSize));
-        }
-
-        // Traiter les batches getAll() en parallèle (max 5 à la fois pour ne pas surcharger)
-        const maxConcurrentGetAll = 5;
-        for (let k = 0; k < getAllBatches.length; k += maxConcurrentGetAll) {
-          const concurrentBatches = getAllBatches.slice(
-            k,
-            k + maxConcurrentGetAll
-          );
-          const getAllPromises = concurrentBatches.map((batch) =>
-            db.getAll(...batch)
-          );
-
-          const results = await Promise.all(getAllPromises);
-
-          results.forEach((docs) => {
-            docs.forEach((doc) => {
-              if (doc.exists) {
-                playerDataMap.set(
-                  doc.id,
-                  doc.data() as Record<string, unknown>
-                );
-              }
-            });
-          });
-        }
+      const seasonLabel = await readPublishedSeasonLabel(db);
+      const rosterWithStats = rosterDocIdsWithSeasonalMatchStats(
+        await listChampionshipPlayers(db, seasonLabel)
+      );
+      for (const playerId of rosterWithStats) {
+        allPlayerIds.add(playerId);
       }
+      const playerIds = Array.from(allPlayerIds);
+      console.log(`📥 Récupération de ${playerIds.length} fiches roster...`);
+      const playerDataMap = await loadChampionshipPlayersByIds(
+        db,
+        seasonLabel,
+        playerIds
+      );
 
       type BurnoutTeamByPhase = { aller?: number; retour?: number };
       type BurnoutPhaseFieldUpdate =
@@ -900,43 +854,37 @@ export class TeamMatchesSyncService {
 
       for (const playerId of playerIds) {
         try {
-          const playerData = playerDataMap.get(playerId);
-          if (playerData) {
-            const updates: Record<string, unknown> = {};
+          const playerData = playerDataMap.get(playerId) ?? {};
+          const updates: Record<string, unknown> = {};
 
-            // Mettre à jour hasPlayedAtLeastOneMatch si pas déjà true (championnat par équipes)
+            if (participatingPlayers.has(playerId)) {
+              if (playerData?.hasPlayedAtLeastOneMatch !== true) {
+                updates.hasPlayedAtLeastOneMatch = true;
+              }
+            } else if (playerData?.hasPlayedAtLeastOneMatch === true) {
+              updates.hasPlayedAtLeastOneMatch = false;
+            }
+
+            if (participatingPlayersParis.has(playerId)) {
+              if (playerData?.hasPlayedAtLeastOneMatchParis !== true) {
+                updates.hasPlayedAtLeastOneMatchParis = true;
+              }
+            } else if (playerData?.hasPlayedAtLeastOneMatchParis === true) {
+              updates.hasPlayedAtLeastOneMatchParis = false;
+            }
+
             if (
               participatingPlayers.has(playerId) &&
-              !playerData?.hasPlayedAtLeastOneMatch
+              playerData.championnat !== true
             ) {
-              updates.hasPlayedAtLeastOneMatch = true;
+              updates.championnat = true;
             }
 
-            // Mettre à jour hasPlayedAtLeastOneMatchParis si pas déjà true (championnat de Paris)
             if (
               participatingPlayersParis.has(playerId) &&
-              !playerData?.hasPlayedAtLeastOneMatchParis
+              playerData.championnatParis !== true
             ) {
-              updates.hasPlayedAtLeastOneMatchParis = true;
-            }
-
-            // Mettre à jour participation.championnat si pas déjà true
-            const participation = playerData?.participation as
-              | { championnat?: boolean; championnatParis?: boolean }
-              | undefined;
-            if (
-              participatingPlayers.has(playerId) &&
-              !participation?.championnat
-            ) {
-              updates["participation.championnat"] = true;
-            }
-
-            // Mettre à jour participation.championnatParis si pas déjà true
-            if (
-              participatingPlayersParis.has(playerId) &&
-              !participation?.championnatParis
-            ) {
-              updates["participation.championnatParis"] = true;
+              updates.championnatParis = true;
             }
 
             const masculineBurnUpdate = resolveBurnoutByPhaseFieldUpdate(
@@ -980,6 +928,8 @@ export class TeamMatchesSyncService {
               }
 
               updates.masculineMatchesByTeamByPhase = matchesByTeamByPhaseObj;
+            } else if (playerData?.masculineMatchesByTeamByPhase !== undefined) {
+              updates.masculineMatchesByTeamByPhase = FieldValue.delete();
             }
 
             // Mettre à jour feminineMatchesByTeamByPhase pour l'affichage dans le tooltip
@@ -1003,6 +953,8 @@ export class TeamMatchesSyncService {
               }
 
               updates.feminineMatchesByTeamByPhase = matchesByTeamByPhaseObj;
+            } else if (playerData?.feminineMatchesByTeamByPhase !== undefined) {
+              updates.feminineMatchesByTeamByPhase = FieldValue.delete();
             }
 
             const parisBurnUpdate = resolveBurnoutByPhaseFieldUpdate(
@@ -1035,14 +987,13 @@ export class TeamMatchesSyncService {
               }
 
               updates.matchesByTeamByPhaseParis = matchesByTeamByPhaseObj;
+            } else if (playerData?.matchesByTeamByPhaseParis !== undefined) {
+              updates.matchesByTeamByPhaseParis = FieldValue.delete();
             }
 
-            // Ajouter updatedAt si il y a des mises à jour
             if (Object.keys(updates).length > 0) {
-              updates.updatedAt = Timestamp.now();
               playersToUpdate.push({ playerId, updates });
             }
-          }
         } catch (error) {
           console.error(
             `❌ Erreur lors de la récupération du joueur ${playerId}:`,
@@ -1056,39 +1007,16 @@ export class TeamMatchesSyncService {
         `\n📊 ${playersToUpdate.length} joueurs nécessitent une mise à jour de leur statut`
       );
 
-      // Mettre à jour par batch
-      const batchSize = 500;
-      for (let i = 0; i < playersToUpdate.length; i += batchSize) {
-        const batch = db.batch();
-        const batchEnd = Math.min(i + batchSize, playersToUpdate.length);
-
-        for (let j = i; j < batchEnd; j++) {
-          const { playerId, updates } = playersToUpdate[j];
-          const playerRef = db.collection("players").doc(playerId);
-          batch.update(playerRef, updates as UpdateData<DocumentData>);
-          updated++;
-        }
-
-        try {
-          await batch.commit();
-          console.log(
-            `✅ Batch ${Math.floor(i / batchSize) + 1} traité: ${
-              batchEnd - i
-            } joueurs mis à jour`
-          );
-        } catch (error) {
-          console.error(
-            `❌ Erreur lors du commit du batch ${
-              Math.floor(i / batchSize) + 1
-            }:`,
-            error
-          );
-          errors += batchEnd - i;
-        }
-      }
+      const commitResult = await commitMatchSyncUpdatesToRoster(
+        db,
+        seasonLabel,
+        playersToUpdate
+      );
+      updated += commitResult.updated;
+      errors += commitResult.errors;
 
       console.log(
-        `✅ Participation mise à jour: ${updated} joueurs, ${errors} erreurs`
+        `✅ Participation roster mise à jour: ${updated} joueurs, ${errors} erreurs`
       );
       return { updated, errors };
     } catch (error) {

--- a/src/lib/shared/team-sync.ts
+++ b/src/lib/shared/team-sync.ts
@@ -7,6 +7,8 @@ import {
 } from "./fftt-utils";
 import type { Firestore } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
+import { markTeamsListedInFftt } from "./mark-teams-listed-in-fftt";
+import { isTrackedClubChampionshipEpreuve } from "./epreuve-utils";
 import type { FFTTEquipe } from "./fftt-types";
 
 export interface TeamSyncResult {
@@ -95,17 +97,24 @@ export class TeamSyncService {
 
       console.log(`✅ ${equipes.length} équipes récupérées depuis l&apos;API FFTT`);
 
-      // Filtrer les équipes pour les épreuves spécifiques
-      // 15954 = Championnat de France par Équipes Masculin
-      // 15955 = Championnat de France par Équipes Féminin
-      // 15980 = Championnat de Paris IDF (Excellence)
-      const filteredEquipes = equipes.filter(
-        (equipe: FFTTEquipe) =>
-          equipe.idEpreuve === 15954 || equipe.idEpreuve === 15955 || equipe.idEpreuve === 15980
+      // Les IDs d'épreuve FFTT changent chaque saison : filtrer par ID connus + libellé.
+      const filteredEquipes = equipes.filter((equipe: FFTTEquipe) =>
+        isTrackedClubChampionshipEpreuve(equipe)
+      );
+      const ignoredEquipes = equipes.filter(
+        (equipe: FFTTEquipe) => !isTrackedClubChampionshipEpreuve(equipe)
       );
       console.log(
-        `Équipes filtrées (épreuves 15954, 15955 et 15980): ${filteredEquipes.length}`
+        `Équipes filtrées (championnat France / Paris): ${filteredEquipes.length}`
       );
+      if (ignoredEquipes.length > 0) {
+        console.log(
+          "Épreuves ignorées:",
+          ignoredEquipes
+            .map((equipe) => `${equipe.idEpreuve}:${equipe.libelleEpreuve}`)
+            .join(" | ")
+        );
+      }
 
       // Traiter les équipes
       const processedTeams: TeamData[] = [];
@@ -171,6 +180,13 @@ export class TeamSyncService {
         `💾 Sauvegarde de ${teamsData.length} équipes dans Firestore...`
       );
 
+      if (teamsData.length === 0) {
+        console.log(
+          "⚠️ Aucune équipe championnat à sauvegarder, listing Firestore inchangé"
+        );
+        return { saved: 0, errors: 0 };
+      }
+
       // Traitement par batch pour éviter les limites Firestore
       const batchSize = 500;
       for (let i = 0; i < teamsData.length; i += batchSize) {
@@ -196,6 +212,7 @@ export class TeamSyncService {
           // Ne pas inclure les champs undefined car Firestore ne les accepte pas
           const teamData: Record<string, unknown> = {
             ...team,
+            listedInFftt: true,
             createdAt: Timestamp.fromDate(team.createdAt),
             updatedAt: Timestamp.fromDate(team.updatedAt),
           };
@@ -237,6 +254,14 @@ export class TeamSyncService {
           console.log(`🗑️ Ancien doc équipe supprimé: ${baseId}`);
         }
       }
+
+      const listedMark = await markTeamsListedInFftt(
+        db,
+        teamsData.map((team) => team.id)
+      );
+      console.log(
+        `🏷️ Listing FFTT mis à jour: ${listedMark.listed} courantes, ${listedMark.unlisted} masquées`
+      );
 
       // Mettre à jour les métadonnées
       await db.collection("metadata").doc("lastSync").set(

--- a/src/stores/teamManagementStore.ts
+++ b/src/stores/teamManagementStore.ts
@@ -76,6 +76,7 @@ interface TeamManagementState {
     journee: number;
     phase: "aller" | "retour";
     championshipType: ChampionshipType;
+    idEpreuve?: number;
   }) => () => void;
   fetchCompositionDefaults: (params: {
     phase: "aller" | "retour";
@@ -119,7 +120,11 @@ export const useTeamManagementStore = create<TeamManagementState>((set, get) => 
     try {
       set({ playersLoading: true, playersError: null });
       const players = await playerService.getAllPlayers();
-      set({ players, playersLoading: false });
+      const { mergeLoadedPlayersWithRoster } = await import(
+        "@/lib/championship/load-merged-players"
+      );
+      const merged = await mergeLoadedPlayersWithRoster(players);
+      set({ players: merged, playersLoading: false });
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Erreur de chargement";
@@ -261,8 +266,13 @@ export const useTeamManagementStore = create<TeamManagementState>((set, get) => 
     };
   },
 
-  subscribeToComposition: ({ journee, phase, championshipType }) => {
-    const key = getDayKey({ journee, phase, championshipType });
+  subscribeToComposition: ({ journee, phase, championshipType, idEpreuve }) => {
+    const key = getDayKey({
+      journee,
+      phase,
+      championshipType,
+      ...(idEpreuve !== undefined ? { idEpreuve } : {}),
+    });
     const existing = get().compositionSubscriptions[key];
     if (existing) {
       existing();
@@ -284,7 +294,8 @@ export const useTeamManagementStore = create<TeamManagementState>((set, get) => 
             : state.compositionsByKey,
           compositionsLoading: { ...state.compositionsLoading, [key]: false },
         }));
-      }
+      },
+      idEpreuve
     );
 
     set((state) => ({

--- a/src/types/team-management.ts
+++ b/src/types/team-management.ts
@@ -69,7 +69,7 @@ export interface Player {
   discordMentions?: string[]; // IDs des membres Discord à notifier
   listedInClub?: boolean;
   championshipPersonKey?: string;
-  championshipAlerts?: import("@/lib/championship/merge-players").ChampionshipAlertCode[];
+  championshipAlerts?: import("@/lib/championship/records").ChampionshipAlertCode[];
 }
 
 export interface Team {

--- a/src/types/team-management.ts
+++ b/src/types/team-management.ts
@@ -67,6 +67,9 @@ export interface Player {
   isHomme?: boolean;
   // Mentions Discord pour les notifications
   discordMentions?: string[]; // IDs des membres Discord à notifier
+  listedInClub?: boolean;
+  championshipPersonKey?: string;
+  championshipAlerts?: import("@/lib/championship/merge-players").ChampionshipAlertCode[];
 }
 
 export interface Team {


### PR DESCRIPTION
## Summary
- Effectif championnat saisonnier (`championshipPlayers`) alimenté par les dossiers (`championnat_equipe` / `championnat_paris`), sans bloquer sur paiement ou licence.
- Miroir FFTT (`players`) recentré sur la liste club + type de licence de saison ; compositions, dispos et joueurs lisent le roster 2026-2027.
- Correction de transition : épreuves 2026-2027, matchs `listedInFftt`, IDs de compositions, licences périmées, mutations (ex. Lecheminant). Recalcul d'effectif dans Admin → Synchronisation FFTT.

## Test plan
- [ ] Recalculer l'effectif depuis Admin → Synchronisation FFTT
- [ ] `/joueurs` : Actifs = licence saison T/P/A ; hors liste = N/A ; mutation = chip autre club
- [ ] Interrupteurs participation = intention dossier (ou toggle coach), pas le reliquat FFTT
- [ ] `/equipes` et compositions : équipes et matchs de la génération d'épreuve courante
- [ ] Soumettre / payer / patcher un dossier championnat met à jour le roster


Made with [Cursor](https://cursor.com)