### PR TITLE
fix(championship): retirer l’index Firestore inutile sur registrationId

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -467,16 +467,6 @@
           "order": "DESCENDING"
         }
       ]
-    },
-    {
-      "collectionGroup": "championshipPlayers",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "registrationId",
-          "order": "ASCENDING"
-        }
-      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- Le deploy Firestore staging a échoué : index `championshipPlayers.registrationId` refusé (index à un seul champ).
- La requête d’égalité utilise l’index automatique ; l’entrée composite est retirée.

## Test plan
- [ ] CI Deploy Firestore to staging passe.
- [ ] Lookup roster par `registrationId` toujours possible (seed / sync dossier).


Made with [Cursor](https://cursor.com)