### PR TITLE
fix(championship): exclure les mutés et clarifier Non licencié

### DIFF
--- a/src/app/compositions/_containers/DefaultCompositionsContainer.tsx
+++ b/src/app/compositions/_containers/DefaultCompositionsContainer.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/compositions/championship-utils";
 import { divisionIndicatesPhase2 } from "@/lib/shared/fftt-utils";
 import type { Player } from "@/types/team-management";
+import { ChampionshipStatusChips } from "@/components/championship/ChampionshipStatusChips";
 import { AvailablePlayersPanel } from "@/components/compositions/AvailablePlayersPanel";
 import { AvailablePlayerListItem } from "@/components/compositions/AvailablePlayerListItem";
 import { TeamCompositionCard } from "@/components/compositions/TeamCompositionCard";
@@ -723,6 +724,7 @@ export function DefaultCompositionsContainer() {
                                       ];
                                   return (
                                     <>
+                                      <ChampionshipStatusChips player={player} />
                                       {player.nationality === "C" && (
                                         <Chip
                                           label="EUR"
@@ -931,6 +933,7 @@ export function DefaultCompositionsContainer() {
                                       ];
                                   return (
                                     <>
+                                      <ChampionshipStatusChips player={player} />
                                       {player.nationality === "C" && (
                                         <Chip
                                           label="EUR"

--- a/src/components/championship/ChampionshipStatusChips.tsx
+++ b/src/components/championship/ChampionshipStatusChips.tsx
@@ -15,7 +15,7 @@ const ALERT_LABELS: Record<ChampionshipAlertCode, { label: string; title: string
     title: "Licence absente de la liste club FFTT de la saison",
   },
   fftt_sqy_unlicensed: {
-    label: "Licence saison",
+    label: "Non licencié",
     title: "Toujours affilié SQY à la FFTT, sans licence de saison",
   },
   other_club: { label: "Autre club", title: "Licence rattachée à un autre club FFTT" },
@@ -28,10 +28,12 @@ const ALERT_LABELS: Record<ChampionshipAlertCode, { label: string; title: string
 
 type Props = {
   player: Player;
+  hideCodes?: readonly ChampionshipAlertCode[];
 };
 
-export function ChampionshipStatusChips({ player }: Props) {
-  const alerts = player.championshipAlerts ?? [];
+export function ChampionshipStatusChips({ player, hideCodes = [] }: Props) {
+  const hidden = new Set(hideCodes);
+  const alerts = (player.championshipAlerts ?? []).filter((code) => !hidden.has(code));
   if (alerts.length === 0) {
     return null;
   }

--- a/src/components/compositions/AvailablePlayerListItem.tsx
+++ b/src/components/compositions/AvailablePlayerListItem.tsx
@@ -41,6 +41,13 @@ export function AvailablePlayerListItem({
 }: AvailablePlayerListItemProps) {
   const isForeign = player.nationality === "ETR";
   const isEuropean = player.nationality === "C";
+  const hasLicenseAlert = (player.championshipAlerts ?? []).some(
+    (code) =>
+      code === "fftt_sqy_unlicensed" ||
+      code === "no_license" ||
+      code === "not_in_club_list" ||
+      code === "other_federation"
+  );
 
   return (
     <ListItem disablePadding sx={{ mb: 1 }} secondaryAction={null}>
@@ -125,7 +132,10 @@ export function AvailablePlayerListItem({
                   sx={{ height: 20, fontSize: "0.7rem" }}
                 />
               )}
-              {showEligibilityChips && !player.isActive && !player.isTemporary && (
+              {showEligibilityChips &&
+                !player.isActive &&
+                !player.isTemporary &&
+                !hasLicenseAlert && (
                 <Chip
                   label="Sans licence"
                   size="small"

--- a/src/components/compositions/TeamCompositionRow.tsx
+++ b/src/components/compositions/TeamCompositionRow.tsx
@@ -11,6 +11,7 @@ import {
 import { EquipeWithMatches } from "@/hooks/useTeamData";
 import { ChampionshipType, Match } from "@/types";
 import { Player } from "@/types/team-management";
+import { ChampionshipStatusChips } from "@/components/championship/ChampionshipStatusChips";
 import { TeamCompositionCard } from "@/components/compositions/TeamCompositionCard";
 import { PoolRankingPopover } from "@/components/compositions/PoolRankingPopover";
 import { PoolSchedulePopover } from "@/components/compositions/PoolSchedulePopover";
@@ -196,6 +197,7 @@ export function TeamCompositionRow({
 
     return (
       <>
+        <ChampionshipStatusChips player={player} />
         {player.nationality === "C" && <Chip label="EUR" size="small" color="info" variant="outlined" sx={{ height: 18, fontSize: "0.65rem" }} />}
         {player.nationality === "ETR" && <Chip label="ETR" size="small" color="warning" variant="outlined" sx={{ height: 18, fontSize: "0.65rem" }} />}
         {burnedTeam !== undefined && burnedTeam !== null && (

--- a/src/components/players/PlayersActiveTable.tsx
+++ b/src/components/players/PlayersActiveTable.tsx
@@ -152,7 +152,10 @@ export function PlayersActiveTable({
                   <Typography variant="body2" fontWeight="medium">
                     {player.firstName} {player.name}
                   </Typography>
-                  <ChampionshipStatusChips player={player} />
+                  <ChampionshipStatusChips
+                    player={player}
+                    hideCodes={["fftt_sqy_unlicensed"]}
+                  />
                   {player.hasPlayedAtLeastOneMatch && (
                     <Chip
                       icon={<SportsTennisIcon />}

--- a/src/components/players/PlayersBasicTable.tsx
+++ b/src/components/players/PlayersBasicTable.tsx
@@ -99,7 +99,10 @@ export function PlayersBasicTable({
                   <Typography variant="body2" fontWeight="medium">
                     {player.firstName} {player.name}
                   </Typography>
-                  <ChampionshipStatusChips player={player} />
+                  <ChampionshipStatusChips
+                    player={player}
+                    hideCodes={["fftt_sqy_unlicensed"]}
+                  />
                   {player.hasPlayedAtLeastOneMatch && (
                     <Chip
                       icon={<SportsTennisIcon />}

--- a/src/lib/championship/load-merged-players.test.ts
+++ b/src/lib/championship/load-merged-players.test.ts
@@ -1,0 +1,42 @@
+import { splitMergedPlayersByTab } from "./load-merged-players";
+import type { Player } from "@/types/team-management";
+
+function player(partial: Partial<Player> & Pick<Player, "id" | "name" | "firstName">): Player {
+  return {
+    license: partial.id,
+    typeLicence: "",
+    gender: "M",
+    nationality: "FR",
+    isActive: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    preferredTeams: { masculine: [], feminine: [] },
+    participation: {},
+    ...partial,
+  };
+}
+
+describe("splitMergedPlayersByTab", () => {
+  it("drops leftover players licensed at another club", () => {
+    const split = splitMergedPlayersByTab([
+      player({
+        id: "7859322",
+        name: "LECHEMINANT",
+        firstName: "Claude",
+        listedInClub: false,
+        nomClub: "CHESNAY 78 AS",
+        championshipAlerts: ["other_club"],
+      }),
+      player({
+        id: "5984668",
+        name: "NEMACIUC",
+        firstName: "Mihai",
+        listedInClub: true,
+        championshipAlerts: ["fftt_sqy_unlicensed"],
+      }),
+    ]);
+    expect(split.withoutLicense.map((item) => item.id)).toEqual(["5984668"]);
+    expect(split.active).toHaveLength(0);
+    expect(split.temporary).toHaveLength(0);
+  });
+});

--- a/src/lib/championship/load-merged-players.ts
+++ b/src/lib/championship/load-merged-players.ts
@@ -1,6 +1,21 @@
 import { fetchChampionshipRoster } from "./client";
 import { mergePlayersWithChampionshipRoster } from "./merge-players";
+import { resolveLicensePresence } from "./license-presence";
 import type { Player } from "@/types/team-management";
+
+function isOtherClubMirrorPlayer(player: Player): boolean {
+  if (player.championshipAlerts?.includes("other_club")) {
+    return true;
+  }
+  return (
+    resolveLicensePresence({
+      ffttLicense: player.license,
+      listedInClub: player.listedInClub === true,
+      typeLicence: player.typeLicence,
+      playerNomClub: player.nomClub ?? player.club ?? null,
+    }) === "other_club"
+  );
+}
 
 export async function mergeLoadedPlayersWithRoster(
   players: Player[]
@@ -9,7 +24,7 @@ export async function mergeLoadedPlayersWithRoster(
     const { roster } = await fetchChampionshipRoster();
     return mergePlayersWithChampionshipRoster(players, roster);
   } catch {
-    return players;
+    return players.filter((player) => !isOtherClubMirrorPlayer(player));
   }
 }
 
@@ -22,6 +37,9 @@ export function splitMergedPlayersByTab(merged: Player[]): {
   const withoutLicense: Player[] = [];
   const temporary: Player[] = [];
   for (const player of merged) {
+    if (isOtherClubMirrorPlayer(player)) {
+      continue;
+    }
     if (player.isTemporary) {
       temporary.push(player);
     } else if (player.isActive) {

--- a/src/lib/championship/merge-players.test.ts
+++ b/src/lib/championship/merge-players.test.ts
@@ -44,7 +44,7 @@ function roster(
 }
 
 describe("mergePlayersWithChampionshipRoster", () => {
-  it("flags a leftover player who moved to another club", () => {
+  it("hides leftover players who moved to another club", () => {
     const merged = mergePlayersWithChampionshipRoster(
       [
         player({
@@ -58,8 +58,47 @@ describe("mergePlayersWithChampionshipRoster", () => {
       ],
       []
     );
-    expect(merged[0].isActive).toBe(false);
-    expect(merged[0].championshipAlerts).toEqual(["other_club"]);
+    expect(merged).toHaveLength(0);
+  });
+
+  it("hides a roster entry whose FFTT licence is now at another club", () => {
+    const merged = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "7859322",
+          name: "LECHEMINANT",
+          firstName: "Claude",
+          listedInClub: false,
+          nomClub: "CHESNAY 78 AS",
+        }),
+      ],
+      [
+        roster({
+          id: "7859322",
+          personKey: "7859322",
+          licensePresence: "other_club",
+        }),
+      ]
+    );
+    expect(merged).toHaveLength(0);
+  });
+
+  it("keeps leftover SQY affiliates without a season licence", () => {
+    const merged = mergePlayersWithChampionshipRoster(
+      [
+        player({
+          id: "5984668",
+          name: "NEMACIUC",
+          firstName: "Mihai",
+          listedInClub: true,
+          nomClub: "SQY PING",
+          typeLicence: "",
+        }),
+      ],
+      []
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0].championshipAlerts).toEqual(["fftt_sqy_unlicensed"]);
   });
 
   it("clears last-season participation when the player is absent from the roster", () => {

--- a/src/lib/championship/merge-players.ts
+++ b/src/lib/championship/merge-players.ts
@@ -40,15 +40,17 @@ function withCurrentClubLicense(player: Player): Player {
   return { ...player, ...currentClubLicenseFields(player) };
 }
 
-function alertsFromPlayerMirror(player: Player): ChampionshipAlertCode[] {
-  return alertsFromRoster({
-    licensePresence: resolveLicensePresence({
-      ffttLicense: player.license,
-      listedInClub: player.listedInClub === true,
-      typeLicence: player.typeLicence,
-      playerNomClub: player.nomClub ?? player.club ?? null,
-    }),
+function licensePresenceFromPlayerMirror(player: Player): LicensePresence {
+  return resolveLicensePresence({
+    ffttLicense: player.license,
+    listedInClub: player.listedInClub === true,
+    typeLicence: player.typeLicence,
+    playerNomClub: player.nomClub ?? player.club ?? null,
   });
+}
+
+function isHiddenOtherClubPresence(presence: LicensePresence): boolean {
+  return presence === "other_club";
 }
 
 export function alertsFromRoster(record: {
@@ -125,6 +127,10 @@ export function mergePlayersWithChampionshipRoster(
       rosterByLicense.get(player.id) ??
       (player.license ? rosterByLicense.get(player.license) : undefined);
     if (!entry) {
+      const licensePresence = licensePresenceFromPlayerMirror(player);
+      if (isHiddenOtherClubPresence(licensePresence)) {
+        continue;
+      }
       result.push(
         withCurrentClubLicense({
           ...withoutSeasonalMatchStats(player),
@@ -133,7 +139,7 @@ export function mergePlayersWithChampionshipRoster(
             championnat: false,
             championnatParis: false,
           },
-          championshipAlerts: alertsFromPlayerMirror(player),
+          championshipAlerts: alertsFromRoster({ licensePresence }),
           championshipPersonKey: player.id,
           hasPlayedAtLeastOneMatch: false,
           hasPlayedAtLeastOneMatchParis: false,
@@ -145,6 +151,9 @@ export function mergePlayersWithChampionshipRoster(
     if (entry.ffttLicense) {
       mergedIds.add(entry.ffttLicense);
     }
+    if (isHiddenOtherClubPresence(entry.licensePresence)) {
+      continue;
+    }
     result.push(withCurrentClubLicense(applyRosterToPlayer(player, entry)));
   }
 
@@ -153,6 +162,9 @@ export function mergePlayersWithChampionshipRoster(
       continue;
     }
     if (entry.ffttLicense && mergedIds.has(entry.ffttLicense)) {
+      continue;
+    }
+    if (isHiddenOtherClubPresence(entry.licensePresence)) {
       continue;
     }
     result.push(


### PR DESCRIPTION
## Summary
- Release staging → main : les joueurs licenciés dans un autre club disparaissent de l’app.
- Chip « Non licencié » sur les compositions ; masqué sur la page joueurs (onglet *Sans licence*).

## Test plan
- [ ] CI verte
- [ ] Prod : page joueurs sans mutés, chip Non licencié uniquement en composition


Made with [Cursor](https://cursor.com)