### PR TITLE
fix(championship): omettre les champs undefined à l'écriture du roster

### DIFF
--- a/src/lib/championship/apply-match-sync-to-roster.ts
+++ b/src/lib/championship/apply-match-sync-to-roster.ts
@@ -1,5 +1,6 @@
 import type { Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
+import { omitUndefinedFields } from "./omit-undefined-fields";
 import { championshipPlayersCollection } from "./store";
 
 export type MatchSyncBurnoutUpdate = Record<string, unknown>;
@@ -26,7 +27,7 @@ function remapMatchSyncUpdates(
     next.championnatParis = true;
     delete next["participation.championnatParis"];
   }
-  return next;
+  return omitUndefinedFields(next);
 }
 
 export async function applyMatchSyncUpdatesToRoster(

--- a/src/lib/championship/omit-undefined-fields.test.ts
+++ b/src/lib/championship/omit-undefined-fields.test.ts
@@ -1,0 +1,18 @@
+import { omitUndefinedFields } from "./omit-undefined-fields";
+
+describe("omitUndefinedFields", () => {
+  it("drops top-level undefined without touching null or false", () => {
+    expect(
+      omitUndefinedFields({
+        championnat: true,
+        hasPlayedAtLeastOneMatch: undefined,
+        registrationId: null,
+        coachExcluded: false,
+      })
+    ).toEqual({
+      championnat: true,
+      registrationId: null,
+      coachExcluded: false,
+    });
+  });
+});

--- a/src/lib/championship/omit-undefined-fields.ts
+++ b/src/lib/championship/omit-undefined-fields.ts
@@ -1,0 +1,12 @@
+/** Firestore Admin refuse `undefined` comme valeur de document. */
+export function omitUndefinedFields(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value !== undefined) {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/src/lib/championship/store.ts
+++ b/src/lib/championship/store.ts
@@ -6,6 +6,7 @@ import type {
   PlayerClubProfileRecord,
 } from "./records";
 import { PLAYER_CLUB_PROFILES_COLLECTION } from "./paths";
+import { omitUndefinedFields } from "./omit-undefined-fields";
 
 export function championshipPlayersCollection(
   db: Firestore,
@@ -47,12 +48,12 @@ export async function upsertChampionshipPlayer(
   await championshipPlayersCollection(db, seasonLabel)
     .doc(personKey)
     .set(
-      {
+      omitUndefinedFields({
         ...rest,
         personKey,
         seasonLabel,
         updatedAt: FieldValue.serverTimestamp(),
-      },
+      }),
       { merge: true }
     );
 }
@@ -103,10 +104,10 @@ export async function upsertPlayerClubProfile(
     .collection(PLAYER_CLUB_PROFILES_COLLECTION)
     .doc(profile.personKey)
     .set(
-      {
+      omitUndefinedFields({
         ...profile,
         updatedAt: FieldValue.serverTimestamp(),
-      },
+      }),
       { merge: true }
     );
 }


### PR DESCRIPTION
## Summary
- Le recalcul d'effectif plantait en prod (`hasPlayedAtLeastOneMatch: undefined` refusé par Firestore), donc `seasons/2026-2027/championshipPlayers` restait vide.
- Les écritures roster/profil omettent désormais les champs `undefined` au lieu de les envoyer à Firestore.

## Test plan
- [ ] CI verte
- [ ] Admin → Recalculer l'effectif : plus de popup d'erreur
- [ ] Licence 7864877 : cases Championnat et Paris cochées après recalcul


Made with [Cursor](https://cursor.com)